### PR TITLE
fix: exclude venv and dev artifacts from backend and worker zip deploys

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -57,7 +57,13 @@ jobs:
       - name: Deploy to Azure App Service
         run: |
           cd backend
-          zip -r ../backend.zip .
+          zip -r ../backend.zip . \
+            -x "venv/*" -x ".venv/*" -x "env/*" \
+            -x "*.pyc" -x "__pycache__/*" \
+            -x ".pytest_cache/*" -x ".coverage" \
+            -x "*.db" -x "*.sqlite3" \
+            -x ".env" -x ".env.*" \
+            -x "storage/*"
           cd ..
           az webapp deploy \
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -14,7 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build zip
-        run: cd backend && zip -r ../worker.zip . -x "*.pyc" -x "__pycache__/*"
+        run: |
+          cd backend && zip -r ../worker.zip . \
+            -x "venv/*" -x ".venv/*" -x "env/*" \
+            -x "*.pyc" -x "__pycache__/*" \
+            -x ".pytest_cache/*" -x ".coverage" \
+            -x "*.db" -x "*.sqlite3" \
+            -x ".env" -x ".env.*" \
+            -x "storage/*"
       - uses: actions/upload-artifact@v4
         with:
           name: worker-zip


### PR DESCRIPTION
Neither workflow excluded venv/, .venv/, or env/ from the zip, so any
virtual environment present in the backend/ directory would be bundled
into the deploy artifact, causing bloated packages and potential Azure
App Service zip-deploy failures.

Both deploy-backend.yml and deploy-workers.yml now exclude:
- venv/, .venv/, env/ (virtual environments)
- *.pyc, __pycache__/ (bytecode)
- .pytest_cache/, .coverage (test artifacts)
- *.db, *.sqlite3 (local databases)
- .env, .env.* (local secrets)
- storage/ (local export storage)

https://claude.ai/code/session_01GKGJrZ5dWmBfBZMegxrjBM