### PR TITLE
fix: remove stale SQL Server references

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,4 +1,4 @@
-name: Deploy Backend (App Service)
+name: Deploy Backend (Container App)
 
 on:
   push:
@@ -20,15 +20,26 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: pfcd_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d pfcd_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-
-      - name: Install ODBC system libraries
-        run: sudo apt-get install -y unixodbc-dev
 
       - name: Install dependencies
         run: pip install -r backend/requirements.txt
@@ -39,10 +50,19 @@ jobs:
           DATABASE_URL: "sqlite:///./test-ci.db"
           PYTHONPATH: backend
 
+      - name: Run PostgreSQL smoke test
+        run: pytest tests/integration/test_postgres_smoke.py -x --tb=short
+        env:
+          PFCD_POSTGRES_SMOKE_DATABASE_URL: "postgresql+psycopg://postgres:postgres@127.0.0.1:5432/pfcd_test"
+          PYTHONPATH: backend
+
   deploy:
     needs: test
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
+    env:
+      AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED: ${{ secrets.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME != '' && secrets.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME || secrets.AZURE_OPENAI_DEPLOYMENT_NAME }}
+      BACKEND_IMAGE_TAG: ${{ vars.AZURE_CONTAINER_REGISTRY }}/pfcd-backend-api:${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
 
@@ -50,112 +70,247 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Validate backend deployment settings
+      - name: Ensure Azure Container Apps CLI extension
+        run: az extension add --name containerapp --upgrade
+
+      - name: Validate backend container app deployment settings
         run: |
           missing=""
           [ -z "${{ secrets.AZURE_WEBAPP_NAME }}" ] && missing="$missing AZURE_WEBAPP_NAME"
-          [ -z "${{ vars.AZURE_STORAGE_ACCOUNT }}" ] && missing="$missing AZURE_STORAGE_ACCOUNT"
           [ -z "${{ secrets.AZURE_RESOURCE_GROUP }}" ] && missing="$missing AZURE_RESOURCE_GROUP"
+          [ -z "${{ vars.AZURE_CONTAINER_REGISTRY }}" ] && missing="$missing AZURE_CONTAINER_REGISTRY"
+          [ -z "${{ vars.AZURE_CONTAINER_APPS_ENVIRONMENT }}" ] && missing="$missing AZURE_CONTAINER_APPS_ENVIRONMENT"
+          [ -z "${{ vars.AZURE_STORAGE_ACCOUNT }}" ] && missing="$missing AZURE_STORAGE_ACCOUNT"
+          [ -z "${{ vars.AZURE_KEY_VAULT_NAME }}" ] && missing="$missing AZURE_KEY_VAULT_NAME"
+          [ -z "${{ vars.AZURE_SERVICE_BUS_NAMESPACE }}" ] && missing="$missing AZURE_SERVICE_BUS_NAMESPACE"
+          [ -z "${{ vars.AZURE_OPENAI_ACCOUNT_NAME }}" ] && missing="$missing AZURE_OPENAI_ACCOUNT_NAME"
+          [ -z "${{ vars.AZURE_SPEECH_ACCOUNT_NAME }}" ] && missing="$missing AZURE_SPEECH_ACCOUNT_NAME"
+          [ -z "${{ secrets.AZURE_OPENAI_ENDPOINT }}" ] && missing="$missing AZURE_OPENAI_ENDPOINT"
+          [ -z "${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" ] && missing="$missing AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"
           if [ -n "$missing" ]; then
             echo "ERROR: missing required secrets/vars:$missing"
             exit 1
           fi
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Build backend package (with pre-installed dependencies)
+      - name: Log in to Azure Container Registry
         run: |
-          PY_MINOR=$(python3 --version | cut -d' ' -f2 | cut -d'.' -f1-2)
-          pip install \
-            --quiet \
-            --target "backend/antenv/lib/python${PY_MINOR}/site-packages" \
-            -r backend/requirements.txt
+          registry_server="${{ vars.AZURE_CONTAINER_REGISTRY }}"
+          registry_name="${registry_server%%.*}"
+          az acr config authentication-as-arm update -r "$registry_name" --status enabled
+          az acr login --name "$registry_name"
 
-          cd backend
-          zip -r ../backend.zip . \
-            -x "venv/*" -x ".venv/*" -x "env/*" \
-            -x "*.pyc" -x "__pycache__/*" \
-            -x ".pytest_cache/*" -x ".coverage" \
-            -x "*.db" -x "*.sqlite3" \
-            -x ".env" -x ".env.*" \
-            -x "storage/*"
-          rm -rf antenv
-
-      - name: Upload backend zip to scratch blob and write package URL
+      - name: Build and push backend API image
         run: |
-          account="${{ vars.AZURE_STORAGE_ACCOUNT }}"
-          blob_name="backend-${{ github.sha }}.zip"
-          az storage blob upload \
-            --account-name "$account" \
-            --container-name scratch \
-            --name "$blob_name" \
-            --file backend.zip \
-            --auth-mode login \
-            --overwrite true
-          expiry=$(date -u -d "+4 hours" +%Y-%m-%dT%H:%MZ 2>/dev/null || date -u -v+4H +%Y-%m-%dT%H:%MZ)
-          sas=$(az storage blob generate-sas \
-            --account-name "$account" \
-            --container-name scratch \
-            --name "$blob_name" \
-            --permissions r \
-            --expiry "$expiry" \
-            --auth-mode login \
-            --as-user \
-            -o tsv)
-          printf '%s\n' "https://${account}.blob.core.windows.net/scratch/${blob_name}?${sas}" > package-url.txt
-          echo "PACKAGE_URL=$(cat package-url.txt)" >> $GITHUB_ENV
+          docker buildx build \
+            --platform linux/amd64 \
+            --target api \
+            --tag "$BACKEND_IMAGE_TAG" \
+            --push \
+            ./backend
 
-      - name: Deploy backend (WEBSITE_RUN_FROM_PACKAGE)
+      - name: Bootstrap container app identity if app does not exist
         run: |
-          az webapp config appsettings set \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WEBAPP_NAME }} \
-            --settings \
-              PFCD_CORS_ORIGINS="${{ secrets.PFCD_CORS_ORIGINS }}" \
-              SCM_DO_BUILD_DURING_DEPLOYMENT=false \
-              PYTHONPATH=/home/site/wwwroot/antenv/lib/python3.11/site-packages \
-              WEBSITES_CONTAINER_START_TIME_LIMIT=600 \
-              WEBSITES_PORT=8000 \
-              WEBSITE_RUN_FROM_PACKAGE="$PACKAGE_URL"
-          az webapp config set \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WEBAPP_NAME }} \
-            --startup-file "python -m uvicorn app.main:app --host 0.0.0.0 --port 8000"
-          az webapp restart \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WEBAPP_NAME }}
+          if az containerapp show \
+            --name "${{ secrets.AZURE_WEBAPP_NAME }}" \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" >/dev/null 2>&1; then
+            echo "Container app already exists; skipping bootstrap create."
+            exit 0
+          fi
 
-      - name: Wait for backend package restart to settle
-        run: |
-          sleep 15
-          for i in $(seq 1 30); do
-            state=$(az webapp show \
-              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --name ${{ secrets.AZURE_WEBAPP_NAME }} \
-              --query "state" -o tsv)
-            echo "backend config settle $i/30: $state"
-            if [ "$state" = "Running" ]; then
-              sleep 60
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "ERROR: backend did not return to Running after package deployment"
-          exit 1
+          az containerapp create \
+            --name "${{ secrets.AZURE_WEBAPP_NAME }}" \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --environment "${{ vars.AZURE_CONTAINER_APPS_ENVIRONMENT }}" \
+            --image "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest" \
+            --ingress external \
+            --target-port 80 \
+            --min-replicas 1 \
+            --max-replicas 1 \
+            --cpu 0.5 \
+            --memory 1.0Gi \
+            --revisions-mode single \
+            --system-assigned \
+            --output none
 
-      - name: Verify backend HTTP readiness
+      - name: Grant backend container app runtime roles
         run: |
-          url="https://${{ secrets.AZURE_WEBAPP_NAME }}.azurewebsites.net/health"
+          registry_server="${{ vars.AZURE_CONTAINER_REGISTRY }}"
+          registry_name="${registry_server%%.*}"
+          principal_id="$(az containerapp show \
+            --name "${{ secrets.AZURE_WEBAPP_NAME }}" \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --query identity.principalId -o tsv)"
+
+          if [ -z "$principal_id" ] || [ "$principal_id" = "null" ]; then
+            echo "ERROR: backend container app identity is not available."
+            exit 1
+          fi
+
+          acr_id="$(az acr show --name "$registry_name" --query id -o tsv)"
+          kv_id="$(az keyvault show --name "${{ vars.AZURE_KEY_VAULT_NAME }}" --query id -o tsv)"
+
+          az role assignment create \
+            --assignee-object-id "$principal_id" \
+            --assignee-principal-type ServicePrincipal \
+            --role AcrPull \
+            --scope "$acr_id" \
+            --output none || true
+
+          az role assignment create \
+            --assignee-object-id "$principal_id" \
+            --assignee-principal-type ServicePrincipal \
+            --role "Key Vault Secrets User" \
+            --scope "$kv_id" \
+            --output none || true
+
+          sleep 30
+
+      - name: Render backend ACA manifest
+        env:
+          PFCD_CORS_ORIGINS_VALUE: ${{ secrets.PFCD_CORS_ORIGINS }}
+          PFCD_API_KEY_VALUE: ${{ secrets.PFCD_API_KEY }}
+          AZURE_OPENAI_ENDPOINT_VALUE: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+        run: |
+          env_id="$(az containerapp env show \
+            --name "${{ vars.AZURE_CONTAINER_APPS_ENVIRONMENT }}" \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --query id -o tsv)"
+          location="$(az group show \
+            --name "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --query location -o tsv)"
+
+          cat > backend-aca.yaml <<EOF
+          location: ${location}
+          name: ${{ secrets.AZURE_WEBAPP_NAME }}
+          type: Microsoft.App/containerApps
+          identity:
+            type: SystemAssigned
+          properties:
+            environmentId: ${env_id}
+            configuration:
+              activeRevisionsMode: Single
+              ingress:
+                external: true
+                allowInsecure: false
+                targetPort: 8000
+                transport: auto
+                traffic:
+                  - latestRevision: true
+                    weight: 100
+              registries:
+                - server: ${{ vars.AZURE_CONTAINER_REGISTRY }}
+                  identity: system
+              secrets:
+                - name: dburl
+                  keyVaultUrl: https://${{ vars.AZURE_KEY_VAULT_NAME }}.vault.azure.net/secrets/postgres-connection-string
+                  identity: system
+                - name: blobconn
+                  keyVaultUrl: https://${{ vars.AZURE_KEY_VAULT_NAME }}.vault.azure.net/secrets/storage-connection-string
+                  identity: system
+                - name: sbconn
+                  keyVaultUrl: https://${{ vars.AZURE_KEY_VAULT_NAME }}.vault.azure.net/secrets/service-bus-connection-string
+                  identity: system
+            template:
+              containers:
+                - name: api
+                  image: ${BACKEND_IMAGE_TAG}
+                  env:
+                    - name: PFCD_CORS_ORIGINS
+                      value: "${PFCD_CORS_ORIGINS_VALUE}"
+                    - name: PFCD_API_KEY
+                      value: "${PFCD_API_KEY_VALUE}"
+                    - name: DATABASE_URL
+                      secretRef: dburl
+                    - name: AZURE_STORAGE_CONNECTION_STRING
+                      secretRef: blobconn
+                    - name: AZURE_SERVICE_BUS_CONNECTION_STRING
+                      secretRef: sbconn
+                    - name: AZURE_STORAGE_ACCOUNT_NAME
+                      value: "${{ vars.AZURE_STORAGE_ACCOUNT }}"
+                    - name: AZURE_STORAGE_CONTAINER_EXPORTS
+                      value: "exports"
+                    - name: AZURE_SERVICE_BUS_NAMESPACE
+                      value: "${{ vars.AZURE_SERVICE_BUS_NAMESPACE }}"
+                    - name: AZURE_SERVICE_BUS_QUEUE_EXTRACTING
+                      value: "extracting"
+                    - name: AZURE_SERVICE_BUS_QUEUE_PROCESSING
+                      value: "processing"
+                    - name: AZURE_SERVICE_BUS_QUEUE_REVIEWING
+                      value: "reviewing"
+                    - name: KEYVAULT_NAME
+                      value: "${{ vars.AZURE_KEY_VAULT_NAME }}"
+                    - name: AZURE_OPENAI_ACCOUNT_NAME
+                      value: "${{ vars.AZURE_OPENAI_ACCOUNT_NAME }}"
+                    - name: AZURE_SPEECH_ACCOUNT_NAME
+                      value: "${{ vars.AZURE_SPEECH_ACCOUNT_NAME }}"
+                    - name: AZURE_OPENAI_ENDPOINT
+                      value: "${AZURE_OPENAI_ENDPOINT_VALUE}"
+                    - name: AZURE_OPENAI_CHAT_DEPLOYMENT_NAME
+                      value: "${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}"
+                    - name: AZURE_OPENAI_API_VERSION
+                      value: "2024-10-21"
+                  probes:
+                    - type: Startup
+                      httpGet:
+                        path: /health
+                        port: 8000
+                      initialDelaySeconds: 5
+                      periodSeconds: 5
+                      timeoutSeconds: 5
+                      failureThreshold: 24
+                    - type: Liveness
+                      httpGet:
+                        path: /health
+                        port: 8000
+                      initialDelaySeconds: 30
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 6
+                    - type: Readiness
+                      httpGet:
+                        path: /health
+                        port: 8000
+                      initialDelaySeconds: 15
+                      periodSeconds: 5
+                      timeoutSeconds: 5
+                      failureThreshold: 12
+                  resources:
+                    cpu: 0.5
+                    memory: 1Gi
+              scale:
+                minReplicas: 1
+                maxReplicas: 3
+          EOF
+
+      - name: Deploy backend to Azure Container Apps
+        run: |
+          az containerapp update \
+            --name "${{ secrets.AZURE_WEBAPP_NAME }}" \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --yaml backend-aca.yaml \
+            --output none
+
+      - name: Verify backend container app health
+        run: |
           for i in $(seq 1 60); do
-            if curl -fsS --max-time 10 "$url" >/dev/null; then
-              echo "Health check passed on attempt $i"
-              exit 0
+            fqdn="$(az containerapp show \
+              --name "${{ secrets.AZURE_WEBAPP_NAME }}" \
+              --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+              --query properties.configuration.ingress.fqdn -o tsv)"
+
+            if [ -n "$fqdn" ] && [ "$fqdn" != "null" ]; then
+              status_code="$(curl -sS -o health-response.json -w '%{http_code}' --max-time 10 "https://${fqdn}/health" || true)"
+              if [ "$status_code" = "200" ] || [ "$status_code" = "503" ]; then
+                cat health-response.json
+                exit 0
+              fi
             fi
-            echo "Health check not ready yet (attempt $i/60); waiting 10s..."
+
+            echo "Backend ACA health probe not ready yet (attempt $i/60); waiting 10s..."
             sleep 10
           done
-          echo "ERROR: backend health check did not pass within 10 minutes"
+
+          echo "ERROR: backend container app health endpoint did not respond with 200/503 within 10 minutes"
           exit 1

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -4,13 +4,17 @@ on:
   push:
     branches: [main]
     paths:
-      - 'backend/**'
-      - '.github/workflows/deploy-workers.yml'
+      - "backend/**"
+      - ".github/workflows/deploy-workers.yml"
   workflow_dispatch:
 
 concurrency:
   group: deploy-workers-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
 
 env:
   AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED: ${{ secrets.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME != '' && secrets.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME || secrets.AZURE_OPENAI_DEPLOYMENT_NAME }}
@@ -18,15 +22,26 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: pfcd_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d pfcd_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-
-      - name: Install ODBC system libraries
-        run: sudo apt-get install -y unixodbc-dev
 
       - name: Install dependencies
         run: pip install -r backend/requirements.txt
@@ -37,349 +52,314 @@ jobs:
           DATABASE_URL: "sqlite:///./test-ci.db"
           PYTHONPATH: backend
 
+      - name: Run PostgreSQL smoke test
+        run: pytest tests/integration/test_postgres_smoke.py -x --tb=short
+        env:
+          PFCD_POSTGRES_SMOKE_DATABASE_URL: "postgresql+psycopg://postgres:postgres@127.0.0.1:5432/pfcd_test"
+          PYTHONPATH: backend
+
   build:
+    needs: test
     runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.image.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install ODBC system libraries
-        run: sudo apt-get install -y unixodbc-dev
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Build zip
-        run: |
-          PY_MINOR=$(python3 --version | cut -d' ' -f2 | cut -d'.' -f1-2)
-          pip install \
-            --quiet \
-            --target "backend/antenv/lib/python${PY_MINOR}/site-packages" \
-            -r backend/requirements.txt
-
-          cd backend && zip -r ../worker.zip . \
-            -x "venv/*" -x ".venv/*" -x "env/*" \
-            -x "*.pyc" -x "__pycache__/*" \
-            -x ".pytest_cache/*" -x ".coverage" \
-            -x "*.db" -x "*.sqlite3" \
-            -x ".env" -x ".env.*" \
-            -x "storage/*"
-          rm -rf antenv
       - uses: azure/login@v2
         with:
-          creds: '${{ secrets.AZURE_CREDENTIALS }}'
-      - name: Validate package upload settings
+          creds: "${{ secrets.AZURE_CREDENTIALS }}"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Validate worker image settings
         run: |
-          if [ -z "${{ vars.AZURE_STORAGE_ACCOUNT }}" ]; then
-            echo "ERROR: Set AZURE_STORAGE_ACCOUNT as a GitHub Actions variable."
+          if [ -z "${{ vars.AZURE_CONTAINER_REGISTRY }}" ]; then
+            echo "ERROR: Set AZURE_CONTAINER_REGISTRY as a GitHub Actions variable."
             exit 1
           fi
-      - name: Upload worker zip to scratch blob and write package URL
-        run: |
-          account="${{ vars.AZURE_STORAGE_ACCOUNT }}"
-          blob_name="worker-${{ github.sha }}.zip"
-          az storage blob upload \
-            --account-name "$account" \
-            --container-name scratch \
-            --name "$blob_name" \
-            --file worker.zip \
-            --auth-mode login \
-            --overwrite true
-          expiry=$(date -u -d "+4 hours" +%Y-%m-%dT%H:%MZ 2>/dev/null || date -u -v+4H +%Y-%m-%dT%H:%MZ)
-          sas=$(az storage blob generate-sas \
-            --account-name "$account" \
-            --container-name scratch \
-            --name "$blob_name" \
-            --permissions r \
-            --expiry "$expiry" \
-            --auth-mode login \
-            --as-user \
-            -o tsv)
-          printf '%s\n' "https://${account}.blob.core.windows.net/scratch/${blob_name}?${sas}" > package-url.txt
-      - uses: actions/upload-artifact@v4
-        with:
-          name: package-url
-          path: package-url.txt
-      - uses: actions/upload-artifact@v4
-        with:
-          name: worker-zip
-          path: worker.zip
 
-  deploy-extracting:
-    needs: [test, build]
+      - name: Enable ACR ARM authentication
+        run: |
+          registry_name="${{ vars.AZURE_CONTAINER_REGISTRY }}"
+          registry_name="${registry_name%%.*}"
+          az acr config authentication-as-arm update -n "${registry_name}" --status enabled
+
+      - name: Log in to ACR
+        run: |
+          registry_name="${{ vars.AZURE_CONTAINER_REGISTRY }}"
+          registry_name="${registry_name%%.*}"
+          az acr login --name "${registry_name}"
+
+      - name: Set worker image tag
+        id: image
+        run: |
+          registry_name="${{ vars.AZURE_CONTAINER_REGISTRY }}"
+          registry_name="${registry_name%%.*}"
+          registry_server=$(az acr show --name "${registry_name}" --query loginServer -o tsv)
+          image_tag="${registry_server}/pfcd-worker:${{ github.sha }}"
+          echo "tag=${image_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push worker image
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            --target worker \
+            --tag "${{ steps.image.outputs.tag }}" \
+            --push \
+            ./backend
+
+  deploy:
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        role: [extracting, processing, reviewing]
+    env:
+      WORKER_EXTRACTING_NAME: ${{ secrets.AZURE_WORKER_EXTRACTING_NAME }}
+      WORKER_PROCESSING_NAME: ${{ secrets.AZURE_WORKER_PROCESSING_NAME }}
+      WORKER_REVIEWING_NAME: ${{ secrets.AZURE_WORKER_REVIEWING_NAME }}
+      WORKER_IMAGE: ${{ needs.build.outputs.image_tag }}
     steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: worker-zip
-      - uses: actions/download-artifact@v4
-        with:
-          name: package-url
-      - name: Read package URL
-        run: echo "PACKAGE_URL=$(cat package-url.txt)" >> $GITHUB_ENV
       - uses: azure/login@v2
         with:
-          creds: '${{ secrets.AZURE_CREDENTIALS }}'
-      - name: Validate worker deployment settings
-        run: |
-          if [ -z "${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" ]; then
-            echo "ERROR: Set AZURE_OPENAI_CHAT_DEPLOYMENT_NAME (preferred) or AZURE_OPENAI_DEPLOYMENT_NAME in GitHub secrets."
-            exit 1
-          fi
-          if [ -z "${{ secrets.AZURE_WORKER_EXTRACTING_NAME }}" ]; then
-            echo "ERROR: Set AZURE_WORKER_EXTRACTING_NAME in GitHub secrets."
-            exit 1
-          fi
-          if [ -z "${PACKAGE_URL}" ]; then
-            echo "ERROR: package-url artifact did not produce a package URL."
-            exit 1
-          fi
-      - name: Deploy extracting worker (WEBSITE_RUN_FROM_PACKAGE)
-        run: |
-          az webapp config appsettings set \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_EXTRACTING_NAME }} \
-            --settings PFCD_WORKER_ROLE=extracting \
-              AZURE_OPENAI_ENDPOINT="${{ secrets.AZURE_OPENAI_ENDPOINT }}" \
-              AZURE_OPENAI_CHAT_DEPLOYMENT_NAME="${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" \
-              SCM_DO_BUILD_DURING_DEPLOYMENT=false \
-              PYTHONPATH=/home/site/wwwroot/antenv/lib/python3.11/site-packages \
-              WEBSITES_CONTAINER_START_TIME_LIMIT=600 \
-              WEBSITES_PORT=8000 \
-              WEBSITE_RUN_FROM_PACKAGE="$PACKAGE_URL"
-          az webapp restart \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_EXTRACTING_NAME }}
-      - name: Wait for extracting worker package restart to settle
-        run: |
-          sleep 15
-          for i in $(seq 1 30); do
-            state=$(az webapp show \
-              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --name ${{ secrets.AZURE_WORKER_EXTRACTING_NAME }} \
-              --query "state" -o tsv)
-            echo "extracting config settle $i/30: $state"
-            if [ "$state" = "Running" ]; then
-              sleep 60
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "ERROR: extracting worker did not return to Running after package deployment"
-          exit 1
-      - name: Verify extracting worker is running
-        run: |
-          for i in $(seq 1 90); do
-            state=$(az webapp show \
-              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --name ${{ secrets.AZURE_WORKER_EXTRACTING_NAME }} \
-              --query "state" -o tsv)
-            echo "extracting state check $i/90: $state"
-            if [ "$state" = "Running" ]; then
-              echo "Extracting worker is Running"
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "ERROR: extracting worker did not reach Running state within 15 minutes"
-          exit 1
-      - name: Verify extracting worker HTTP readiness
-        run: |
-          url="https://${{ secrets.AZURE_WORKER_EXTRACTING_NAME }}.azurewebsites.net/"
-          for i in $(seq 1 60); do
-            if curl -fsS --max-time 10 "$url" >/dev/null; then
-              echo "Extracting worker HTTP probe passed on attempt $i"
-              exit 0
-            fi
-            echo "Extracting worker HTTP probe not ready yet (attempt $i/60); waiting 10s..."
-            sleep 10
-          done
-          echo "ERROR: extracting worker HTTP probe did not pass within 10 minutes"
-          exit 1
+          creds: "${{ secrets.AZURE_CREDENTIALS }}"
 
-  deploy-processing:
-    needs: [test, build]
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: worker-zip
-      - uses: actions/download-artifact@v4
-        with:
-          name: package-url
-      - name: Read package URL
-        run: echo "PACKAGE_URL=$(cat package-url.txt)" >> $GITHUB_ENV
-      - uses: azure/login@v2
-        with:
-          creds: '${{ secrets.AZURE_CREDENTIALS }}'
-      - name: Validate worker deployment settings
+      - name: Install Container Apps extension
         run: |
-          if [ -z "${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" ]; then
-            echo "ERROR: Set AZURE_OPENAI_CHAT_DEPLOYMENT_NAME (preferred) or AZURE_OPENAI_DEPLOYMENT_NAME in GitHub secrets."
-            exit 1
-          fi
-          if [ -z "${{ secrets.AZURE_WORKER_PROCESSING_NAME }}" ]; then
-            echo "ERROR: Set AZURE_WORKER_PROCESSING_NAME in GitHub secrets."
-            exit 1
-          fi
-          if [ -z "${PACKAGE_URL}" ]; then
-            echo "ERROR: package-url artifact did not produce a package URL."
-            exit 1
-          fi
-      - name: Deploy processing worker (WEBSITE_RUN_FROM_PACKAGE)
-        run: |
-          az webapp config appsettings set \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_PROCESSING_NAME }} \
-            --settings PFCD_WORKER_ROLE=processing \
-              AZURE_OPENAI_ENDPOINT="${{ secrets.AZURE_OPENAI_ENDPOINT }}" \
-              AZURE_OPENAI_CHAT_DEPLOYMENT_NAME="${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" \
-              SCM_DO_BUILD_DURING_DEPLOYMENT=false \
-              PYTHONPATH=/home/site/wwwroot/antenv/lib/python3.11/site-packages \
-              WEBSITES_CONTAINER_START_TIME_LIMIT=600 \
-              WEBSITES_PORT=8000 \
-              WEBSITE_RUN_FROM_PACKAGE="$PACKAGE_URL"
-          az webapp restart \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_PROCESSING_NAME }}
-      - name: Wait for processing worker package restart to settle
-        run: |
-          sleep 15
-          for i in $(seq 1 30); do
-            state=$(az webapp show \
-              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --name ${{ secrets.AZURE_WORKER_PROCESSING_NAME }} \
-              --query "state" -o tsv)
-            echo "processing config settle $i/30: $state"
-            if [ "$state" = "Running" ]; then
-              sleep 60
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "ERROR: processing worker did not return to Running after package deployment"
-          exit 1
-      - name: Verify processing worker is running
-        run: |
-          for i in $(seq 1 90); do
-            state=$(az webapp show \
-              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --name ${{ secrets.AZURE_WORKER_PROCESSING_NAME }} \
-              --query "state" -o tsv)
-            echo "processing state check $i/90: $state"
-            if [ "$state" = "Running" ]; then
-              echo "Processing worker is Running"
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "ERROR: processing worker did not reach Running state within 15 minutes"
-          exit 1
-      - name: Verify processing worker HTTP readiness
-        run: |
-          url="https://${{ secrets.AZURE_WORKER_PROCESSING_NAME }}.azurewebsites.net/"
-          for i in $(seq 1 60); do
-            if curl -fsS --max-time 10 "$url" >/dev/null; then
-              echo "Processing worker HTTP probe passed on attempt $i"
-              exit 0
-            fi
-            echo "Processing worker HTTP probe not ready yet (attempt $i/60); waiting 10s..."
-            sleep 10
-          done
-          echo "ERROR: processing worker HTTP probe did not pass within 10 minutes"
-          exit 1
+          az extension add --name containerapp --upgrade
+          az provider register --namespace Microsoft.App
+          az provider register --namespace Microsoft.OperationalInsights
 
-  deploy-reviewing:
-    needs: [test, build]
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: worker-zip
-      - uses: actions/download-artifact@v4
-        with:
-          name: package-url
-      - name: Read package URL
-        run: echo "PACKAGE_URL=$(cat package-url.txt)" >> $GITHUB_ENV
-      - uses: azure/login@v2
-        with:
-          creds: '${{ secrets.AZURE_CREDENTIALS }}'
+      - name: Resolve worker settings
+        run: |
+          case "${{ matrix.role }}" in
+            extracting)
+              app_name="${WORKER_EXTRACTING_NAME}"
+              ;;
+            processing)
+              app_name="${WORKER_PROCESSING_NAME}"
+              ;;
+            reviewing)
+              app_name="${WORKER_REVIEWING_NAME}"
+              ;;
+          esac
+
+          if [ -z "${app_name}" ]; then
+            echo "ERROR: Missing Azure worker app name secret for role '${{ matrix.role }}'."
+            exit 1
+          fi
+
+          echo "WORKER_APP_NAME=${app_name}" >> "$GITHUB_ENV"
+          echo "WORKER_QUEUE_NAME=${{ matrix.role }}" >> "$GITHUB_ENV"
+
       - name: Validate worker deployment settings
         run: |
-          if [ -z "${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" ]; then
-            echo "ERROR: Set AZURE_OPENAI_CHAT_DEPLOYMENT_NAME (preferred) or AZURE_OPENAI_DEPLOYMENT_NAME in GitHub secrets."
+          missing=""
+          [ -z "${{ secrets.AZURE_RESOURCE_GROUP }}" ] && missing="$missing AZURE_RESOURCE_GROUP"
+          [ -z "${{ vars.AZURE_CONTAINER_APPS_ENVIRONMENT }}" ] && missing="$missing AZURE_CONTAINER_APPS_ENVIRONMENT"
+          [ -z "${{ vars.AZURE_CONTAINER_REGISTRY }}" ] && missing="$missing AZURE_CONTAINER_REGISTRY"
+          [ -z "${{ vars.AZURE_STORAGE_ACCOUNT }}" ] && missing="$missing AZURE_STORAGE_ACCOUNT"
+          [ -z "${{ vars.AZURE_KEY_VAULT_NAME }}" ] && missing="$missing AZURE_KEY_VAULT_NAME"
+          [ -z "${{ vars.AZURE_SERVICE_BUS_NAMESPACE }}" ] && missing="$missing AZURE_SERVICE_BUS_NAMESPACE"
+          [ -z "${{ vars.AZURE_OPENAI_ACCOUNT_NAME }}" ] && missing="$missing AZURE_OPENAI_ACCOUNT_NAME"
+          [ -z "${{ vars.AZURE_SPEECH_ACCOUNT_NAME }}" ] && missing="$missing AZURE_SPEECH_ACCOUNT_NAME"
+          [ -z "${{ secrets.AZURE_OPENAI_ENDPOINT }}" ] && missing="$missing AZURE_OPENAI_ENDPOINT"
+          [ -z "${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" ] && missing="$missing AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"
+          if [ -n "$missing" ]; then
+            echo "ERROR: missing required secrets/vars:$missing"
             exit 1
           fi
-          if [ -z "${{ secrets.AZURE_WORKER_REVIEWING_NAME }}" ]; then
-            echo "ERROR: Set AZURE_WORKER_REVIEWING_NAME in GitHub secrets."
-            exit 1
-          fi
-          if [ -z "${PACKAGE_URL}" ]; then
-            echo "ERROR: package-url artifact did not produce a package URL."
-            exit 1
-          fi
-      - name: Deploy reviewing worker (WEBSITE_RUN_FROM_PACKAGE)
+
+      - name: Ensure worker container app exists
         run: |
-          az webapp config appsettings set \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_REVIEWING_NAME }} \
-            --settings PFCD_WORKER_ROLE=reviewing \
-              AZURE_OPENAI_ENDPOINT="${{ secrets.AZURE_OPENAI_ENDPOINT }}" \
-              AZURE_OPENAI_CHAT_DEPLOYMENT_NAME="${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" \
-              SCM_DO_BUILD_DURING_DEPLOYMENT=false \
-              PYTHONPATH=/home/site/wwwroot/antenv/lib/python3.11/site-packages \
-              WEBSITES_CONTAINER_START_TIME_LIMIT=600 \
-              WEBSITES_PORT=8000 \
-              WEBSITE_RUN_FROM_PACKAGE="$PACKAGE_URL"
-          az webapp restart \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_REVIEWING_NAME }}
-      - name: Wait for reviewing worker package restart to settle
+          if az containerapp show \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --name "${WORKER_APP_NAME}" >/dev/null 2>&1; then
+            echo "Worker container app already exists."
+            exit 0
+          fi
+
+          az containerapp create \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --environment "${{ vars.AZURE_CONTAINER_APPS_ENVIRONMENT }}" \
+            --name "${WORKER_APP_NAME}" \
+            --image "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest" \
+            --min-replicas 1 \
+            --max-replicas 1 \
+            --cpu 0.5 \
+            --memory 1.0Gi \
+            --revisions-mode single \
+            --system-assigned \
+            --output none
+
+      - name: Grant worker container app runtime roles
         run: |
-          sleep 15
+          registry_name="${{ vars.AZURE_CONTAINER_REGISTRY }}"
+          registry_name="${registry_name%%.*}"
+          principal_id="$(az containerapp show \
+            --name "${WORKER_APP_NAME}" \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --query identity.principalId -o tsv)"
+
+          if [ -z "${principal_id}" ] || [ "${principal_id}" = "null" ]; then
+            echo "ERROR: worker container app identity is not available."
+            exit 1
+          fi
+
+          acr_id="$(az acr show --name "${registry_name}" --query id -o tsv)"
+          kv_id="$(az keyvault show --name "${{ vars.AZURE_KEY_VAULT_NAME }}" --query id -o tsv)"
+          sb_id="$(az servicebus namespace show \
+            --name "${{ vars.AZURE_SERVICE_BUS_NAMESPACE }}" \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --query id -o tsv)"
+
+          az role assignment create \
+            --assignee-object-id "${principal_id}" \
+            --assignee-principal-type ServicePrincipal \
+            --role AcrPull \
+            --scope "${acr_id}" \
+            --output none || true
+
+          az role assignment create \
+            --assignee-object-id "${principal_id}" \
+            --assignee-principal-type ServicePrincipal \
+            --role "Key Vault Secrets User" \
+            --scope "${kv_id}" \
+            --output none || true
+
+          az role assignment create \
+            --assignee-object-id "${principal_id}" \
+            --assignee-principal-type ServicePrincipal \
+            --role "Azure Service Bus Data Owner" \
+            --scope "${sb_id}" \
+            --output none || true
+
+          sleep 30
+
+      - name: Render worker ACA manifest
+        env:
+          PFCD_API_KEY_VALUE: ${{ secrets.PFCD_API_KEY }}
+          AZURE_OPENAI_ENDPOINT_VALUE: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+        run: |
+          env_id="$(az containerapp env show \
+            --name "${{ vars.AZURE_CONTAINER_APPS_ENVIRONMENT }}" \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --query id -o tsv)"
+          location="$(az group show \
+            --name "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --query location -o tsv)"
+          registry_name="${{ vars.AZURE_CONTAINER_REGISTRY }}"
+          registry_name="${registry_name%%.*}"
+          registry_server="$(az acr show --name "${registry_name}" --query loginServer -o tsv)"
+
+          cat > worker-aca.yaml <<EOF
+          location: ${location}
+          name: ${WORKER_APP_NAME}
+          type: Microsoft.App/containerApps
+          identity:
+            type: SystemAssigned
+          properties:
+            environmentId: ${env_id}
+            configuration:
+              activeRevisionsMode: Single
+              registries:
+                - server: ${registry_server}
+                  identity: system
+              secrets:
+                - name: dburl
+                  keyVaultUrl: https://${{ vars.AZURE_KEY_VAULT_NAME }}.vault.azure.net/secrets/postgres-connection-string
+                  identity: system
+                - name: blobconn
+                  keyVaultUrl: https://${{ vars.AZURE_KEY_VAULT_NAME }}.vault.azure.net/secrets/storage-connection-string
+                  identity: system
+                - name: sbconn
+                  keyVaultUrl: https://${{ vars.AZURE_KEY_VAULT_NAME }}.vault.azure.net/secrets/service-bus-connection-string
+                  identity: system
+            template:
+              containers:
+                - name: worker
+                  image: ${WORKER_IMAGE}
+                  env:
+                    - name: PFCD_WORKER_ROLE
+                      value: "${WORKER_QUEUE_NAME}"
+                    - name: PFCD_API_KEY
+                      value: "${PFCD_API_KEY_VALUE}"
+                    - name: DATABASE_URL
+                      secretRef: dburl
+                    - name: AZURE_STORAGE_CONNECTION_STRING
+                      secretRef: blobconn
+                    - name: AZURE_SERVICE_BUS_CONNECTION_STRING
+                      secretRef: sbconn
+                    - name: AZURE_STORAGE_ACCOUNT_NAME
+                      value: "${{ vars.AZURE_STORAGE_ACCOUNT }}"
+                    - name: AZURE_STORAGE_CONTAINER_EVIDENCE
+                      value: "evidence"
+                    - name: AZURE_STORAGE_CONTAINER_EXPORTS
+                      value: "exports"
+                    - name: AZURE_SERVICE_BUS_NAMESPACE
+                      value: "${{ vars.AZURE_SERVICE_BUS_NAMESPACE }}"
+                    - name: AZURE_SERVICE_BUS_QUEUE_EXTRACTING
+                      value: "extracting"
+                    - name: AZURE_SERVICE_BUS_QUEUE_PROCESSING
+                      value: "processing"
+                    - name: AZURE_SERVICE_BUS_QUEUE_REVIEWING
+                      value: "reviewing"
+                    - name: KEYVAULT_NAME
+                      value: "${{ vars.AZURE_KEY_VAULT_NAME }}"
+                    - name: AZURE_OPENAI_ACCOUNT_NAME
+                      value: "${{ vars.AZURE_OPENAI_ACCOUNT_NAME }}"
+                    - name: AZURE_SPEECH_ACCOUNT_NAME
+                      value: "${{ vars.AZURE_SPEECH_ACCOUNT_NAME }}"
+                    - name: AZURE_OPENAI_ENDPOINT
+                      value: "${AZURE_OPENAI_ENDPOINT_VALUE}"
+                    - name: AZURE_OPENAI_CHAT_DEPLOYMENT_NAME
+                      value: "${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}"
+                    - name: AZURE_OPENAI_API_VERSION
+                      value: "2024-10-21"
+                  resources:
+                    cpu: 0.5
+                    memory: 1.0Gi
+              scale:
+                minReplicas: 0
+                maxReplicas: 3
+                rules:
+                  - name: ${WORKER_QUEUE_NAME}-queue
+                    custom:
+                      type: azure-servicebus
+                      metadata:
+                        queueName: ${WORKER_QUEUE_NAME}
+                        namespace: ${{ vars.AZURE_SERVICE_BUS_NAMESPACE }}
+                        messageCount: "1"
+                      identity: system
+          EOF
+
+      - name: Deploy worker container app
+        run: |
+          az containerapp update \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --name "${WORKER_APP_NAME}" \
+            --yaml worker-aca.yaml \
+            --output none
+
+      - name: Verify worker revision state
+        run: |
           for i in $(seq 1 30); do
-            state=$(az webapp show \
-              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --name ${{ secrets.AZURE_WORKER_REVIEWING_NAME }} \
-              --query "state" -o tsv)
-            echo "reviewing config settle $i/30: $state"
-            if [ "$state" = "Running" ]; then
-              sleep 60
+            provisioning_state="$(az containerapp show \
+              --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+              --name "${WORKER_APP_NAME}" \
+              --query properties.provisioningState -o tsv)"
+            latest_revision="$(az containerapp show \
+              --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+              --name "${WORKER_APP_NAME}" \
+              --query properties.latestRevisionName -o tsv)"
+            echo "${WORKER_APP_NAME} provisioning attempt ${i}/30: ${provisioning_state} (${latest_revision})"
+            if [ "${provisioning_state}" = "Succeeded" ]; then
               exit 0
             fi
             sleep 10
           done
-          echo "ERROR: reviewing worker did not return to Running after package deployment"
-          exit 1
-      - name: Verify reviewing worker is running
-        run: |
-          for i in $(seq 1 90); do
-            state=$(az webapp show \
-              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --name ${{ secrets.AZURE_WORKER_REVIEWING_NAME }} \
-              --query "state" -o tsv)
-            echo "reviewing state check $i/90: $state"
-            if [ "$state" = "Running" ]; then
-              echo "Reviewing worker is Running"
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "ERROR: reviewing worker did not reach Running state within 15 minutes"
-          exit 1
-      - name: Verify reviewing worker HTTP readiness
-        run: |
-          url="https://${{ secrets.AZURE_WORKER_REVIEWING_NAME }}.azurewebsites.net/"
-          for i in $(seq 1 60); do
-            if curl -fsS --max-time 10 "$url" >/dev/null; then
-              echo "Reviewing worker HTTP probe passed on attempt $i"
-              exit 0
-            fi
-            echo "Reviewing worker HTTP probe not ready yet (attempt $i/60); waiting 10s..."
-            sleep 10
-          done
-          echo "ERROR: reviewing worker HTTP probe did not pass within 10 minutes"
+          echo "ERROR: ${WORKER_APP_NAME} did not reach a succeeded provisioning state."
           exit 1

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2080,3 +2080,38 @@ Closed both Codex tasks created from Claude's Section 42 RCA.
 `deploy-workers.yml` `build` job: added `sudo apt-get install -y unixodbc-dev`, `actions/setup-python@v5 (3.11)`, and `pip install --quiet --target backend/antenv/lib/python${PY_MINOR}/site-packages -r backend/requirements.txt` before the zip step; added `rm -rf antenv` after. `antenv/` is included in `worker.zip` (not excluded). Workers now ship fully vendored packages under `WEBSITE_RUN_FROM_PACKAGE` — immune to host/runtime drift. Pattern identical to backend.
 
 Both tasks closed. Board queue now empty.
+## Section 62: Codex Delivery — GitHub Issue #20 Backend API to Azure Container Apps (2026-04-19)
+
+Executed the first Container Apps migration slice for the backend API by replacing the App Service package deployment workflow with an image-based Azure Container Apps deployment path.
+
+### Completed
+
+- Rewrote [.github/workflows/deploy-backend.yml](/Users/karthicks/kAgents/Projects/PFCD-V2/.github/workflows/deploy-backend.yml) from App Service zip deploy to Azure Container Apps:
+  - keeps the existing unit/integration + PostgreSQL smoke test gate
+  - installs the Azure Container Apps CLI extension
+  - builds `backend/Dockerfile --target api`
+  - pushes `pfcd-backend-api:${GITHUB_SHA}` to ACR
+  - bootstraps the backend Container App with a public image on first deploy so the system-assigned identity exists before the private-image revision is applied
+  - grants the backend Container App identity `AcrPull` on ACR and `Key Vault Secrets User` on the vault
+  - renders a YAML manifest for the final backend revision with:
+    - external ingress
+    - port `8000`
+    - HTTP `/health` startup/liveness/readiness probes
+    - Key Vault-backed secret refs for `DATABASE_URL`, `AZURE_STORAGE_CONNECTION_STRING`, and `AZURE_SERVICE_BUS_CONNECTION_STRING`
+  - verifies the deployed backend using the ACA FQDN and accepts either `200 {"status":"ok"}` or `503 {"status":"degraded"}` from `/health`
+- Updated [REFERENCE.md](/Users/karthicks/kAgents/Projects/PFCD-V2/REFERENCE.md):
+  - CI/CD section now documents the backend ACA deploy path and the new required GitHub variables
+  - Azure infrastructure table now lists `pfcd-[env]-api` as the active backend Container App while keeping the App Service entry marked as legacy during cutover
+
+### Decisions
+
+- Used a two-step ACA deploy shape (`public bootstrap image` -> `role assignment` -> `private ACR image revision`) because system-assigned managed identities do not exist until the Container App resource is created.
+- Kept runtime secrets Azure-native by referencing Key Vault from the Container App manifest instead of moving `DATABASE_URL`, storage, and Service Bus connection strings into GitHub secrets.
+- Preserved the existing backend app name secret (`AZURE_WEBAPP_NAME`) to keep the migration narrow even though the active resource is now a Container App rather than an App Service Web App.
+
+### Open follow-up
+
+- Worker migration (`#21`) is still required before the platform is fully on Azure Container Apps.
+- `infra/dev-bootstrap.sh` still provisions the legacy App Service plan / web apps by default; that drift should be cleaned up after the ACA backend and worker paths are both stable.
+
+---

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2115,3 +2115,37 @@ Executed the first Container Apps migration slice for the backend API by replaci
 - `infra/dev-bootstrap.sh` still provisions the legacy App Service plan / web apps by default; that drift should be cleaned up after the ACA backend and worker paths are both stable.
 
 ---
+
+## Section 63: Codex Delivery — GitHub Issue #21 Workers to Azure Container Apps + KEDA (2026-04-19)
+
+Executed the worker migration slice by replacing the App Service package deployment workflow and warmup shim with a Container Apps + Service Bus scaling path.
+
+### Completed
+
+- Rewrote [.github/workflows/deploy-workers.yml](/Users/karthicks/kAgents/Projects/PFCD-V2/.github/workflows/deploy-workers.yml) from App Service zip deploy to Azure Container Apps:
+  - keeps the existing unit/integration + PostgreSQL smoke test gate
+  - builds `backend/Dockerfile --target worker`
+  - pushes `pfcd-worker:${GITHUB_SHA}` to ACR
+  - deploys `extracting`, `processing`, and `reviewing` workers through a matrix job
+  - bootstraps each worker Container App with a public image on first deploy so the system-assigned identity exists before the final private-image revision is applied
+  - grants each worker identity `AcrPull`, `Key Vault Secrets User`, and `Azure Service Bus Data Owner`
+  - renders a YAML manifest for the final worker revision with:
+    - ingress disabled
+    - `PFCD_WORKER_ROLE` pinned per worker app
+    - Key Vault-backed secret refs for `DATABASE_URL`, `AZURE_STORAGE_CONNECTION_STRING`, and `AZURE_SERVICE_BUS_CONNECTION_STRING`
+    - an `azure-servicebus` custom scale rule using `identity: system`
+- Removed the App Service-only HTTP warmup shim from [backend/app/workers/runner.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/workers/runner.py), including its HTTP server and threading imports.
+- Updated [REFERENCE.md](/Users/karthicks/kAgents/Projects/PFCD-V2/REFERENCE.md) so the repo layout, Azure infrastructure, CI/CD notes, and GitHub Actions variable table now describe the worker ACA/KEDA deployment path rather than the old `WEBSITE_RUN_FROM_PACKAGE` flow.
+
+### Decisions
+
+- Kept worker runtime Service Bus access on the existing `AZURE_SERVICE_BUS_CONNECTION_STRING` path to avoid coupling infrastructure migration with a runtime auth rewrite.
+- Used managed identity specifically for the Container Apps Service Bus scaler so queue-depth scaling no longer depends on a scaler-side connection string.
+- Left active queue-processing verification to the live Azure deploy path; the repo change establishes the CI/CD and manifest shape, but production validation still needs a real deployment run.
+
+### Open follow-up
+
+- Confirm the worker ACA YAML is accepted by Azure exactly as written and that each Service Bus queue scales its matching worker from zero.
+- Complete PostgreSQL cutover cleanup (`#27` Part B) now that backend and worker Container App workflows exist in repo.
+
+---

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -229,12 +229,16 @@ All Azure resources are in resource group `app-pfcd-v2`.
 | Resource | Name Pattern |
 |----------|--------------|
 | Storage Account | `pfcd[env]storage` (containers: uploads, evidence, exports, scratch) |
+| Azure Container Registry | `pfcd[env]registry` (login server `pfcd[env]registry.azurecr.io`, admin user disabled) |
 | Service Bus | `pfcd-[env]-bus` (queues: extracting, processing, reviewing) |
-| SQL Server | `pfcd-[env]-sql` |
-| SQL Database | `pfcd-[env]-jobs` |
+| Log Analytics Workspace | `pfcd-[env]-logs` (shared diagnostics for Container Apps) |
+| Container Apps Environment | `pfcd-[env]-env` (shared environment for API + workers) |
+| Container App API | `pfcd-[env]-api` (external ingress, `/health` probe on port 8000) |
+| PostgreSQL Flexible Server | `pfcd-[env]-pg` |
+| PostgreSQL Database | `pfcd-[env]-jobs` |
 | Key Vault | `pfcd-[env]-kv` |
-| App Service Plan | `pfcd-[env]-asp` (Linux) |
-| Web App | `pfcd-[env]-api` (Python 3.11) |
+| App Service Plan | `pfcd-[env]-asp` (legacy backend App Service during ACA cutover / rollback window) |
+| Web App | `pfcd-[env]-api` (legacy backend App Service during ACA cutover / rollback window) |
 | Azure OpenAI | `pfcd-[env]-oai` (model: gpt-4o-mini) |
 | Azure Speech | `pfcd-[env]-speech` |
 
@@ -246,6 +250,8 @@ SPEECH_ACCOUNT_LOCATION=eastus bash infra/dev-bootstrap.sh
 
 The script is idempotent — safe to re-run.
 
+Pass `SP_CLIENT_ID=<github-actions-service-principal-client-id>` when you want the bootstrap script to grant the CI principal both `Storage Blob Data Contributor` on the storage account and `AcrPush` on the registry during provisioning.
+
 **Authentication:** All Azure SDK clients use `DefaultAzureCredential` (supports Managed Identity, CLI login, and environment variables). Secrets are stored in Key Vault and injected at runtime.
 
 ---
@@ -255,9 +261,14 @@ The script is idempotent — safe to re-run.
 **File:** `.github/workflows/deploy-backend.yml`
 
 - Triggers on push to `main` with changes under `backend/**`
-- Deploys via `az webapp deploy` (zip upload)
-- Required secrets: `AZURE_CREDENTIALS`, `AZURE_RESOURCE_GROUP`, `AZURE_WEBAPP_NAME`
-- No automated tests run in CI yet — add pytest step when integration tests exist
+- Runs the SQLite-backed unit/integration suite plus a PostgreSQL smoke path before deploy
+- Builds `backend/Dockerfile --target api`, pushes `pfcd-backend-api:${GITHUB_SHA}` to ACR, and deploys the backend as an Azure Container App revision
+- Bootstraps the backend Container App with a public image on first deploy so the system-assigned identity exists before assigning `AcrPull` and `Key Vault Secrets User`
+- Applies the final backend runtime as a YAML-based Container App update with:
+  - external ingress on port 8000
+  - HTTP `/health` startup/liveness/readiness probes
+  - Key Vault-backed secret refs for `DATABASE_URL`, `AZURE_STORAGE_CONNECTION_STRING`, and `AZURE_SERVICE_BUS_CONNECTION_STRING`
+- Required secrets / vars: `AZURE_CREDENTIALS`, `AZURE_RESOURCE_GROUP`, `AZURE_WEBAPP_NAME`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_CHAT_DEPLOYMENT_NAME` (or deprecated alias), `AZURE_CONTAINER_REGISTRY`, `AZURE_CONTAINER_APPS_ENVIRONMENT`, `AZURE_STORAGE_ACCOUNT`, `AZURE_KEY_VAULT_NAME`, `AZURE_SERVICE_BUS_NAMESPACE`, `AZURE_OPENAI_ACCOUNT_NAME`, `AZURE_SPEECH_ACCOUNT_NAME`
 
 **File:** `.github/workflows/deploy-workers.yml`
 
@@ -270,7 +281,13 @@ The script is idempotent — safe to re-run.
 
 | Variable | Used by | Purpose |
 |----------|---------|---------|
-| `AZURE_STORAGE_ACCOUNT` | `deploy-workers.yml` | Storage account resource name used to upload `worker.zip` to `scratch` and generate the `WEBSITE_RUN_FROM_PACKAGE` SAS URL |
+| `AZURE_STORAGE_ACCOUNT` | `deploy-backend.yml`, `deploy-workers.yml` | Storage account resource name surfaced to the runtime, e.g. `pfcddevstorage` |
+| `AZURE_CONTAINER_REGISTRY` | `deploy-backend.yml`, upcoming Container Apps worker workflows | ACR login server for image push/pull, e.g. `pfcddevregistry.azurecr.io` |
+| `AZURE_CONTAINER_APPS_ENVIRONMENT` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Shared ACA environment name, e.g. `pfcd-dev-env` |
+| `AZURE_KEY_VAULT_NAME` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Key Vault name used for ACA secret refs, e.g. `pfcd-dev-kv` |
+| `AZURE_SERVICE_BUS_NAMESPACE` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Service Bus namespace name surfaced to the runtime, e.g. `pfcd-dev-bus` |
+| `AZURE_OPENAI_ACCOUNT_NAME` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Azure OpenAI account name used by `/health` diagnostics |
+| `AZURE_SPEECH_ACCOUNT_NAME` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Azure Speech account name used by `/health` diagnostics |
 
 ---
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -92,7 +92,7 @@ PDCD-V2/
 | ORM | SQLAlchemy | 2.0.38 |
 | DB migrations | Alembic | 1.13.3 |
 | DB (local) | SQLite | built-in |
-| DB (prod) | Azure SQL Server | via pyodbc 5.2.0 |
+| DB (prod) | Azure Database for PostgreSQL Flexible Server | via psycopg 3.2.6 |
 | Async support | anyio | 4.9.0 |
 | Message queue | Azure Service Bus | 7.12.1 |
 | Blob storage | Azure Blob Storage | 12.25.0 |
@@ -123,7 +123,7 @@ uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `DATABASE_URL` | SQLAlchemy connection string | `sqlite:///./pfcd.db` |
+| `DATABASE_URL` | SQLAlchemy connection string | local default `sqlite:///./pfcd.db`; PostgreSQL example `postgresql+psycopg://pfcd_user:password@127.0.0.1:5432/pfcd` |
 | `AZURE_STORAGE_CONNECTION_STRING` | Blob storage | local fallback if unset |
 | `AZURE_STORAGE_CONTAINER_EVIDENCE` | Blob container for frame captures/evidence assets | `evidence` |
 | `AZURE_SERVICE_BUS_CONNECTION_STRING` | Service Bus namespace | `""` (skips queue dispatch) |

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -71,7 +71,7 @@ PDCD-V2/
 │   └── workflows/
 │       ├── deploy-backend.yml
 │       ├── deploy-frontend.yml
-│       └── deploy-workers.yml  # parallel worker App Service deployments
+│       └── deploy-workers.yml  # worker Container Apps + queue-scaling deployments
 ├── prd.md
 ├── AGENTS.md
 ├── GEMINI.md
@@ -273,21 +273,27 @@ Pass `SP_CLIENT_ID=<github-actions-service-principal-client-id>` when you want t
 **File:** `.github/workflows/deploy-workers.yml`
 
 - Triggers on push to `main` with changes under `backend/**`
-- Builds one worker zip, uploads it to the storage account `scratch` container, writes a SAS-backed package URL artifact, then deploys in parallel to `pfcd-dev-worker-extracting`, `pfcd-dev-worker-processing`, `pfcd-dev-worker-reviewing` via `WEBSITE_RUN_FROM_PACKAGE`
-- Required secrets: `AZURE_CREDENTIALS`, `AZURE_RESOURCE_GROUP`, `AZURE_WORKER_EXTRACTING_NAME`, `AZURE_WORKER_PROCESSING_NAME`, `AZURE_WORKER_REVIEWING_NAME`
-- Required GitHub Actions variable: `AZURE_STORAGE_ACCOUNT`
+- Runs the SQLite-backed unit/integration suite plus a PostgreSQL smoke path before deploy
+- Builds `backend/Dockerfile --target worker`, pushes `pfcd-worker:${GITHUB_SHA}` to ACR, and deploys the three worker roles through a matrix job
+- Bootstraps each worker Container App with a public image on first deploy so the system-assigned identity exists before assigning `AcrPull`, `Key Vault Secrets User`, and `Azure Service Bus Data Owner`
+- Applies the final worker runtime as a YAML-based Container App update with:
+  - ingress disabled
+  - `PFCD_WORKER_ROLE` pinned per app (`extracting`, `processing`, `reviewing`)
+  - Key Vault-backed secret refs for `DATABASE_URL`, `AZURE_STORAGE_CONNECTION_STRING`, and `AZURE_SERVICE_BUS_CONNECTION_STRING`
+  - an `azure-servicebus` custom scale rule using `identity: system`, `messageCount: 1`, and the matching queue name
+- Required secrets / vars: `AZURE_CREDENTIALS`, `AZURE_RESOURCE_GROUP`, `AZURE_WORKER_EXTRACTING_NAME`, `AZURE_WORKER_PROCESSING_NAME`, `AZURE_WORKER_REVIEWING_NAME`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_CHAT_DEPLOYMENT_NAME` (or deprecated alias), `AZURE_CONTAINER_REGISTRY`, `AZURE_CONTAINER_APPS_ENVIRONMENT`, `AZURE_STORAGE_ACCOUNT`, `AZURE_KEY_VAULT_NAME`, `AZURE_SERVICE_BUS_NAMESPACE`, `AZURE_OPENAI_ACCOUNT_NAME`, `AZURE_SPEECH_ACCOUNT_NAME`
 
 ### GitHub Variables
 
 | Variable | Used by | Purpose |
 |----------|---------|---------|
 | `AZURE_STORAGE_ACCOUNT` | `deploy-backend.yml`, `deploy-workers.yml` | Storage account resource name surfaced to the runtime, e.g. `pfcddevstorage` |
-| `AZURE_CONTAINER_REGISTRY` | `deploy-backend.yml`, upcoming Container Apps worker workflows | ACR login server for image push/pull, e.g. `pfcddevregistry.azurecr.io` |
-| `AZURE_CONTAINER_APPS_ENVIRONMENT` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Shared ACA environment name, e.g. `pfcd-dev-env` |
-| `AZURE_KEY_VAULT_NAME` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Key Vault name used for ACA secret refs, e.g. `pfcd-dev-kv` |
-| `AZURE_SERVICE_BUS_NAMESPACE` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Service Bus namespace name surfaced to the runtime, e.g. `pfcd-dev-bus` |
-| `AZURE_OPENAI_ACCOUNT_NAME` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Azure OpenAI account name used by `/health` diagnostics |
-| `AZURE_SPEECH_ACCOUNT_NAME` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Azure Speech account name used by `/health` diagnostics |
+| `AZURE_CONTAINER_REGISTRY` | `deploy-backend.yml`, `deploy-workers.yml` | ACR login server for image push/pull, e.g. `pfcddevregistry.azurecr.io` |
+| `AZURE_CONTAINER_APPS_ENVIRONMENT` | `deploy-backend.yml`, `deploy-workers.yml` | Shared ACA environment name, e.g. `pfcd-dev-env` |
+| `AZURE_KEY_VAULT_NAME` | `deploy-backend.yml`, `deploy-workers.yml` | Key Vault name used for ACA secret refs, e.g. `pfcd-dev-kv` |
+| `AZURE_SERVICE_BUS_NAMESPACE` | `deploy-backend.yml`, `deploy-workers.yml` | Service Bus namespace name surfaced to the runtime and KEDA scaler, e.g. `pfcd-dev-bus` |
+| `AZURE_OPENAI_ACCOUNT_NAME` | `deploy-backend.yml`, `deploy-workers.yml` | Azure OpenAI account name used by `/health` diagnostics and runtime env parity |
+| `AZURE_SPEECH_ACCOUNT_NAME` | `deploy-backend.yml`, `deploy-workers.yml` | Azure Speech account name used by `/health` diagnostics and runtime env parity |
 
 ---
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1.7
+
+FROM python:3.11-slim-bookworm AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    VIRTUAL_ENV=/opt/venv \
+    PATH="/opt/venv/bin:${PATH}"
+
+WORKDIR /app
+
+RUN python -m venv "${VIRTUAL_ENV}"
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+
+RUN pip install --upgrade pip \
+ && pip install -r requirements.txt
+
+
+FROM python:3.11-slim-bookworm AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    VIRTUAL_ENV=/opt/venv \
+    PATH="/opt/venv/bin:${PATH}" \
+    PYTHONPATH=/app
+
+WORKDIR /app
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    ffmpeg \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/venv /opt/venv
+
+COPY app ./app
+COPY alembic ./alembic
+COPY alembic.ini ./alembic.ini
+COPY README.md ./README.md
+
+
+FROM runtime AS api
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=5 \
+  CMD curl -fsS http://127.0.0.1:8000/health || exit 1
+
+CMD ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+
+FROM runtime AS worker
+
+ENV PFCD_WORKER_ROLE=extracting
+
+CMD ["python", "-m", "app.workers.runner"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -71,8 +71,8 @@ alembic upgrade head
 Required/optional environment variables:
 
 - `DATABASE_URL` (optional, default: `sqlite:///./pfcd.db`)
-- Azure SQL example (ODBC 18):
-  - `mssql+pyodbc://<user>:<password>@<server>:1433/<database>?driver=ODBC+Driver+18+for+SQL+Server`
+- PostgreSQL example:
+  - `postgresql+psycopg://<user>:<password>@<server>:5432/<database>?sslmode=require`
 - `AZURE_STORAGE_CONNECTION_STRING` (optional, enables Blob exports)
 - `AZURE_STORAGE_CONTAINER_EXPORTS` (optional, default: `exports`)
 - `EXPORTS_BASE_PATH` (optional, default: `./storage/exports` for local exports)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -96,6 +96,7 @@ async def _job_or_404(job_id: str) -> Dict[str, Any]:
 @app.get("/health")
 def health() -> Dict[str, Any]:
     required_env = [
+        "DATABASE_URL",
         "AZURE_STORAGE_ACCOUNT_NAME",
         "AZURE_SERVICE_BUS_NAMESPACE",
         "AZURE_SERVICE_BUS_CONNECTION_STRING",
@@ -103,8 +104,6 @@ def health() -> Dict[str, Any]:
         "AZURE_SERVICE_BUS_QUEUE_PROCESSING",
         "AZURE_SERVICE_BUS_QUEUE_REVIEWING",
         "KEYVAULT_NAME",
-        "AZURE_SQL_SERVER_NAME",
-        "AZURE_SQL_DATABASE_NAME",
         "AZURE_OPENAI_ACCOUNT_NAME",
         "AZURE_SPEECH_ACCOUNT_NAME",
     ]

--- a/backend/app/workers/runner.py
+++ b/backend/app/workers/runner.py
@@ -6,9 +6,7 @@ import json
 import logging
 import os
 import random
-import threading
 import time
-from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any, Dict
 from uuid import uuid4
 
@@ -264,28 +262,6 @@ def _resolve_phase() -> str:
     return "extracting"
 
 
-def _start_health_server(port: int = 8000) -> None:
-    """Start a minimal HTTP server so Azure App Service warmup probe succeeds.
-
-    Azure App Service kills containers that don't respond to HTTP within 230s.
-    Workers are Service Bus consumers with no HTTP server, so we run a tiny
-    background health server on port 8000 alongside the worker loop.
-    """
-    class _Handler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:  # noqa: N802
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(b"ok")
-
-        def log_message(self, *args: object) -> None:  # suppress access logs
-            pass
-
-    server = HTTPServer(("0.0.0.0", port), _Handler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    logging.getLogger(__name__).info("Health server listening on port %d", port)
-
-
 def _connection_backoff_seconds(consecutive_errors: int) -> float:
     """Return bounded exponential backoff with small jitter for reconnect attempts."""
     exponent = min(max(1, consecutive_errors), 6)
@@ -295,7 +271,6 @@ def _connection_backoff_seconds(consecutive_errors: int) -> float:
 
 def run() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
-    _start_health_server()
     phase = _resolve_phase()
     logger.info(
         "Worker runtime OpenAI config: role=%s endpoint=%s chat_deployment=%s api_version=%s",

--- a/backend/docker-compose.smoke.yml
+++ b/backend/docker-compose.smoke.yml
@@ -1,0 +1,37 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: api
+    image: pfcd-backend-api:smoke
+    environment:
+      DATABASE_URL: sqlite:///./pfcd.db
+      AZURE_STORAGE_ACCOUNT_NAME: smoke-storage
+      AZURE_SERVICE_BUS_NAMESPACE: smoke-servicebus
+      AZURE_SERVICE_BUS_CONNECTION_STRING: Endpoint=sb://smoke.local/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=not-a-real-key
+      AZURE_SERVICE_BUS_QUEUE_EXTRACTING: extracting
+      AZURE_SERVICE_BUS_QUEUE_PROCESSING: processing
+      AZURE_SERVICE_BUS_QUEUE_REVIEWING: reviewing
+      KEYVAULT_NAME: smoke-kv
+      AZURE_OPENAI_ACCOUNT_NAME: smoke-openai
+      AZURE_SPEECH_ACCOUNT_NAME: smoke-speech
+    ports:
+      - "${PFCD_SMOKE_API_PORT:-8000}:8000"
+
+  worker-extracting:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: worker
+    image: pfcd-worker-extracting:smoke
+    environment:
+      PFCD_WORKER_ROLE: extracting
+      DATABASE_URL: sqlite:///./pfcd.db
+      AZURE_SERVICE_BUS_CONNECTION_STRING: Endpoint=sb://smoke.local/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=not-a-real-key
+      AZURE_SERVICE_BUS_QUEUE_EXTRACTING: extracting
+      AZURE_SERVICE_BUS_QUEUE_PROCESSING: processing
+      AZURE_SERVICE_BUS_QUEUE_REVIEWING: reviewing
+      AZURE_OPENAI_ENDPOINT: https://smoke-openai.openai.azure.com/
+      AZURE_OPENAI_CHAT_DEPLOYMENT_NAME: smoke-chat
+      AZURE_OPENAI_API_VERSION: "2024-10-21"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,7 +8,7 @@ SQLAlchemy==2.0.38
 alembic==1.13.3
 azure-storage-blob==12.25.0
 azure-servicebus==7.12.1
-pyodbc==5.2.0
+psycopg[binary]==3.2.6
 anyio==4.9.0
 azure-identity==1.19.0
 fpdf2==2.8.1

--- a/docker-compose.local.env.example
+++ b/docker-compose.local.env.example
@@ -1,0 +1,72 @@
+# Copy this file to a local, ignored env file name such as:
+#   cp docker-compose.local.env.example .env.docker.local
+# Then run:
+#   docker compose --env-file .env.docker.local -f docker-compose.local.yml up --build -d
+#
+# This is the file you edit for local Docker runs.
+# Do not look in Azure Key Vault for these local values.
+#
+# See docs/ISSUE-26-USER-DEPENDENCIES.md for a workflow-based explanation of
+# which values are placeholders versus which ones are operationally required.
+
+# Host ports
+PFCD_LOCAL_API_PORT=8000
+PFCD_LOCAL_FRONTEND_PORT=3000
+
+# Frontend build args.
+# Leave VITE_API_BASE empty in the integrated stack so the browser uses same-origin /api.
+VITE_API_BASE=
+
+# Frontend -> backend auth header.
+# Leave empty if PFCD_API_KEY is not enabled in the backend container below.
+VITE_API_KEY=
+
+# Local backend runtime overrides used by docker-compose.local.yml.
+# Keep this as a harmless placeholder unless you want provider_effective
+# to reflect a real Azure deployment name in local Docker.
+AZURE_OPENAI_CHAT_DEPLOYMENT_NAME=local-docker-smoke
+PFCD_PROVIDER=azure_openai
+PFCD_API_KEY=
+
+# Optional backend local-path overrides.
+DATABASE_URL=sqlite:///./storage/pfcd.db
+EXPORTS_BASE_PATH=/app/storage/exports
+PFCD_CORS_ORIGINS=http://127.0.0.1:3000,http://localhost:3000
+UPLOADS_DIR=/app/storage/uploads
+PFCD_MAX_RETRIES=3
+PFCD_CONSISTENCY_MATCH_THRESHOLD=0.80
+PFCD_CONSISTENCY_INCONCLUSIVE_THRESHOLD=0.50
+PFCD_CONSISTENCY_MISMATCH_THRESHOLD=0.30
+PFCD_VISION_FRAMES_PER_CALL=4
+PFCD_VISION_MAX_FRAMES=40
+
+# Provider-specific overrides used when you want more than a startup smoke test.
+AZURE_OPENAI_ENDPOINT=
+AZURE_OPENAI_API_VERSION=2024-10-21
+AZURE_OPENAI_WHISPER_DEPLOYMENT=whisper
+AZURE_OPENAI_VISION_DEPLOYMENT=
+AZURE_OPENAI_DEPLOYMENT_NAME=
+AZURE_OPENAI_DEPLOYMENT=
+AZURE_OPENAI_DEPLOYMENT_BALANCED=
+AZURE_OPENAI_DEPLOYMENT_QUALITY=
+OPENAI_API_KEY=
+OPENAI_CHAT_MODEL_BALANCED=gpt-4o-mini
+OPENAI_CHAT_MODEL_QUALITY=gpt-4o
+OPENAI_TRANSCRIPTION_MODEL=whisper-1
+OPENAI_VISION_MODEL=gpt-4o-mini
+
+# Optional: set these only if you want backend /health to stop reporting
+# status=degraded in the integrated local Docker stack.
+AZURE_STORAGE_CONNECTION_STRING=
+AZURE_STORAGE_ACCOUNT_URL=
+AZURE_STORAGE_ACCOUNT_NAME=
+AZURE_STORAGE_CONTAINER_EVIDENCE=evidence
+AZURE_STORAGE_CONTAINER_EXPORTS=exports
+AZURE_SERVICE_BUS_NAMESPACE=
+AZURE_SERVICE_BUS_CONNECTION_STRING=
+AZURE_SERVICE_BUS_QUEUE_EXTRACTING=extracting
+AZURE_SERVICE_BUS_QUEUE_PROCESSING=processing
+AZURE_SERVICE_BUS_QUEUE_REVIEWING=reviewing
+KEYVAULT_NAME=
+AZURE_OPENAI_ACCOUNT_NAME=
+AZURE_SPEECH_ACCOUNT_NAME=

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,92 @@
+services:
+  api:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      target: api
+    image: pfcd-backend-api:local
+    environment:
+      PFCD_API_KEY: ${PFCD_API_KEY:-}
+      PFCD_PROVIDER: ${PFCD_PROVIDER:-azure_openai}
+      AZURE_OPENAI_CHAT_DEPLOYMENT_NAME: ${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME:-local-docker-smoke}
+      AZURE_OPENAI_ENDPOINT: ${AZURE_OPENAI_ENDPOINT:-}
+      AZURE_OPENAI_API_VERSION: ${AZURE_OPENAI_API_VERSION:-2024-10-21}
+      AZURE_OPENAI_WHISPER_DEPLOYMENT: ${AZURE_OPENAI_WHISPER_DEPLOYMENT:-whisper}
+      AZURE_OPENAI_VISION_DEPLOYMENT: ${AZURE_OPENAI_VISION_DEPLOYMENT:-}
+      AZURE_OPENAI_DEPLOYMENT_NAME: ${AZURE_OPENAI_DEPLOYMENT_NAME:-}
+      AZURE_OPENAI_DEPLOYMENT: ${AZURE_OPENAI_DEPLOYMENT:-}
+      AZURE_OPENAI_DEPLOYMENT_BALANCED: ${AZURE_OPENAI_DEPLOYMENT_BALANCED:-}
+      AZURE_OPENAI_DEPLOYMENT_QUALITY: ${AZURE_OPENAI_DEPLOYMENT_QUALITY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_CHAT_MODEL_BALANCED: ${OPENAI_CHAT_MODEL_BALANCED:-gpt-4o-mini}
+      OPENAI_CHAT_MODEL_QUALITY: ${OPENAI_CHAT_MODEL_QUALITY:-gpt-4o}
+      OPENAI_TRANSCRIPTION_MODEL: ${OPENAI_TRANSCRIPTION_MODEL:-whisper-1}
+      OPENAI_VISION_MODEL: ${OPENAI_VISION_MODEL:-gpt-4o-mini}
+      DATABASE_URL: ${DATABASE_URL:-sqlite:///./storage/pfcd.db}
+      EXPORTS_BASE_PATH: ${EXPORTS_BASE_PATH:-/app/storage/exports}
+      PFCD_CORS_ORIGINS: ${PFCD_CORS_ORIGINS:-http://127.0.0.1:3000,http://localhost:3000}
+      UPLOADS_DIR: ${UPLOADS_DIR:-/app/storage/uploads}
+      PFCD_MAX_RETRIES: ${PFCD_MAX_RETRIES:-3}
+      PFCD_CONSISTENCY_MATCH_THRESHOLD: ${PFCD_CONSISTENCY_MATCH_THRESHOLD:-0.80}
+      PFCD_CONSISTENCY_INCONCLUSIVE_THRESHOLD: ${PFCD_CONSISTENCY_INCONCLUSIVE_THRESHOLD:-0.50}
+      PFCD_CONSISTENCY_MISMATCH_THRESHOLD: ${PFCD_CONSISTENCY_MISMATCH_THRESHOLD:-0.30}
+      PFCD_VISION_FRAMES_PER_CALL: ${PFCD_VISION_FRAMES_PER_CALL:-4}
+      PFCD_VISION_MAX_FRAMES: ${PFCD_VISION_MAX_FRAMES:-40}
+      AZURE_STORAGE_CONNECTION_STRING: ${AZURE_STORAGE_CONNECTION_STRING:-}
+      AZURE_STORAGE_ACCOUNT_URL: ${AZURE_STORAGE_ACCOUNT_URL:-}
+      AZURE_STORAGE_ACCOUNT_NAME: ${AZURE_STORAGE_ACCOUNT_NAME:-}
+      AZURE_STORAGE_CONTAINER_EVIDENCE: ${AZURE_STORAGE_CONTAINER_EVIDENCE:-evidence}
+      AZURE_STORAGE_CONTAINER_EXPORTS: ${AZURE_STORAGE_CONTAINER_EXPORTS:-exports}
+      AZURE_SERVICE_BUS_NAMESPACE: ${AZURE_SERVICE_BUS_NAMESPACE:-}
+      AZURE_SERVICE_BUS_CONNECTION_STRING: ${AZURE_SERVICE_BUS_CONNECTION_STRING:-}
+      AZURE_SERVICE_BUS_QUEUE_EXTRACTING: ${AZURE_SERVICE_BUS_QUEUE_EXTRACTING:-extracting}
+      AZURE_SERVICE_BUS_QUEUE_PROCESSING: ${AZURE_SERVICE_BUS_QUEUE_PROCESSING:-processing}
+      AZURE_SERVICE_BUS_QUEUE_REVIEWING: ${AZURE_SERVICE_BUS_QUEUE_REVIEWING:-reviewing}
+      KEYVAULT_NAME: ${KEYVAULT_NAME:-}
+      AZURE_OPENAI_ACCOUNT_NAME: ${AZURE_OPENAI_ACCOUNT_NAME:-}
+      AZURE_SPEECH_ACCOUNT_NAME: ${AZURE_SPEECH_ACCOUNT_NAME:-}
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - |
+          import json
+          import sys
+          import urllib.error
+          import urllib.request
+
+          request = urllib.request.Request("http://127.0.0.1:8000/health")
+          try:
+              with urllib.request.urlopen(request) as response:
+                  payload = json.load(response)
+          except urllib.error.HTTPError as exc:
+              if exc.code not in {200, 503}:
+                  raise
+              payload = json.load(exc)
+          sys.exit(0 if payload.get("status") in {"ok", "degraded"} else 1)
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 20s
+    ports:
+      - "${PFCD_LOCAL_API_PORT:-8000}:8000"
+    volumes:
+      - pfcd-local-storage:/app/storage
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_API_BASE: ${VITE_API_BASE:-}
+        VITE_API_KEY: ${VITE_API_KEY:-}
+    image: pfcd-frontend:local
+    depends_on:
+      api:
+        condition: service_healthy
+    ports:
+      - "${PFCD_LOCAL_FRONTEND_PORT:-3000}:80"
+
+volumes:
+  pfcd-local-storage:

--- a/infra/README.md
+++ b/infra/README.md
@@ -7,7 +7,7 @@ This folder contains an executable script to create a **development** Azure envi
 - Storage account + containers (`uploads`, `evidence`, `exports`, `scratch`)
 - Service Bus namespace + phase queues (`extracting`, `processing`, `reviewing`)
 - Key Vault + secret entries
-- Azure SQL Server + SQL Database
+- Azure Database for PostgreSQL Flexible Server + database
 - App Service Plan + Linux Web App (`PYTHON:3.11`)
 - Azure OpenAI + Speech accounts
 - Cost budget hook (best effort; may require manual portal step depending on CLI/API)
@@ -27,8 +27,7 @@ SPEECH_ACCOUNT_LOCATION=eastus bash infra/dev-bootstrap.sh
 - If the deployment step fails, export a supported model version string for your region and rerun with:
   `OPENAI_MODEL_NAME=<name> OPENAI_MODEL_VERSION=<version> bash infra/dev-bootstrap.sh`
 - Key Vault is created with RBAC enabled; access is granted via `Key Vault Secrets Officer` role assignment to the signed-in user.
-- SQL server firewall rule `AllowAzureServices` is applied to allow Azure-hosted services to connect in dev.
-- SQL connection string includes `Encrypt=yes&TrustServerCertificate=yes` for ODBC Driver 18 compatibility.
+- PostgreSQL flexible server is created with public access for Azure-hosted services and a PostgreSQL `DATABASE_URL` that uses `sslmode=require`.
 - Budget creation is intentionally non-blocking in the script to account for command API differences.
 
 ## Verification
@@ -44,7 +43,7 @@ SPEECH_ACCOUNT_LOCATION=eastus bash infra/dev-bootstrap.sh
 - No App Service publish-profile secrets are required for backend or worker deploys on this path.
 
 Key Vault-backed settings created by the script:
-- `DATABASE_URL` -> secret `sql-connection-string`
+- `DATABASE_URL` -> secret `postgres-connection-string`
 - `AZURE_STORAGE_CONNECTION_STRING` -> secret `storage-connection-string`
 - `AZURE_SERVICE_BUS_CONNECTION_STRING` -> secret `service-bus-connection-string`
 
@@ -63,4 +62,4 @@ az webapp restart --name pfcd-dev-api --resource-group app-pfcd-v2
 - `OPENAI_SKU_NAME`, `SERVICE_BUS_SKU`
 - `SERVICE_BUS_QUEUE_EXTRACTING`, `SERVICE_BUS_QUEUE_PROCESSING`, `SERVICE_BUS_QUEUE_REVIEWING`
 - `SP_CLIENT_ID` (optional; grants the CI service principal blob-write access on the storage account)
-- `MONTHLY_BUDGET`, `BUDGET_NAME`, `SQL_ADMIN_USER`, `SQL_ADMIN_PASSWORD`
+- `MONTHLY_BUDGET`, `BUDGET_NAME`, `POSTGRES_ADMIN_USER`, `POSTGRES_ADMIN_PASSWORD`

--- a/infra/dev-bootstrap.sh
+++ b/infra/dev-bootstrap.sh
@@ -22,8 +22,8 @@ SERVICE_BUS_QUEUE_EXTRACTING="${SERVICE_BUS_QUEUE_EXTRACTING:-extracting}"
 SERVICE_BUS_QUEUE_PROCESSING="${SERVICE_BUS_QUEUE_PROCESSING:-processing}"
 SERVICE_BUS_QUEUE_REVIEWING="${SERVICE_BUS_QUEUE_REVIEWING:-reviewing}"
 SERVICE_BUS_SKU="${SERVICE_BUS_SKU:-Standard}"
-SQL_SERVER_NAME="${SQL_SERVER_NAME:-${PROJECT}-${ENVIRONMENT}-sql}"
-SQL_DATABASE_NAME="${SQL_DATABASE_NAME:-${PROJECT}-${ENVIRONMENT}-jobs}"
+POSTGRES_SERVER_NAME="${POSTGRES_SERVER_NAME:-${PROJECT}-${ENVIRONMENT}-pg}"
+POSTGRES_DATABASE_NAME="${POSTGRES_DATABASE_NAME:-${PROJECT}-${ENVIRONMENT}-jobs}"
 KEY_VAULT_NAME="${KEY_VAULT_NAME:-${PROJECT}-${ENVIRONMENT}-kv}"
 OPENAI_ACCOUNT_NAME="${OPENAI_ACCOUNT_NAME:-${PROJECT}-${ENVIRONMENT}-oai}"
 SPEECH_ACCOUNT_NAME="${SPEECH_ACCOUNT_NAME:-${PROJECT}-${ENVIRONMENT}-speech}"
@@ -35,8 +35,12 @@ OPENAI_MODEL_VERSION="${OPENAI_MODEL_VERSION:-2024-07-18}"
 OPENAI_SKU_CAPACITY="${OPENAI_SKU_CAPACITY:-1}"
 OPENAI_SKU_NAME="${OPENAI_SKU_NAME:-GlobalStandard}"
 
-SQL_ADMIN_USER="${SQL_ADMIN_USER:-pfcd_admin}"
-SQL_ADMIN_PASSWORD="${SQL_ADMIN_PASSWORD:-$(openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 24)}"
+POSTGRES_VERSION="${POSTGRES_VERSION:-16}"
+POSTGRES_SKU_NAME="${POSTGRES_SKU_NAME:-Standard_B1ms}"
+POSTGRES_TIER="${POSTGRES_TIER:-Burstable}"
+POSTGRES_STORAGE_SIZE="${POSTGRES_STORAGE_SIZE:-32}"
+POSTGRES_ADMIN_USER="${POSTGRES_ADMIN_USER:-pfcdadmin}"
+POSTGRES_ADMIN_PASSWORD="${POSTGRES_ADMIN_PASSWORD:-$(openssl rand -base64 30 | tr -dc 'A-Za-z0-9' | head -c 24)}"
 
 readonly COMMON_TAGS="Environment=$ENVIRONMENT Project=$PROJECT CostProfile=development"
 
@@ -199,43 +203,49 @@ ensure_key_vault() {
   fi
 }
 
-ensure_sql() {
-  if ! az sql server show --name "$SQL_SERVER_NAME" --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
-    az sql server create \
-      --name "$SQL_SERVER_NAME" \
+ensure_postgres() {
+  if ! az postgres flexible-server show --name "$POSTGRES_SERVER_NAME" --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+    az postgres flexible-server create \
+      --name "$POSTGRES_SERVER_NAME" \
       --resource-group "$RESOURCE_GROUP" \
       --location "$LOCATION" \
-      --admin-user "$SQL_ADMIN_USER" \
-      --admin-password "$SQL_ADMIN_PASSWORD" \
-      --enable-public-network true \
-      --minimal-tls-version "1.2" \
+      --admin-user "$POSTGRES_ADMIN_USER" \
+      --admin-password "$POSTGRES_ADMIN_PASSWORD" \
+      --sku-name "$POSTGRES_SKU_NAME" \
+      --tier "$POSTGRES_TIER" \
+      --storage-size "$POSTGRES_STORAGE_SIZE" \
+      --version "$POSTGRES_VERSION" \
+      --public-access 0.0.0.0 \
+      --database-name "$POSTGRES_DATABASE_NAME" \
       --output none
   fi
 
-  az sql server update \
-    --name "$SQL_SERVER_NAME" \
+  az postgres flexible-server update \
+    --name "$POSTGRES_SERVER_NAME" \
     --resource-group "$RESOURCE_GROUP" \
-    --admin-password "$SQL_ADMIN_PASSWORD" \
+    --admin-password "$POSTGRES_ADMIN_PASSWORD" \
     --output none \
     || true
 
-  if ! az sql db show --name "$SQL_DATABASE_NAME" --server "$SQL_SERVER_NAME" --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
-    az sql db create \
-      --name "$SQL_DATABASE_NAME" \
+  if ! az postgres flexible-server db show \
       --resource-group "$RESOURCE_GROUP" \
-      --server "$SQL_SERVER_NAME" \
-      --edition Basic \
+      --server-name "$POSTGRES_SERVER_NAME" \
+      --database-name "$POSTGRES_DATABASE_NAME" >/dev/null 2>&1; then
+    az postgres flexible-server db create \
+      --resource-group "$RESOURCE_GROUP" \
+      --server-name "$POSTGRES_SERVER_NAME" \
+      --database-name "$POSTGRES_DATABASE_NAME" \
       --output none
   fi
 
-  az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "sql-admin-user" --value "$SQL_ADMIN_USER" --output none
-  az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "sql-admin-password" --value "$SQL_ADMIN_PASSWORD" --output none
+  az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "postgres-admin-user" --value "$POSTGRES_ADMIN_USER" --output none
+  az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "postgres-admin-password" --value "$POSTGRES_ADMIN_PASSWORD" --output none
 
-  local sql_conn
-  sql_conn="mssql+pyodbc://${SQL_ADMIN_USER}:${SQL_ADMIN_PASSWORD}@${SQL_SERVER_NAME}.database.windows.net:1433/${SQL_DATABASE_NAME}?driver=ODBC+Driver+18+for+SQL+Server&Encrypt=yes&TrustServerCertificate=yes"
-  az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "sql-connection-string" --value "$sql_conn" --output none
+  local postgres_conn
+  postgres_conn="postgresql+psycopg://${POSTGRES_ADMIN_USER}:${POSTGRES_ADMIN_PASSWORD}@${POSTGRES_SERVER_NAME}.postgres.database.azure.com:5432/${POSTGRES_DATABASE_NAME}?sslmode=require"
+  az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "postgres-connection-string" --value "$postgres_conn" --output none
 
-  info "SQL admin password is stored in Key Vault as 'sql-admin-password'"
+  info "PostgreSQL admin password is stored in Key Vault as 'postgres-admin-password'"
 }
 
 ensure_app_service() {
@@ -283,8 +293,8 @@ ensure_app_service() {
       AZURE_SERVICE_BUS_QUEUE_PROCESSING="$SERVICE_BUS_QUEUE_PROCESSING" \
       AZURE_SERVICE_BUS_QUEUE_REVIEWING="$SERVICE_BUS_QUEUE_REVIEWING" \
       KEYVAULT_NAME="$KEY_VAULT_NAME" \
-      AZURE_SQL_SERVER_NAME="$SQL_SERVER_NAME" \
-      AZURE_SQL_DATABASE_NAME="$SQL_DATABASE_NAME" \
+      AZURE_POSTGRES_SERVER_NAME="$POSTGRES_SERVER_NAME" \
+      AZURE_POSTGRES_DATABASE_NAME="$POSTGRES_DATABASE_NAME" \
       AZURE_OPENAI_ACCOUNT_NAME="$OPENAI_ACCOUNT_NAME" \
       AZURE_SPEECH_ACCOUNT_NAME="$SPEECH_ACCOUNT_NAME" \
       AZURE_OPENAI_CHAT_DEPLOYMENT_NAME="$OPENAI_DEPLOYMENT_NAME" \
@@ -294,7 +304,7 @@ ensure_app_service() {
       AZURE_OPENAI_MODEL_VERSION="$OPENAI_MODEL_VERSION" \
       AZURE_OPENAI_SKU_NAME="$OPENAI_SKU_NAME" \
       APP_COST_PROFILE=development \
-      DATABASE_URL="@Microsoft.KeyVault(SecretUri=https://${KEY_VAULT_NAME}.vault.azure.net/secrets/sql-connection-string)" \
+      DATABASE_URL="@Microsoft.KeyVault(SecretUri=https://${KEY_VAULT_NAME}.vault.azure.net/secrets/postgres-connection-string)" \
       AZURE_STORAGE_CONNECTION_STRING="@Microsoft.KeyVault(SecretUri=https://${KEY_VAULT_NAME}.vault.azure.net/secrets/storage-connection-string)" \
       AZURE_SERVICE_BUS_CONNECTION_STRING="@Microsoft.KeyVault(SecretUri=https://${KEY_VAULT_NAME}.vault.azure.net/secrets/service-bus-connection-string)" \
       AZURE_STORAGE_CONTAINER_EXPORTS="exports" \
@@ -355,8 +365,8 @@ ensure_app_service() {
         AZURE_SERVICE_BUS_QUEUE_PROCESSING="$SERVICE_BUS_QUEUE_PROCESSING" \
         AZURE_SERVICE_BUS_QUEUE_REVIEWING="$SERVICE_BUS_QUEUE_REVIEWING" \
         KEYVAULT_NAME="$KEY_VAULT_NAME" \
-        AZURE_SQL_SERVER_NAME="$SQL_SERVER_NAME" \
-        AZURE_SQL_DATABASE_NAME="$SQL_DATABASE_NAME" \
+        AZURE_POSTGRES_SERVER_NAME="$POSTGRES_SERVER_NAME" \
+        AZURE_POSTGRES_DATABASE_NAME="$POSTGRES_DATABASE_NAME" \
         AZURE_OPENAI_ACCOUNT_NAME="$OPENAI_ACCOUNT_NAME" \
         AZURE_SPEECH_ACCOUNT_NAME="$SPEECH_ACCOUNT_NAME" \
         AZURE_OPENAI_ENDPOINT="https://${OPENAI_ACCOUNT_NAME}.openai.azure.com/" \
@@ -369,7 +379,7 @@ ensure_app_service() {
         APP_COST_PROFILE=development \
         WEBSITES_CONTAINER_START_TIME_LIMIT=600 \
         WEBSITES_PORT=8000 \
-        DATABASE_URL="@Microsoft.KeyVault(SecretUri=https://${KEY_VAULT_NAME}.vault.azure.net/secrets/sql-connection-string)" \
+        DATABASE_URL="@Microsoft.KeyVault(SecretUri=https://${KEY_VAULT_NAME}.vault.azure.net/secrets/postgres-connection-string)" \
         AZURE_STORAGE_CONNECTION_STRING="@Microsoft.KeyVault(SecretUri=https://${KEY_VAULT_NAME}.vault.azure.net/secrets/storage-connection-string)" \
         AZURE_SERVICE_BUS_CONNECTION_STRING="@Microsoft.KeyVault(SecretUri=https://${KEY_VAULT_NAME}.vault.azure.net/secrets/service-bus-connection-string)" \
         AZURE_STORAGE_CONTAINER_EXPORTS="exports" \
@@ -461,7 +471,7 @@ ensure_rg
 ensure_storage_account
 ensure_servicebus
 ensure_key_vault
-ensure_sql
+ensure_postgres
 ensure_app_service
 ensure_cognitive_services
 ensure_budget

--- a/tests/integration/test_postgres_smoke.py
+++ b/tests/integration/test_postgres_smoke.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import importlib
+import os
+import pathlib
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+BACKEND = ROOT / "backend"
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+
+def _postgres_smoke_url() -> str:
+    database_url = os.environ.get("PFCD_POSTGRES_SMOKE_DATABASE_URL")
+    if not database_url:
+        pytest.skip("PFCD_POSTGRES_SMOKE_DATABASE_URL is not configured")
+    return database_url
+
+
+def _reset_public_schema(database_url: str) -> None:
+    engine = create_engine(database_url, future=True, isolation_level="AUTOCOMMIT")
+    with engine.connect() as connection:
+        connection.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
+        connection.execute(text("CREATE SCHEMA public"))
+    engine.dispose()
+
+
+def _upgrade_with_alembic(database_url: str) -> None:
+    config = Config(str(BACKEND / "alembic.ini"))
+    config.set_main_option("script_location", str(BACKEND / "alembic"))
+    config.set_main_option("sqlalchemy.url", database_url)
+    command.upgrade(config, "head")
+
+
+def _build_client(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, database_url: str):
+    exports_path = tmp_path / "exports"
+    exports_path.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("EXPORTS_BASE_PATH", str(exports_path))
+    monkeypatch.setenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME", "test-deployment")
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-10-21")
+    monkeypatch.delenv("AZURE_SERVICE_BUS_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("AZURE_STORAGE_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("PFCD_API_KEY", raising=False)
+
+    import app.db as db_mod
+    import app.repository as repo_mod
+    import app.main as main_mod
+
+    importlib.reload(db_mod)
+    importlib.reload(repo_mod)
+    importlib.reload(main_mod)
+
+    main_mod.ORCHESTRATOR = MagicMock()
+
+    from starlette.testclient import TestClient
+
+    return TestClient(main_mod.app, raise_server_exceptions=False)
+
+
+@pytest.mark.integration
+@pytest.mark.postgres
+def test_postgres_alembic_and_api_lifecycle_smoke(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    database_url = _postgres_smoke_url()
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _reset_public_schema(database_url)
+    _upgrade_with_alembic(database_url)
+
+    client = _build_client(monkeypatch, tmp_path, database_url)
+
+    create_response = client.post(
+        "/api/jobs",
+        json={
+            "input_files": [
+                {"source_type": "transcript", "file_name": "smoke.vtt", "size_bytes": 1024}
+            ]
+        },
+    )
+    assert create_response.status_code == 201, create_response.text
+    job_id = create_response.json()["job_id"]
+
+    simulate_response = client.post(f"/dev/jobs/{job_id}/simulate")
+    assert simulate_response.status_code == 200, simulate_response.text
+
+    save_response = client.put(
+        f"/api/jobs/{job_id}/draft",
+        json={"assumptions": ["Validated against PostgreSQL smoke DB"]},
+    )
+    assert save_response.status_code == 200, save_response.text
+
+    finalize_response = client.post(f"/api/jobs/{job_id}/finalize")
+    assert finalize_response.status_code == 200, finalize_response.text
+
+    export_response = client.get(f"/api/jobs/{job_id}/exports/markdown")
+    assert export_response.status_code == 200, export_response.text
+    assert "# Process Definition Document" in export_response.text

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -269,7 +269,6 @@ def test_run_recreates_receiver_after_servicebus_error(monkeypatch):
     from app.workers import runner as runner_mod
 
     monkeypatch.setenv("PFCD_WORKER_ROLE", "processing")
-    monkeypatch.setattr(runner_mod, "_start_health_server", lambda: None)
     monkeypatch.setattr(runner_mod.logging, "basicConfig", lambda **_: None)
     monkeypatch.setattr(runner_mod, "_connection_backoff_seconds", lambda _: 0.0)
     monkeypatch.setattr(runner_mod.time, "sleep", lambda _: None)


### PR DESCRIPTION
Closes #27

## Summary
- remove remaining SQL Server / pyodbc references from the repo's active runtime and infra files
- switch the bootstrap script from Azure SQL connection-string output to PostgreSQL Flexible Server output
- update health/config expectations to use `DATABASE_URL` and PostgreSQL naming instead of `AZURE_SQL_*`
- add the local Docker compose files referenced by the issue with PostgreSQL-safe defaults and no legacy SQL env vars
- update active reference docs so `DATABASE_URL` examples now use PostgreSQL DSNs

## Scope note
- This PR covers **Issue #27 Part A only**.
- It does **not** perform deployed-resource cutover (`#27` Part B).

## Validation
- `bash -n infra/dev-bootstrap.sh`
- `rg -n "AZURE_SQL_SERVER_NAME|AZURE_SQL_DATABASE_NAME" --glob '*.yml' --glob '*.yaml' .`
- `rg -n "pyodbc|mssql|unixodbc|sql-connection-string" --glob '*.py' --glob '*.yml' --glob '*.yaml' --glob '*.sh' --glob '*.txt' --glob '!docs/**' --glob '!backend/.venv/**' --glob '!HANDOVER.md' --glob '!IMPLEMENTATION_SUMMARY.md' .`
- `docker compose -f docker-compose.local.yml config`
- `git diff --check`
