### PR TITLE
fix: deployment restart cycles, venv in zip, and CI test failures

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -47,13 +47,6 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Set CORS origins on App Service
-        run: |
-          az webapp config appsettings set \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WEBAPP_NAME }} \
-            --settings PFCD_CORS_ORIGINS="${{ secrets.PFCD_CORS_ORIGINS }}"
-
       - name: Deploy to Azure App Service
         run: |
           cd backend
@@ -84,3 +77,10 @@ jobs:
           done
           echo "ERROR: backend health check did not pass within 20 minutes"
           exit 1
+
+      - name: Apply post-deploy configuration
+        run: |
+          az webapp config appsettings set \
+            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
+            --name ${{ secrets.AZURE_WEBAPP_NAME }} \
+            --settings PFCD_CORS_ORIGINS="${{ secrets.PFCD_CORS_ORIGINS }}"

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -37,12 +37,8 @@ jobs:
       - uses: azure/login@v2
         with:
           creds: '${{ secrets.AZURE_CREDENTIALS }}'
-      - name: Deploy extracting worker
+      - name: Configure extracting worker
         run: |
-          az webapp deploy \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_EXTRACTING_NAME }} \
-            --src-path worker.zip --type zip --async true --track-status false
           az webapp config appsettings set \
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
             --name ${{ secrets.AZURE_WORKER_EXTRACTING_NAME }} \
@@ -54,6 +50,12 @@ jobs:
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
             --name ${{ secrets.AZURE_WORKER_EXTRACTING_NAME }} \
             --startup-file "python -m app.workers.runner"
+      - name: Deploy extracting worker
+        run: |
+          az webapp deploy \
+            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
+            --name ${{ secrets.AZURE_WORKER_EXTRACTING_NAME }} \
+            --src-path worker.zip --type zip --async true --track-status false
       - name: Verify extracting worker is running
         run: |
           for i in $(seq 1 60); do
@@ -104,12 +106,8 @@ jobs:
       - uses: azure/login@v2
         with:
           creds: '${{ secrets.AZURE_CREDENTIALS }}'
-      - name: Deploy processing worker
+      - name: Configure processing worker
         run: |
-          az webapp deploy \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_PROCESSING_NAME }} \
-            --src-path worker.zip --type zip --async true --track-status false
           az webapp config appsettings set \
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
             --name ${{ secrets.AZURE_WORKER_PROCESSING_NAME }} \
@@ -121,6 +119,12 @@ jobs:
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
             --name ${{ secrets.AZURE_WORKER_PROCESSING_NAME }} \
             --startup-file "python -m app.workers.runner"
+      - name: Deploy processing worker
+        run: |
+          az webapp deploy \
+            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
+            --name ${{ secrets.AZURE_WORKER_PROCESSING_NAME }} \
+            --src-path worker.zip --type zip --async true --track-status false
       - name: Verify processing worker is running
         run: |
           for i in $(seq 1 60); do
@@ -171,12 +175,8 @@ jobs:
       - uses: azure/login@v2
         with:
           creds: '${{ secrets.AZURE_CREDENTIALS }}'
-      - name: Deploy reviewing worker
+      - name: Configure reviewing worker
         run: |
-          az webapp deploy \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_REVIEWING_NAME }} \
-            --src-path worker.zip --type zip --async true --track-status false
           az webapp config appsettings set \
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
             --name ${{ secrets.AZURE_WORKER_REVIEWING_NAME }} \
@@ -188,6 +188,12 @@ jobs:
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
             --name ${{ secrets.AZURE_WORKER_REVIEWING_NAME }} \
             --startup-file "python -m app.workers.runner"
+      - name: Deploy reviewing worker
+        run: |
+          az webapp deploy \
+            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
+            --name ${{ secrets.AZURE_WORKER_REVIEWING_NAME }} \
+            --src-path worker.zip --type zip --async true --track-status false
       - name: Verify reviewing worker is running
         run: |
           for i in $(seq 1 60); do

--- a/backend/app/agents/__init__.py
+++ b/backend/app/agents/__init__.py
@@ -3,15 +3,9 @@
 from app.agents.adapters import AdapterRegistry, IProcessEvidenceAdapter
 from app.agents.alignment import run_anchor_alignment
 from app.agents.evidence import compute_evidence_strength
-from app.agents.extraction import run_extraction
-from app.agents.processing import run_processing
-from app.agents.reviewing import run_reviewing
 from app.agents.sipoc_validator import SIPOCValidationResult, validate_sipoc
 
 __all__ = [
-    "run_extraction",
-    "run_processing",
-    "run_reviewing",
     "run_anchor_alignment",
     "compute_evidence_strength",
     "IProcessEvidenceAdapter",

--- a/backend/app/agents/extraction.py
+++ b/backend/app/agents/extraction.py
@@ -7,11 +7,7 @@ import json
 import os
 from typing import Any, Dict, List, Tuple
 
-from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion, AzureChatPromptExecutionSettings
-from semantic_kernel.contents import ChatHistory
-
 from app.agents.adapters.registry import AdapterRegistry
-from app.agents.kernel_factory import get_kernel
 
 _DEPLOYMENT = os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4o-mini")
 _adapter_registry = AdapterRegistry()
@@ -59,6 +55,9 @@ def _cost_usd(prompt_tokens: int, completion_tokens: int) -> float:
 
 async def _call_extraction(deployment: str, system_prompt: str, user_content: str):
     """Invoke Azure OpenAI via Semantic Kernel; returns (raw_json, prompt_tokens, completion_tokens)."""
+    from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion, AzureChatPromptExecutionSettings
+    from semantic_kernel.contents import ChatHistory
+    from app.agents.kernel_factory import get_kernel
     kernel = get_kernel(deployment)
     chat = ChatHistory()
     chat.add_system_message(system_prompt)

--- a/backend/app/agents/kernel_factory.py
+++ b/backend/app/agents/kernel_factory.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import logging
 import os
 
-from azure.identity import DefaultAzureCredential, get_bearer_token_provider
-from semantic_kernel import Kernel
-from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
-
 logger = logging.getLogger(__name__)
 
 
-def get_kernel(deployment: str) -> Kernel:
+def get_kernel(deployment: str):
+    from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+    from semantic_kernel import Kernel
+    from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
     endpoint = os.environ["AZURE_OPENAI_ENDPOINT"]
     logger.info(
         "Initializing Semantic Kernel AzureChatCompletion with endpoint=%s deployment=%s",

--- a/backend/app/agents/processing.py
+++ b/backend/app/agents/processing.py
@@ -9,10 +9,6 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Dict
 
-from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion, AzureChatPromptExecutionSettings
-from semantic_kernel.contents import ChatHistory
-
-from app.agents.kernel_factory import get_kernel
 
 _DEPLOYMENT = os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4o-mini")
 logger = logging.getLogger(__name__)
@@ -101,6 +97,9 @@ def _cost_usd(prompt_tokens: int, completion_tokens: int) -> float:
 
 async def _call_processing(deployment: str, system_prompt: str, user_content: str):
     """Invoke Azure OpenAI via Semantic Kernel; returns (raw_json, prompt_tokens, completion_tokens)."""
+    from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion, AzureChatPromptExecutionSettings
+    from semantic_kernel.contents import ChatHistory
+    from app.agents.kernel_factory import get_kernel
     kernel = get_kernel(deployment)
     chat = ChatHistory()
     chat.add_system_message(system_prompt)

--- a/backend/app/workers/runner.py
+++ b/backend/app/workers/runner.py
@@ -16,8 +16,10 @@ from uuid import uuid4
 from azure.servicebus import ServiceBusMessage
 from azure.servicebus.exceptions import ServiceBusConnectionError as SBConnectionError
 
-from app.agents import run_extraction, run_processing, run_reviewing
 from app.agents.alignment import run_anchor_alignment
+from app.agents.extraction import run_extraction
+from app.agents.processing import run_processing
+from app.agents.reviewing import run_reviewing
 from app.job_logic import JobStatus, Profile, add_agent_run, build_draft, load_transcript_text, profile_config
 from app.repository import JobRepository
 from app.servicebus import ServiceBusOrchestrator, build_message, max_retries


### PR DESCRIPTION
## Summary

- **Fix slow Azure deployment** — workers were triggering 3 App Service restarts per worker (9 total) because `az webapp deploy`, `appsettings set`, and `startup-file config set` each caused a restart. Reordered to apply all config first, then deploy zip last so only one restart matters. Also moves `WEBSITES_CONTAINER_START_TIME_LIMIT=600` before the deploy so the 600s startup window is active on the deployment restart (previously used the default 230s, risking container kill during heavy Python imports).
- **Fix backend extra restart** — `appsettings set` (CORS) ran before the zip deploy, restarting the app with old code. Moved to a post-deploy step after the health check passes.
- **Fix CI test failures** — `app/agents/__init__.py` eagerly imported `run_extraction` → `extraction.py` → `from semantic_kernel...` at module level. Any test touching any `app.agents.*` submodule failed immediately if `semantic_kernel` was not installed, before any monkeypatch could apply. Fixed by deferring SK imports inside `_call_extraction()`, `_call_processing()`, and `get_kernel()` so they only load at worker runtime. Also removed SK-dependent symbols from `__init__.py` re-exports and updated `runner.py` to import directly from submodules.

## Test plan

- [ ] CI test job passes (no more SK import errors on adapter/alignment/sipoc/evidence tests)
- [ ] Worker deployments complete with fewer restarts — verify runtime logs appear sooner after deploy
- [ ] Backend health check passes on first deployment without extra CORS-triggered restart
- [ ] `WEBSITES_CONTAINER_START_TIME_LIMIT=600` confirmed active before zip deploy restart

https://claude.ai/code/session_01GKGJrZ5dWmBfBZMegxrjBM