### PR TITLE
feat: deploy workers as container apps

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -4,13 +4,17 @@ on:
   push:
     branches: [main]
     paths:
-      - 'backend/**'
-      - '.github/workflows/deploy-workers.yml'
+      - "backend/**"
+      - ".github/workflows/deploy-workers.yml"
   workflow_dispatch:
 
 concurrency:
   group: deploy-workers-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
 
 env:
   AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED: ${{ secrets.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME != '' && secrets.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME || secrets.AZURE_OPENAI_DEPLOYMENT_NAME }}
@@ -18,15 +22,26 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: pfcd_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d pfcd_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-
-      - name: Install ODBC system libraries
-        run: sudo apt-get install -y unixodbc-dev
 
       - name: Install dependencies
         run: pip install -r backend/requirements.txt
@@ -37,349 +52,314 @@ jobs:
           DATABASE_URL: "sqlite:///./test-ci.db"
           PYTHONPATH: backend
 
+      - name: Run PostgreSQL smoke test
+        run: pytest tests/integration/test_postgres_smoke.py -x --tb=short
+        env:
+          PFCD_POSTGRES_SMOKE_DATABASE_URL: "postgresql+psycopg://postgres:postgres@127.0.0.1:5432/pfcd_test"
+          PYTHONPATH: backend
+
   build:
+    needs: test
     runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.image.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install ODBC system libraries
-        run: sudo apt-get install -y unixodbc-dev
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Build zip
-        run: |
-          PY_MINOR=$(python3 --version | cut -d' ' -f2 | cut -d'.' -f1-2)
-          pip install \
-            --quiet \
-            --target "backend/antenv/lib/python${PY_MINOR}/site-packages" \
-            -r backend/requirements.txt
-
-          cd backend && zip -r ../worker.zip . \
-            -x "venv/*" -x ".venv/*" -x "env/*" \
-            -x "*.pyc" -x "__pycache__/*" \
-            -x ".pytest_cache/*" -x ".coverage" \
-            -x "*.db" -x "*.sqlite3" \
-            -x ".env" -x ".env.*" \
-            -x "storage/*"
-          rm -rf antenv
       - uses: azure/login@v2
         with:
-          creds: '${{ secrets.AZURE_CREDENTIALS }}'
-      - name: Validate package upload settings
+          creds: "${{ secrets.AZURE_CREDENTIALS }}"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Validate worker image settings
         run: |
-          if [ -z "${{ vars.AZURE_STORAGE_ACCOUNT }}" ]; then
-            echo "ERROR: Set AZURE_STORAGE_ACCOUNT as a GitHub Actions variable."
+          if [ -z "${{ vars.AZURE_CONTAINER_REGISTRY }}" ]; then
+            echo "ERROR: Set AZURE_CONTAINER_REGISTRY as a GitHub Actions variable."
             exit 1
           fi
-      - name: Upload worker zip to scratch blob and write package URL
-        run: |
-          account="${{ vars.AZURE_STORAGE_ACCOUNT }}"
-          blob_name="worker-${{ github.sha }}.zip"
-          az storage blob upload \
-            --account-name "$account" \
-            --container-name scratch \
-            --name "$blob_name" \
-            --file worker.zip \
-            --auth-mode login \
-            --overwrite true
-          expiry=$(date -u -d "+4 hours" +%Y-%m-%dT%H:%MZ 2>/dev/null || date -u -v+4H +%Y-%m-%dT%H:%MZ)
-          sas=$(az storage blob generate-sas \
-            --account-name "$account" \
-            --container-name scratch \
-            --name "$blob_name" \
-            --permissions r \
-            --expiry "$expiry" \
-            --auth-mode login \
-            --as-user \
-            -o tsv)
-          printf '%s\n' "https://${account}.blob.core.windows.net/scratch/${blob_name}?${sas}" > package-url.txt
-      - uses: actions/upload-artifact@v4
-        with:
-          name: package-url
-          path: package-url.txt
-      - uses: actions/upload-artifact@v4
-        with:
-          name: worker-zip
-          path: worker.zip
 
-  deploy-extracting:
-    needs: [test, build]
+      - name: Enable ACR ARM authentication
+        run: |
+          registry_name="${{ vars.AZURE_CONTAINER_REGISTRY }}"
+          registry_name="${registry_name%%.*}"
+          az acr config authentication-as-arm update -n "${registry_name}" --status enabled
+
+      - name: Log in to ACR
+        run: |
+          registry_name="${{ vars.AZURE_CONTAINER_REGISTRY }}"
+          registry_name="${registry_name%%.*}"
+          az acr login --name "${registry_name}"
+
+      - name: Set worker image tag
+        id: image
+        run: |
+          registry_name="${{ vars.AZURE_CONTAINER_REGISTRY }}"
+          registry_name="${registry_name%%.*}"
+          registry_server=$(az acr show --name "${registry_name}" --query loginServer -o tsv)
+          image_tag="${registry_server}/pfcd-worker:${{ github.sha }}"
+          echo "tag=${image_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push worker image
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            --target worker \
+            --tag "${{ steps.image.outputs.tag }}" \
+            --push \
+            ./backend
+
+  deploy:
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        role: [extracting, processing, reviewing]
+    env:
+      WORKER_EXTRACTING_NAME: ${{ secrets.AZURE_WORKER_EXTRACTING_NAME }}
+      WORKER_PROCESSING_NAME: ${{ secrets.AZURE_WORKER_PROCESSING_NAME }}
+      WORKER_REVIEWING_NAME: ${{ secrets.AZURE_WORKER_REVIEWING_NAME }}
+      WORKER_IMAGE: ${{ needs.build.outputs.image_tag }}
     steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: worker-zip
-      - uses: actions/download-artifact@v4
-        with:
-          name: package-url
-      - name: Read package URL
-        run: echo "PACKAGE_URL=$(cat package-url.txt)" >> $GITHUB_ENV
       - uses: azure/login@v2
         with:
-          creds: '${{ secrets.AZURE_CREDENTIALS }}'
-      - name: Validate worker deployment settings
-        run: |
-          if [ -z "${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" ]; then
-            echo "ERROR: Set AZURE_OPENAI_CHAT_DEPLOYMENT_NAME (preferred) or AZURE_OPENAI_DEPLOYMENT_NAME in GitHub secrets."
-            exit 1
-          fi
-          if [ -z "${{ secrets.AZURE_WORKER_EXTRACTING_NAME }}" ]; then
-            echo "ERROR: Set AZURE_WORKER_EXTRACTING_NAME in GitHub secrets."
-            exit 1
-          fi
-          if [ -z "${PACKAGE_URL}" ]; then
-            echo "ERROR: package-url artifact did not produce a package URL."
-            exit 1
-          fi
-      - name: Deploy extracting worker (WEBSITE_RUN_FROM_PACKAGE)
-        run: |
-          az webapp config appsettings set \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_EXTRACTING_NAME }} \
-            --settings PFCD_WORKER_ROLE=extracting \
-              AZURE_OPENAI_ENDPOINT="${{ secrets.AZURE_OPENAI_ENDPOINT }}" \
-              AZURE_OPENAI_CHAT_DEPLOYMENT_NAME="${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" \
-              SCM_DO_BUILD_DURING_DEPLOYMENT=false \
-              PYTHONPATH=/home/site/wwwroot/antenv/lib/python3.11/site-packages \
-              WEBSITES_CONTAINER_START_TIME_LIMIT=600 \
-              WEBSITES_PORT=8000 \
-              WEBSITE_RUN_FROM_PACKAGE="$PACKAGE_URL"
-          az webapp restart \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_EXTRACTING_NAME }}
-      - name: Wait for extracting worker package restart to settle
-        run: |
-          sleep 15
-          for i in $(seq 1 30); do
-            state=$(az webapp show \
-              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --name ${{ secrets.AZURE_WORKER_EXTRACTING_NAME }} \
-              --query "state" -o tsv)
-            echo "extracting config settle $i/30: $state"
-            if [ "$state" = "Running" ]; then
-              sleep 60
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "ERROR: extracting worker did not return to Running after package deployment"
-          exit 1
-      - name: Verify extracting worker is running
-        run: |
-          for i in $(seq 1 90); do
-            state=$(az webapp show \
-              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --name ${{ secrets.AZURE_WORKER_EXTRACTING_NAME }} \
-              --query "state" -o tsv)
-            echo "extracting state check $i/90: $state"
-            if [ "$state" = "Running" ]; then
-              echo "Extracting worker is Running"
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "ERROR: extracting worker did not reach Running state within 15 minutes"
-          exit 1
-      - name: Verify extracting worker HTTP readiness
-        run: |
-          url="https://${{ secrets.AZURE_WORKER_EXTRACTING_NAME }}.azurewebsites.net/"
-          for i in $(seq 1 60); do
-            if curl -fsS --max-time 10 "$url" >/dev/null; then
-              echo "Extracting worker HTTP probe passed on attempt $i"
-              exit 0
-            fi
-            echo "Extracting worker HTTP probe not ready yet (attempt $i/60); waiting 10s..."
-            sleep 10
-          done
-          echo "ERROR: extracting worker HTTP probe did not pass within 10 minutes"
-          exit 1
+          creds: "${{ secrets.AZURE_CREDENTIALS }}"
 
-  deploy-processing:
-    needs: [test, build]
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: worker-zip
-      - uses: actions/download-artifact@v4
-        with:
-          name: package-url
-      - name: Read package URL
-        run: echo "PACKAGE_URL=$(cat package-url.txt)" >> $GITHUB_ENV
-      - uses: azure/login@v2
-        with:
-          creds: '${{ secrets.AZURE_CREDENTIALS }}'
-      - name: Validate worker deployment settings
+      - name: Install Container Apps extension
         run: |
-          if [ -z "${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" ]; then
-            echo "ERROR: Set AZURE_OPENAI_CHAT_DEPLOYMENT_NAME (preferred) or AZURE_OPENAI_DEPLOYMENT_NAME in GitHub secrets."
-            exit 1
-          fi
-          if [ -z "${{ secrets.AZURE_WORKER_PROCESSING_NAME }}" ]; then
-            echo "ERROR: Set AZURE_WORKER_PROCESSING_NAME in GitHub secrets."
-            exit 1
-          fi
-          if [ -z "${PACKAGE_URL}" ]; then
-            echo "ERROR: package-url artifact did not produce a package URL."
-            exit 1
-          fi
-      - name: Deploy processing worker (WEBSITE_RUN_FROM_PACKAGE)
-        run: |
-          az webapp config appsettings set \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_PROCESSING_NAME }} \
-            --settings PFCD_WORKER_ROLE=processing \
-              AZURE_OPENAI_ENDPOINT="${{ secrets.AZURE_OPENAI_ENDPOINT }}" \
-              AZURE_OPENAI_CHAT_DEPLOYMENT_NAME="${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" \
-              SCM_DO_BUILD_DURING_DEPLOYMENT=false \
-              PYTHONPATH=/home/site/wwwroot/antenv/lib/python3.11/site-packages \
-              WEBSITES_CONTAINER_START_TIME_LIMIT=600 \
-              WEBSITES_PORT=8000 \
-              WEBSITE_RUN_FROM_PACKAGE="$PACKAGE_URL"
-          az webapp restart \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_PROCESSING_NAME }}
-      - name: Wait for processing worker package restart to settle
-        run: |
-          sleep 15
-          for i in $(seq 1 30); do
-            state=$(az webapp show \
-              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --name ${{ secrets.AZURE_WORKER_PROCESSING_NAME }} \
-              --query "state" -o tsv)
-            echo "processing config settle $i/30: $state"
-            if [ "$state" = "Running" ]; then
-              sleep 60
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "ERROR: processing worker did not return to Running after package deployment"
-          exit 1
-      - name: Verify processing worker is running
-        run: |
-          for i in $(seq 1 90); do
-            state=$(az webapp show \
-              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --name ${{ secrets.AZURE_WORKER_PROCESSING_NAME }} \
-              --query "state" -o tsv)
-            echo "processing state check $i/90: $state"
-            if [ "$state" = "Running" ]; then
-              echo "Processing worker is Running"
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "ERROR: processing worker did not reach Running state within 15 minutes"
-          exit 1
-      - name: Verify processing worker HTTP readiness
-        run: |
-          url="https://${{ secrets.AZURE_WORKER_PROCESSING_NAME }}.azurewebsites.net/"
-          for i in $(seq 1 60); do
-            if curl -fsS --max-time 10 "$url" >/dev/null; then
-              echo "Processing worker HTTP probe passed on attempt $i"
-              exit 0
-            fi
-            echo "Processing worker HTTP probe not ready yet (attempt $i/60); waiting 10s..."
-            sleep 10
-          done
-          echo "ERROR: processing worker HTTP probe did not pass within 10 minutes"
-          exit 1
+          az extension add --name containerapp --upgrade
+          az provider register --namespace Microsoft.App
+          az provider register --namespace Microsoft.OperationalInsights
 
-  deploy-reviewing:
-    needs: [test, build]
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: worker-zip
-      - uses: actions/download-artifact@v4
-        with:
-          name: package-url
-      - name: Read package URL
-        run: echo "PACKAGE_URL=$(cat package-url.txt)" >> $GITHUB_ENV
-      - uses: azure/login@v2
-        with:
-          creds: '${{ secrets.AZURE_CREDENTIALS }}'
+      - name: Resolve worker settings
+        run: |
+          case "${{ matrix.role }}" in
+            extracting)
+              app_name="${WORKER_EXTRACTING_NAME}"
+              ;;
+            processing)
+              app_name="${WORKER_PROCESSING_NAME}"
+              ;;
+            reviewing)
+              app_name="${WORKER_REVIEWING_NAME}"
+              ;;
+          esac
+
+          if [ -z "${app_name}" ]; then
+            echo "ERROR: Missing Azure worker app name secret for role '${{ matrix.role }}'."
+            exit 1
+          fi
+
+          echo "WORKER_APP_NAME=${app_name}" >> "$GITHUB_ENV"
+          echo "WORKER_QUEUE_NAME=${{ matrix.role }}" >> "$GITHUB_ENV"
+
       - name: Validate worker deployment settings
         run: |
-          if [ -z "${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" ]; then
-            echo "ERROR: Set AZURE_OPENAI_CHAT_DEPLOYMENT_NAME (preferred) or AZURE_OPENAI_DEPLOYMENT_NAME in GitHub secrets."
+          missing=""
+          [ -z "${{ secrets.AZURE_RESOURCE_GROUP }}" ] && missing="$missing AZURE_RESOURCE_GROUP"
+          [ -z "${{ vars.AZURE_CONTAINER_APPS_ENVIRONMENT }}" ] && missing="$missing AZURE_CONTAINER_APPS_ENVIRONMENT"
+          [ -z "${{ vars.AZURE_CONTAINER_REGISTRY }}" ] && missing="$missing AZURE_CONTAINER_REGISTRY"
+          [ -z "${{ vars.AZURE_STORAGE_ACCOUNT }}" ] && missing="$missing AZURE_STORAGE_ACCOUNT"
+          [ -z "${{ vars.AZURE_KEY_VAULT_NAME }}" ] && missing="$missing AZURE_KEY_VAULT_NAME"
+          [ -z "${{ vars.AZURE_SERVICE_BUS_NAMESPACE }}" ] && missing="$missing AZURE_SERVICE_BUS_NAMESPACE"
+          [ -z "${{ vars.AZURE_OPENAI_ACCOUNT_NAME }}" ] && missing="$missing AZURE_OPENAI_ACCOUNT_NAME"
+          [ -z "${{ vars.AZURE_SPEECH_ACCOUNT_NAME }}" ] && missing="$missing AZURE_SPEECH_ACCOUNT_NAME"
+          [ -z "${{ secrets.AZURE_OPENAI_ENDPOINT }}" ] && missing="$missing AZURE_OPENAI_ENDPOINT"
+          [ -z "${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" ] && missing="$missing AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"
+          if [ -n "$missing" ]; then
+            echo "ERROR: missing required secrets/vars:$missing"
             exit 1
           fi
-          if [ -z "${{ secrets.AZURE_WORKER_REVIEWING_NAME }}" ]; then
-            echo "ERROR: Set AZURE_WORKER_REVIEWING_NAME in GitHub secrets."
-            exit 1
-          fi
-          if [ -z "${PACKAGE_URL}" ]; then
-            echo "ERROR: package-url artifact did not produce a package URL."
-            exit 1
-          fi
-      - name: Deploy reviewing worker (WEBSITE_RUN_FROM_PACKAGE)
+
+      - name: Ensure worker container app exists
         run: |
-          az webapp config appsettings set \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_REVIEWING_NAME }} \
-            --settings PFCD_WORKER_ROLE=reviewing \
-              AZURE_OPENAI_ENDPOINT="${{ secrets.AZURE_OPENAI_ENDPOINT }}" \
-              AZURE_OPENAI_CHAT_DEPLOYMENT_NAME="${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}" \
-              SCM_DO_BUILD_DURING_DEPLOYMENT=false \
-              PYTHONPATH=/home/site/wwwroot/antenv/lib/python3.11/site-packages \
-              WEBSITES_CONTAINER_START_TIME_LIMIT=600 \
-              WEBSITES_PORT=8000 \
-              WEBSITE_RUN_FROM_PACKAGE="$PACKAGE_URL"
-          az webapp restart \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --name ${{ secrets.AZURE_WORKER_REVIEWING_NAME }}
-      - name: Wait for reviewing worker package restart to settle
+          if az containerapp show \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --name "${WORKER_APP_NAME}" >/dev/null 2>&1; then
+            echo "Worker container app already exists."
+            exit 0
+          fi
+
+          az containerapp create \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --environment "${{ vars.AZURE_CONTAINER_APPS_ENVIRONMENT }}" \
+            --name "${WORKER_APP_NAME}" \
+            --image "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest" \
+            --min-replicas 1 \
+            --max-replicas 1 \
+            --cpu 0.5 \
+            --memory 1.0Gi \
+            --revisions-mode single \
+            --system-assigned \
+            --output none
+
+      - name: Grant worker container app runtime roles
         run: |
-          sleep 15
+          registry_name="${{ vars.AZURE_CONTAINER_REGISTRY }}"
+          registry_name="${registry_name%%.*}"
+          principal_id="$(az containerapp show \
+            --name "${WORKER_APP_NAME}" \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --query identity.principalId -o tsv)"
+
+          if [ -z "${principal_id}" ] || [ "${principal_id}" = "null" ]; then
+            echo "ERROR: worker container app identity is not available."
+            exit 1
+          fi
+
+          acr_id="$(az acr show --name "${registry_name}" --query id -o tsv)"
+          kv_id="$(az keyvault show --name "${{ vars.AZURE_KEY_VAULT_NAME }}" --query id -o tsv)"
+          sb_id="$(az servicebus namespace show \
+            --name "${{ vars.AZURE_SERVICE_BUS_NAMESPACE }}" \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --query id -o tsv)"
+
+          az role assignment create \
+            --assignee-object-id "${principal_id}" \
+            --assignee-principal-type ServicePrincipal \
+            --role AcrPull \
+            --scope "${acr_id}" \
+            --output none || true
+
+          az role assignment create \
+            --assignee-object-id "${principal_id}" \
+            --assignee-principal-type ServicePrincipal \
+            --role "Key Vault Secrets User" \
+            --scope "${kv_id}" \
+            --output none || true
+
+          az role assignment create \
+            --assignee-object-id "${principal_id}" \
+            --assignee-principal-type ServicePrincipal \
+            --role "Azure Service Bus Data Owner" \
+            --scope "${sb_id}" \
+            --output none || true
+
+          sleep 30
+
+      - name: Render worker ACA manifest
+        env:
+          PFCD_API_KEY_VALUE: ${{ secrets.PFCD_API_KEY }}
+          AZURE_OPENAI_ENDPOINT_VALUE: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+        run: |
+          env_id="$(az containerapp env show \
+            --name "${{ vars.AZURE_CONTAINER_APPS_ENVIRONMENT }}" \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --query id -o tsv)"
+          location="$(az group show \
+            --name "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --query location -o tsv)"
+          registry_name="${{ vars.AZURE_CONTAINER_REGISTRY }}"
+          registry_name="${registry_name%%.*}"
+          registry_server="$(az acr show --name "${registry_name}" --query loginServer -o tsv)"
+
+          cat > worker-aca.yaml <<EOF
+          location: ${location}
+          name: ${WORKER_APP_NAME}
+          type: Microsoft.App/containerApps
+          identity:
+            type: SystemAssigned
+          properties:
+            environmentId: ${env_id}
+            configuration:
+              activeRevisionsMode: Single
+              registries:
+                - server: ${registry_server}
+                  identity: system
+              secrets:
+                - name: dburl
+                  keyVaultUrl: https://${{ vars.AZURE_KEY_VAULT_NAME }}.vault.azure.net/secrets/postgres-connection-string
+                  identity: system
+                - name: blobconn
+                  keyVaultUrl: https://${{ vars.AZURE_KEY_VAULT_NAME }}.vault.azure.net/secrets/storage-connection-string
+                  identity: system
+                - name: sbconn
+                  keyVaultUrl: https://${{ vars.AZURE_KEY_VAULT_NAME }}.vault.azure.net/secrets/service-bus-connection-string
+                  identity: system
+            template:
+              containers:
+                - name: worker
+                  image: ${WORKER_IMAGE}
+                  env:
+                    - name: PFCD_WORKER_ROLE
+                      value: "${WORKER_QUEUE_NAME}"
+                    - name: PFCD_API_KEY
+                      value: "${PFCD_API_KEY_VALUE}"
+                    - name: DATABASE_URL
+                      secretRef: dburl
+                    - name: AZURE_STORAGE_CONNECTION_STRING
+                      secretRef: blobconn
+                    - name: AZURE_SERVICE_BUS_CONNECTION_STRING
+                      secretRef: sbconn
+                    - name: AZURE_STORAGE_ACCOUNT_NAME
+                      value: "${{ vars.AZURE_STORAGE_ACCOUNT }}"
+                    - name: AZURE_STORAGE_CONTAINER_EVIDENCE
+                      value: "evidence"
+                    - name: AZURE_STORAGE_CONTAINER_EXPORTS
+                      value: "exports"
+                    - name: AZURE_SERVICE_BUS_NAMESPACE
+                      value: "${{ vars.AZURE_SERVICE_BUS_NAMESPACE }}"
+                    - name: AZURE_SERVICE_BUS_QUEUE_EXTRACTING
+                      value: "extracting"
+                    - name: AZURE_SERVICE_BUS_QUEUE_PROCESSING
+                      value: "processing"
+                    - name: AZURE_SERVICE_BUS_QUEUE_REVIEWING
+                      value: "reviewing"
+                    - name: KEYVAULT_NAME
+                      value: "${{ vars.AZURE_KEY_VAULT_NAME }}"
+                    - name: AZURE_OPENAI_ACCOUNT_NAME
+                      value: "${{ vars.AZURE_OPENAI_ACCOUNT_NAME }}"
+                    - name: AZURE_SPEECH_ACCOUNT_NAME
+                      value: "${{ vars.AZURE_SPEECH_ACCOUNT_NAME }}"
+                    - name: AZURE_OPENAI_ENDPOINT
+                      value: "${AZURE_OPENAI_ENDPOINT_VALUE}"
+                    - name: AZURE_OPENAI_CHAT_DEPLOYMENT_NAME
+                      value: "${AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED}"
+                    - name: AZURE_OPENAI_API_VERSION
+                      value: "2024-10-21"
+                  resources:
+                    cpu: 0.5
+                    memory: 1.0Gi
+              scale:
+                minReplicas: 0
+                maxReplicas: 3
+                rules:
+                  - name: ${WORKER_QUEUE_NAME}-queue
+                    custom:
+                      type: azure-servicebus
+                      metadata:
+                        queueName: ${WORKER_QUEUE_NAME}
+                        namespace: ${{ vars.AZURE_SERVICE_BUS_NAMESPACE }}
+                        messageCount: "1"
+                      identity: system
+          EOF
+
+      - name: Deploy worker container app
+        run: |
+          az containerapp update \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --name "${WORKER_APP_NAME}" \
+            --yaml worker-aca.yaml \
+            --output none
+
+      - name: Verify worker revision state
+        run: |
           for i in $(seq 1 30); do
-            state=$(az webapp show \
-              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --name ${{ secrets.AZURE_WORKER_REVIEWING_NAME }} \
-              --query "state" -o tsv)
-            echo "reviewing config settle $i/30: $state"
-            if [ "$state" = "Running" ]; then
-              sleep 60
+            provisioning_state="$(az containerapp show \
+              --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+              --name "${WORKER_APP_NAME}" \
+              --query properties.provisioningState -o tsv)"
+            latest_revision="$(az containerapp show \
+              --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+              --name "${WORKER_APP_NAME}" \
+              --query properties.latestRevisionName -o tsv)"
+            echo "${WORKER_APP_NAME} provisioning attempt ${i}/30: ${provisioning_state} (${latest_revision})"
+            if [ "${provisioning_state}" = "Succeeded" ]; then
               exit 0
             fi
             sleep 10
           done
-          echo "ERROR: reviewing worker did not return to Running after package deployment"
-          exit 1
-      - name: Verify reviewing worker is running
-        run: |
-          for i in $(seq 1 90); do
-            state=$(az webapp show \
-              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --name ${{ secrets.AZURE_WORKER_REVIEWING_NAME }} \
-              --query "state" -o tsv)
-            echo "reviewing state check $i/90: $state"
-            if [ "$state" = "Running" ]; then
-              echo "Reviewing worker is Running"
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "ERROR: reviewing worker did not reach Running state within 15 minutes"
-          exit 1
-      - name: Verify reviewing worker HTTP readiness
-        run: |
-          url="https://${{ secrets.AZURE_WORKER_REVIEWING_NAME }}.azurewebsites.net/"
-          for i in $(seq 1 60); do
-            if curl -fsS --max-time 10 "$url" >/dev/null; then
-              echo "Reviewing worker HTTP probe passed on attempt $i"
-              exit 0
-            fi
-            echo "Reviewing worker HTTP probe not ready yet (attempt $i/60); waiting 10s..."
-            sleep 10
-          done
-          echo "ERROR: reviewing worker HTTP probe did not pass within 10 minutes"
+          echo "ERROR: ${WORKER_APP_NAME} did not reach a succeeded provisioning state."
           exit 1

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2115,3 +2115,37 @@ Executed the first Container Apps migration slice for the backend API by replaci
 - `infra/dev-bootstrap.sh` still provisions the legacy App Service plan / web apps by default; that drift should be cleaned up after the ACA backend and worker paths are both stable.
 
 ---
+
+## Section 63: Codex Delivery — GitHub Issue #21 Workers to Azure Container Apps + KEDA (2026-04-19)
+
+Executed the worker migration slice by replacing the App Service package deployment workflow and warmup shim with a Container Apps + Service Bus scaling path.
+
+### Completed
+
+- Rewrote [.github/workflows/deploy-workers.yml](/Users/karthicks/kAgents/Projects/PFCD-V2/.github/workflows/deploy-workers.yml) from App Service zip deploy to Azure Container Apps:
+  - keeps the existing unit/integration + PostgreSQL smoke test gate
+  - builds `backend/Dockerfile --target worker`
+  - pushes `pfcd-worker:${GITHUB_SHA}` to ACR
+  - deploys `extracting`, `processing`, and `reviewing` workers through a matrix job
+  - bootstraps each worker Container App with a public image on first deploy so the system-assigned identity exists before the final private-image revision is applied
+  - grants each worker identity `AcrPull`, `Key Vault Secrets User`, and `Azure Service Bus Data Owner`
+  - renders a YAML manifest for the final worker revision with:
+    - ingress disabled
+    - `PFCD_WORKER_ROLE` pinned per worker app
+    - Key Vault-backed secret refs for `DATABASE_URL`, `AZURE_STORAGE_CONNECTION_STRING`, and `AZURE_SERVICE_BUS_CONNECTION_STRING`
+    - an `azure-servicebus` custom scale rule using `identity: system`
+- Removed the App Service-only HTTP warmup shim from [backend/app/workers/runner.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/workers/runner.py), including its HTTP server and threading imports.
+- Updated [REFERENCE.md](/Users/karthicks/kAgents/Projects/PFCD-V2/REFERENCE.md) so the repo layout, Azure infrastructure, CI/CD notes, and GitHub Actions variable table now describe the worker ACA/KEDA deployment path rather than the old `WEBSITE_RUN_FROM_PACKAGE` flow.
+
+### Decisions
+
+- Kept worker runtime Service Bus access on the existing `AZURE_SERVICE_BUS_CONNECTION_STRING` path to avoid coupling infrastructure migration with a runtime auth rewrite.
+- Used managed identity specifically for the Container Apps Service Bus scaler so queue-depth scaling no longer depends on a scaler-side connection string.
+- Left active queue-processing verification to the live Azure deploy path; the repo change establishes the CI/CD and manifest shape, but production validation still needs a real deployment run.
+
+### Open follow-up
+
+- Confirm the worker ACA YAML is accepted by Azure exactly as written and that each Service Bus queue scales its matching worker from zero.
+- Complete PostgreSQL cutover cleanup (`#27` Part B) now that backend and worker Container App workflows exist in repo.
+
+---

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -71,7 +71,7 @@ PDCD-V2/
 │   └── workflows/
 │       ├── deploy-backend.yml
 │       ├── deploy-frontend.yml
-│       └── deploy-workers.yml  # parallel worker App Service deployments
+│       └── deploy-workers.yml  # worker Container Apps + queue-scaling deployments
 ├── prd.md
 ├── AGENTS.md
 ├── GEMINI.md
@@ -273,21 +273,27 @@ Pass `SP_CLIENT_ID=<github-actions-service-principal-client-id>` when you want t
 **File:** `.github/workflows/deploy-workers.yml`
 
 - Triggers on push to `main` with changes under `backend/**`
-- Builds one worker zip, uploads it to the storage account `scratch` container, writes a SAS-backed package URL artifact, then deploys in parallel to `pfcd-dev-worker-extracting`, `pfcd-dev-worker-processing`, `pfcd-dev-worker-reviewing` via `WEBSITE_RUN_FROM_PACKAGE`
-- Required secrets: `AZURE_CREDENTIALS`, `AZURE_RESOURCE_GROUP`, `AZURE_WORKER_EXTRACTING_NAME`, `AZURE_WORKER_PROCESSING_NAME`, `AZURE_WORKER_REVIEWING_NAME`
-- Required GitHub Actions variable: `AZURE_STORAGE_ACCOUNT`
+- Runs the SQLite-backed unit/integration suite plus a PostgreSQL smoke path before deploy
+- Builds `backend/Dockerfile --target worker`, pushes `pfcd-worker:${GITHUB_SHA}` to ACR, and deploys the three worker roles through a matrix job
+- Bootstraps each worker Container App with a public image on first deploy so the system-assigned identity exists before assigning `AcrPull`, `Key Vault Secrets User`, and `Azure Service Bus Data Owner`
+- Applies the final worker runtime as a YAML-based Container App update with:
+  - ingress disabled
+  - `PFCD_WORKER_ROLE` pinned per app (`extracting`, `processing`, `reviewing`)
+  - Key Vault-backed secret refs for `DATABASE_URL`, `AZURE_STORAGE_CONNECTION_STRING`, and `AZURE_SERVICE_BUS_CONNECTION_STRING`
+  - an `azure-servicebus` custom scale rule using `identity: system`, `messageCount: 1`, and the matching queue name
+- Required secrets / vars: `AZURE_CREDENTIALS`, `AZURE_RESOURCE_GROUP`, `AZURE_WORKER_EXTRACTING_NAME`, `AZURE_WORKER_PROCESSING_NAME`, `AZURE_WORKER_REVIEWING_NAME`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_CHAT_DEPLOYMENT_NAME` (or deprecated alias), `AZURE_CONTAINER_REGISTRY`, `AZURE_CONTAINER_APPS_ENVIRONMENT`, `AZURE_STORAGE_ACCOUNT`, `AZURE_KEY_VAULT_NAME`, `AZURE_SERVICE_BUS_NAMESPACE`, `AZURE_OPENAI_ACCOUNT_NAME`, `AZURE_SPEECH_ACCOUNT_NAME`
 
 ### GitHub Variables
 
 | Variable | Used by | Purpose |
 |----------|---------|---------|
 | `AZURE_STORAGE_ACCOUNT` | `deploy-backend.yml`, `deploy-workers.yml` | Storage account resource name surfaced to the runtime, e.g. `pfcddevstorage` |
-| `AZURE_CONTAINER_REGISTRY` | `deploy-backend.yml`, upcoming Container Apps worker workflows | ACR login server for image push/pull, e.g. `pfcddevregistry.azurecr.io` |
-| `AZURE_CONTAINER_APPS_ENVIRONMENT` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Shared ACA environment name, e.g. `pfcd-dev-env` |
-| `AZURE_KEY_VAULT_NAME` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Key Vault name used for ACA secret refs, e.g. `pfcd-dev-kv` |
-| `AZURE_SERVICE_BUS_NAMESPACE` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Service Bus namespace name surfaced to the runtime, e.g. `pfcd-dev-bus` |
-| `AZURE_OPENAI_ACCOUNT_NAME` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Azure OpenAI account name used by `/health` diagnostics |
-| `AZURE_SPEECH_ACCOUNT_NAME` | `deploy-backend.yml`, upcoming Container Apps worker workflows | Azure Speech account name used by `/health` diagnostics |
+| `AZURE_CONTAINER_REGISTRY` | `deploy-backend.yml`, `deploy-workers.yml` | ACR login server for image push/pull, e.g. `pfcddevregistry.azurecr.io` |
+| `AZURE_CONTAINER_APPS_ENVIRONMENT` | `deploy-backend.yml`, `deploy-workers.yml` | Shared ACA environment name, e.g. `pfcd-dev-env` |
+| `AZURE_KEY_VAULT_NAME` | `deploy-backend.yml`, `deploy-workers.yml` | Key Vault name used for ACA secret refs, e.g. `pfcd-dev-kv` |
+| `AZURE_SERVICE_BUS_NAMESPACE` | `deploy-backend.yml`, `deploy-workers.yml` | Service Bus namespace name surfaced to the runtime and KEDA scaler, e.g. `pfcd-dev-bus` |
+| `AZURE_OPENAI_ACCOUNT_NAME` | `deploy-backend.yml`, `deploy-workers.yml` | Azure OpenAI account name used by `/health` diagnostics and runtime env parity |
+| `AZURE_SPEECH_ACCOUNT_NAME` | `deploy-backend.yml`, `deploy-workers.yml` | Azure Speech account name used by `/health` diagnostics and runtime env parity |
 
 ---
 

--- a/backend/app/workers/runner.py
+++ b/backend/app/workers/runner.py
@@ -6,9 +6,7 @@ import json
 import logging
 import os
 import random
-import threading
 import time
-from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any, Dict
 from uuid import uuid4
 
@@ -264,28 +262,6 @@ def _resolve_phase() -> str:
     return "extracting"
 
 
-def _start_health_server(port: int = 8000) -> None:
-    """Start a minimal HTTP server so Azure App Service warmup probe succeeds.
-
-    Azure App Service kills containers that don't respond to HTTP within 230s.
-    Workers are Service Bus consumers with no HTTP server, so we run a tiny
-    background health server on port 8000 alongside the worker loop.
-    """
-    class _Handler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:  # noqa: N802
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(b"ok")
-
-        def log_message(self, *args: object) -> None:  # suppress access logs
-            pass
-
-    server = HTTPServer(("0.0.0.0", port), _Handler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    logging.getLogger(__name__).info("Health server listening on port %d", port)
-
-
 def _connection_backoff_seconds(consecutive_errors: int) -> float:
     """Return bounded exponential backoff with small jitter for reconnect attempts."""
     exponent = min(max(1, consecutive_errors), 6)
@@ -295,7 +271,6 @@ def _connection_backoff_seconds(consecutive_errors: int) -> float:
 
 def run() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
-    _start_health_server()
     phase = _resolve_phase()
     logger.info(
         "Worker runtime OpenAI config: role=%s endpoint=%s chat_deployment=%s api_version=%s",

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -269,7 +269,6 @@ def test_run_recreates_receiver_after_servicebus_error(monkeypatch):
     from app.workers import runner as runner_mod
 
     monkeypatch.setenv("PFCD_WORKER_ROLE", "processing")
-    monkeypatch.setattr(runner_mod, "_start_health_server", lambda: None)
     monkeypatch.setattr(runner_mod.logging, "basicConfig", lambda **_: None)
     monkeypatch.setattr(runner_mod, "_connection_backoff_seconds", lambda _: 0.0)
     monkeypatch.setattr(runner_mod.time, "sleep", lambda _: None)


### PR DESCRIPTION
Closes #21

## Summary
- replace the worker App Service package workflow with an Azure Container Apps + KEDA deployment workflow
- remove the App Service-only worker warmup HTTP shim from `backend/app/workers/runner.py`
- update the worker unit test for the removed warmup shim
- update `REFERENCE.md` and append the Issue #21 delivery note to `IMPLEMENTATION_SUMMARY.md`

## Stack / dependency notes
- This PR is currently based on PR #32 so it inherits the shared container runtime and PostgreSQL smoke-test groundwork.
- Infra provisioning still depends on Issue #19 / PR #30.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-workers.yml")'`
- `cd backend && PYTHONPATH=<issue21 backend> <repo backend>/.venv/bin/pytest <issue21 tests>/unit/test_worker.py -v`
- `git diff --check`

## Follow-up
- Live GitHub Actions / Azure deployment evidence is still required before Issue #21 can be closed.
