### PR TITLE
feat: bootstrap container registry and apps environment

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -43,7 +43,7 @@ Shared coordination board. Read and updated by both Claude and Codex at session 
 
 | ID | Task | PR / Commit |
 |----|------|-------------|
-| — | | |
+| ISSUE-19-ACA-INFRA | Provision Azure Container Registry and shared Container Apps environment for GitHub issue #19 | — |
 
 ---
 

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2080,3 +2080,45 @@ Closed both Codex tasks created from Claude's Section 42 RCA.
 `deploy-workers.yml` `build` job: added `sudo apt-get install -y unixodbc-dev`, `actions/setup-python@v5 (3.11)`, and `pip install --quiet --target backend/antenv/lib/python${PY_MINOR}/site-packages -r backend/requirements.txt` before the zip step; added `rm -rf antenv` after. `antenv/` is included in `worker.zip` (not excluded). Workers now ship fully vendored packages under `WEBSITE_RUN_FROM_PACKAGE` — immune to host/runtime drift. Pattern identical to backend.
 
 Both tasks closed. Board queue now empty.
+
+---
+
+## Section 59: Codex Delivery — GitHub Issue #19 ACR + Container Apps Environment Bootstrap (2026-04-18)
+
+GitHub issue `#19 Provision Azure Container Registry and Container Apps environment` requested a narrow infrastructure bootstrap update ahead of the Container Apps deployment work in `#20` and `#21`.
+
+### Completed
+
+- Updated [infra/dev-bootstrap.sh](/Users/karthicks/kAgents/Projects/PFCD-V2/infra/dev-bootstrap.sh) to derive and provision the new shared container infrastructure names:
+  - `pfcddevregistry` via `CONTAINER_REGISTRY_NAME`
+  - `pfcd-dev-logs` via `LOG_ANALYTICS_WORKSPACE_NAME`
+  - `pfcd-dev-env` via `CONTAINER_APPS_ENVIRONMENT_NAME`
+- Added an ACR provisioning block that creates the registry with the admin user disabled and, when `SP_CLIENT_ID` is supplied, grants the GitHub Actions service principal `AcrPush`.
+- Added a Log Analytics workspace provisioning block plus a Container Apps environment provisioning block wired to that workspace via `customerId` and shared key.
+- Added a deferred Container App RBAC helper that grants `Storage Blob Data Contributor`, `Azure Service Bus Data Owner`, and `Key Vault Secrets User` to the future API and worker Container App identities once those apps exist.
+- Updated the bootstrap script footer to print the ACR login server and shared Container Apps environment name after a run.
+- Updated [REFERENCE.md](/Users/karthicks/kAgents/Projects/PFCD-V2/REFERENCE.md) to document the ACR, Log Analytics workspace, Container Apps environment, the optional `SP_CLIENT_ID` bootstrap input, and the new `AZURE_CONTAINER_REGISTRY` GitHub variable expectation for upcoming Container Apps workflows.
+
+### Decisions
+
+- Kept the resource group source of truth aligned to the repository defaults (`app-pfcd-v2`) rather than the issue body's older `pfcd-dev-rg` wording.
+- Kept the change scoped to infra bootstrap and reference docs only; no application code or workflow files were modified in this issue.
+- Chose a deferred RBAC approach for Container App managed identities because system-assigned identities do not exist until the Container Apps from `#20` and `#21` are created.
+
+### Validation
+
+- Script syntax check:
+  - `bash -n infra/dev-bootstrap.sh`
+  - result: pass
+- Azure CLI command-shape validation with sandbox-safe config path:
+  - `AZURE_CONFIG_DIR=/tmp/azcfg az acr create -h`
+  - `AZURE_CONFIG_DIR=/tmp/azcfg az containerapp env create -h`
+  - `AZURE_CONFIG_DIR=/tmp/azcfg az monitor log-analytics workspace create -h`
+  - `AZURE_CONFIG_DIR=/tmp/azcfg az monitor log-analytics workspace get-shared-keys -h`
+  - `AZURE_CONFIG_DIR=/tmp/azcfg az containerapp show -h`
+  - result: commands and flags used by the new bootstrap blocks are present
+
+### Open follow-up
+
+- The actual repo variable `AZURE_CONTAINER_REGISTRY` and the effective `AcrPush` scope on `AZURE_CREDENTIALS` still need operator-side confirmation in GitHub/Azure; this issue only documents and bootstraps the infra-side expectations.
+- The deferred RBAC helper will report skips until the Container Apps from `#20` and `#21` exist, which is expected for this issue's scope.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -229,7 +229,10 @@ All Azure resources are in resource group `app-pfcd-v2`.
 | Resource | Name Pattern |
 |----------|--------------|
 | Storage Account | `pfcd[env]storage` (containers: uploads, evidence, exports, scratch) |
+| Azure Container Registry | `pfcd[env]registry` (login server `pfcd[env]registry.azurecr.io`, admin user disabled) |
 | Service Bus | `pfcd-[env]-bus` (queues: extracting, processing, reviewing) |
+| Log Analytics Workspace | `pfcd-[env]-logs` (shared diagnostics for Container Apps) |
+| Container Apps Environment | `pfcd-[env]-env` (shared environment for API + workers) |
 | SQL Server | `pfcd-[env]-sql` |
 | SQL Database | `pfcd-[env]-jobs` |
 | Key Vault | `pfcd-[env]-kv` |
@@ -245,6 +248,8 @@ SPEECH_ACCOUNT_LOCATION=eastus bash infra/dev-bootstrap.sh
 ```
 
 The script is idempotent — safe to re-run.
+
+Pass `SP_CLIENT_ID=<github-actions-service-principal-client-id>` when you want the bootstrap script to grant the CI principal both `Storage Blob Data Contributor` on the storage account and `AcrPush` on the registry during provisioning.
 
 **Authentication:** All Azure SDK clients use `DefaultAzureCredential` (supports Managed Identity, CLI login, and environment variables). Secrets are stored in Key Vault and injected at runtime.
 
@@ -271,6 +276,7 @@ The script is idempotent — safe to re-run.
 | Variable | Used by | Purpose |
 |----------|---------|---------|
 | `AZURE_STORAGE_ACCOUNT` | `deploy-workers.yml` | Storage account resource name used to upload `worker.zip` to `scratch` and generate the `WEBSITE_RUN_FROM_PACKAGE` SAS URL |
+| `AZURE_CONTAINER_REGISTRY` | upcoming Container Apps deploy workflows | ACR login server for image push/pull, e.g. `pfcddevregistry.azurecr.io` |
 
 ---
 

--- a/infra/dev-bootstrap.sh
+++ b/infra/dev-bootstrap.sh
@@ -15,6 +15,10 @@ WEBAPP_NAME="${WEBAPP_NAME:-${PROJECT}-${ENVIRONMENT}-api}"
 WORKER_EXTRACTING_NAME="${WORKER_EXTRACTING_NAME:-${PROJECT}-${ENVIRONMENT}-worker-extracting}"
 WORKER_PROCESSING_NAME="${WORKER_PROCESSING_NAME:-${PROJECT}-${ENVIRONMENT}-worker-processing}"
 WORKER_REVIEWING_NAME="${WORKER_REVIEWING_NAME:-${PROJECT}-${ENVIRONMENT}-worker-reviewing}"
+CONTAINER_REGISTRY_NAME="${CONTAINER_REGISTRY_NAME:-${PROJECT}${ENVIRONMENT}registry}"
+CONTAINER_REGISTRY_SKU="${CONTAINER_REGISTRY_SKU:-Basic}"
+CONTAINER_APPS_ENVIRONMENT_NAME="${CONTAINER_APPS_ENVIRONMENT_NAME:-${PROJECT}-${ENVIRONMENT}-env}"
+LOG_ANALYTICS_WORKSPACE_NAME="${LOG_ANALYTICS_WORKSPACE_NAME:-${PROJECT}-${ENVIRONMENT}-logs}"
 STORAGE_ACCOUNT="${STORAGE_ACCOUNT:-${PROJECT}${ENVIRONMENT}storage}"
 SERVICE_BUS_NAMESPACE="${SERVICE_BUS_NAMESPACE:-${PROJECT}-${ENVIRONMENT}-bus}"
 SERVICE_BUS_QUEUE="${SERVICE_BUS_QUEUE:-jobs}"
@@ -236,6 +240,120 @@ ensure_sql() {
   az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "sql-connection-string" --value "$sql_conn" --output none
 
   info "SQL admin password is stored in Key Vault as 'sql-admin-password'"
+}
+
+ensure_container_registry() {
+  local registry_scope
+  registry_scope="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.ContainerRegistry/registries/${CONTAINER_REGISTRY_NAME}"
+
+  if ! az acr show --resource-group "$RESOURCE_GROUP" --name "$CONTAINER_REGISTRY_NAME" >/dev/null 2>&1; then
+    az acr create \
+      --name "$CONTAINER_REGISTRY_NAME" \
+      --resource-group "$RESOURCE_GROUP" \
+      --location "$LOCATION" \
+      --sku "$CONTAINER_REGISTRY_SKU" \
+      --admin-enabled false \
+      --tags $COMMON_TAGS \
+      --output none
+  fi
+
+  if [[ -n "${SP_CLIENT_ID:-}" ]]; then
+    local sp_object_id
+    sp_object_id="$(az ad sp show --id "$SP_CLIENT_ID" --query id -o tsv 2>/dev/null || true)"
+    if [[ -n "$sp_object_id" ]]; then
+      az role assignment create \
+        --assignee-object-id "$sp_object_id" \
+        --assignee-principal-type ServicePrincipal \
+        --role "AcrPush" \
+        --scope "$registry_scope" \
+        --output none >/dev/null \
+        || true
+    fi
+  fi
+}
+
+ensure_log_analytics_workspace() {
+  if ! az monitor log-analytics workspace show \
+    --resource-group "$RESOURCE_GROUP" \
+    --workspace-name "$LOG_ANALYTICS_WORKSPACE_NAME" >/dev/null 2>&1; then
+    az monitor log-analytics workspace create \
+      --resource-group "$RESOURCE_GROUP" \
+      --workspace-name "$LOG_ANALYTICS_WORKSPACE_NAME" \
+      --location "$LOCATION" \
+      --tags $COMMON_TAGS \
+      --output none
+  fi
+}
+
+ensure_container_apps_environment() {
+  local workspace_customer_id workspace_shared_key
+  workspace_customer_id="$(az monitor log-analytics workspace show \
+    --resource-group "$RESOURCE_GROUP" \
+    --workspace-name "$LOG_ANALYTICS_WORKSPACE_NAME" \
+    --query customerId -o tsv)"
+  workspace_shared_key="$(az monitor log-analytics workspace get-shared-keys \
+    --resource-group "$RESOURCE_GROUP" \
+    --workspace-name "$LOG_ANALYTICS_WORKSPACE_NAME" \
+    --query primarySharedKey -o tsv)"
+
+  if ! az containerapp env show \
+    --resource-group "$RESOURCE_GROUP" \
+    --name "$CONTAINER_APPS_ENVIRONMENT_NAME" >/dev/null 2>&1; then
+    az containerapp env create \
+      --name "$CONTAINER_APPS_ENVIRONMENT_NAME" \
+      --resource-group "$RESOURCE_GROUP" \
+      --location "$LOCATION" \
+      --logs-destination log-analytics \
+      --logs-workspace-id "$workspace_customer_id" \
+      --logs-workspace-key "$workspace_shared_key" \
+      --tags $COMMON_TAGS \
+      --output none
+  fi
+}
+
+assign_container_app_runtime_roles() {
+  local storage_scope service_bus_scope key_vault_scope container_app_name container_app_principal_id
+  storage_scope="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$STORAGE_ACCOUNT"
+  service_bus_scope="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.ServiceBus/namespaces/$SERVICE_BUS_NAMESPACE"
+  key_vault_scope="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.KeyVault/vaults/$KEY_VAULT_NAME"
+
+  for container_app_name in \
+    "$WEBAPP_NAME" \
+    "$WORKER_EXTRACTING_NAME" \
+    "$WORKER_PROCESSING_NAME" \
+    "$WORKER_REVIEWING_NAME"; do
+    container_app_principal_id="$(az containerapp show \
+      --name "$container_app_name" \
+      --resource-group "$RESOURCE_GROUP" \
+      --query identity.principalId -o tsv 2>/dev/null || true)"
+
+    if [[ -z "$container_app_principal_id" || "$container_app_principal_id" == "null" ]]; then
+      info "container app identity not available yet for: $container_app_name (RBAC deferred until app exists)"
+      continue
+    fi
+
+    az role assignment create \
+      --assignee-object-id "$container_app_principal_id" \
+      --assignee-principal-type ServicePrincipal \
+      --role "Storage Blob Data Contributor" \
+      --scope "$storage_scope" \
+      --output none \
+      || true
+    az role assignment create \
+      --assignee-object-id "$container_app_principal_id" \
+      --assignee-principal-type ServicePrincipal \
+      --role "Azure Service Bus Data Owner" \
+      --scope "$service_bus_scope" \
+      --output none \
+      || true
+    az role assignment create \
+      --assignee-object-id "$container_app_principal_id" \
+      --assignee-principal-type ServicePrincipal \
+      --role "Key Vault Secrets User" \
+      --scope "$key_vault_scope" \
+      --output none \
+      || true
+  done
 }
 
 ensure_app_service() {
@@ -462,11 +580,17 @@ ensure_storage_account
 ensure_servicebus
 ensure_key_vault
 ensure_sql
+ensure_container_registry
+ensure_log_analytics_workspace
+ensure_container_apps_environment
+assign_container_app_runtime_roles
 ensure_app_service
 ensure_cognitive_services
 ensure_budget
 
 info "Bootstrap complete for environment '$ENVIRONMENT' in $RESOURCE_GROUP"
+echo "Container registry: ${CONTAINER_REGISTRY_NAME}.azurecr.io"
+echo "Container Apps environment: ${CONTAINER_APPS_ENVIRONMENT_NAME}"
 az resource show --ids "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Web/sites/$WEBAPP_NAME" --query "defaultHostName" -o tsv | sed 's|^|API host: https://|' | sed 's|$|/|' | tr -d '\n'
 echo
   if ! az sql server firewall-rule show --resource-group "$RESOURCE_GROUP" --server "$SQL_SERVER_NAME" --name "AllowAzureServices" >/dev/null 2>&1; then


### PR DESCRIPTION
Closes #19

## Summary
- add Azure Container Registry bootstrap provisioning with admin disabled
- add Log Analytics workspace and shared Container Apps environment bootstrap
- add deferred RBAC assignment helper for future Container App identities
- document the new ACR / Container Apps environment details in `REFERENCE.md`
- record the Issue 19 handoff and implementation summary entries

## Notes
- this PR intentionally isolates only the Issue 19 infra/doc scope from a mixed local working tree
- operator-side follow-up is still required for `AZURE_CONTAINER_REGISTRY` and effective `AcrPush` scope on `AZURE_CREDENTIALS`

## Validation
- `bash -n infra/dev-bootstrap.sh`
- `AZURE_CONFIG_DIR=/tmp/azcfg az acr create -h`
- `AZURE_CONFIG_DIR=/tmp/azcfg az containerapp env create -h`
- `AZURE_CONFIG_DIR=/tmp/azcfg az monitor log-analytics workspace create -h`
- `AZURE_CONFIG_DIR=/tmp/azcfg az monitor log-analytics workspace get-shared-keys -h`
- `AZURE_CONFIG_DIR=/tmp/azcfg az containerapp show -h`
