### PR TITLE
[codex] Fix ACA deploy verification and legacy worker rollback regressions

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -63,6 +63,9 @@ jobs:
     env:
       AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED: ${{ secrets.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME != '' && secrets.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME || secrets.AZURE_OPENAI_DEPLOYMENT_NAME }}
       BACKEND_IMAGE_TAG: ${{ vars.AZURE_CONTAINER_REGISTRY }}/pfcd-backend-api:${{ github.sha }}
+      SERVICE_BUS_QUEUE_EXTRACTING: ${{ vars.AZURE_SERVICE_BUS_QUEUE_EXTRACTING != '' && vars.AZURE_SERVICE_BUS_QUEUE_EXTRACTING || 'extracting' }}
+      SERVICE_BUS_QUEUE_PROCESSING: ${{ vars.AZURE_SERVICE_BUS_QUEUE_PROCESSING != '' && vars.AZURE_SERVICE_BUS_QUEUE_PROCESSING || 'processing' }}
+      SERVICE_BUS_QUEUE_REVIEWING: ${{ vars.AZURE_SERVICE_BUS_QUEUE_REVIEWING != '' && vars.AZURE_SERVICE_BUS_QUEUE_REVIEWING || 'reviewing' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -234,11 +237,11 @@ jobs:
                     - name: AZURE_SERVICE_BUS_NAMESPACE
                       value: "${{ vars.AZURE_SERVICE_BUS_NAMESPACE }}"
                     - name: AZURE_SERVICE_BUS_QUEUE_EXTRACTING
-                      value: "extracting"
+                      value: "${SERVICE_BUS_QUEUE_EXTRACTING}"
                     - name: AZURE_SERVICE_BUS_QUEUE_PROCESSING
-                      value: "processing"
+                      value: "${SERVICE_BUS_QUEUE_PROCESSING}"
                     - name: AZURE_SERVICE_BUS_QUEUE_REVIEWING
-                      value: "reviewing"
+                      value: "${SERVICE_BUS_QUEUE_REVIEWING}"
                     - name: KEYVAULT_NAME
                       value: "${{ vars.AZURE_KEY_VAULT_NAME }}"
                     - name: AZURE_OPENAI_ACCOUNT_NAME
@@ -302,9 +305,18 @@ jobs:
 
             if [ -n "$fqdn" ] && [ "$fqdn" != "null" ]; then
               status_code="$(curl -sS -o health-response.json -w '%{http_code}' --max-time 10 "https://${fqdn}/health" || true)"
-              if [ "$status_code" = "200" ] || [ "$status_code" = "503" ]; then
+              if [ "$status_code" = "200" ]; then
                 cat health-response.json
-                exit 0
+                if grep -Eq '"status"[[:space:]]*:[[:space:]]*"ok"' health-response.json; then
+                  exit 0
+                fi
+                echo "ERROR: backend health endpoint returned 200 without an ok payload."
+                exit 1
+              fi
+              if [ "$status_code" = "503" ]; then
+                echo "ERROR: backend reported degraded health."
+                cat health-response.json
+                exit 1
               fi
             fi
 
@@ -312,5 +324,5 @@ jobs:
             sleep 10
           done
 
-          echo "ERROR: backend container app health endpoint did not respond with 200/503 within 10 minutes"
+          echo "ERROR: backend container app health endpoint did not report a healthy 200 response within 10 minutes"
           exit 1

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -290,7 +290,7 @@ jobs:
                   image: ${WORKER_IMAGE}
                   env:
                     - name: PFCD_WORKER_ROLE
-                      value: "${WORKER_QUEUE_NAME}"
+                      value: "${{ matrix.role }}"
                     - name: PFCD_API_KEY
                       value: "${PFCD_API_KEY_VALUE}"
                     - name: DATABASE_URL

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -18,6 +18,9 @@ permissions:
 
 env:
   AZURE_OPENAI_CHAT_DEPLOYMENT_NAME_RESOLVED: ${{ secrets.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME != '' && secrets.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME || secrets.AZURE_OPENAI_DEPLOYMENT_NAME }}
+  SERVICE_BUS_QUEUE_EXTRACTING: ${{ vars.AZURE_SERVICE_BUS_QUEUE_EXTRACTING != '' && vars.AZURE_SERVICE_BUS_QUEUE_EXTRACTING || 'extracting' }}
+  SERVICE_BUS_QUEUE_PROCESSING: ${{ vars.AZURE_SERVICE_BUS_QUEUE_PROCESSING != '' && vars.AZURE_SERVICE_BUS_QUEUE_PROCESSING || 'processing' }}
+  SERVICE_BUS_QUEUE_REVIEWING: ${{ vars.AZURE_SERVICE_BUS_QUEUE_REVIEWING != '' && vars.AZURE_SERVICE_BUS_QUEUE_REVIEWING || 'reviewing' }}
 
 jobs:
   test:
@@ -138,12 +141,15 @@ jobs:
           case "${{ matrix.role }}" in
             extracting)
               app_name="${WORKER_EXTRACTING_NAME}"
+              queue_name="${SERVICE_BUS_QUEUE_EXTRACTING}"
               ;;
             processing)
               app_name="${WORKER_PROCESSING_NAME}"
+              queue_name="${SERVICE_BUS_QUEUE_PROCESSING}"
               ;;
             reviewing)
               app_name="${WORKER_REVIEWING_NAME}"
+              queue_name="${SERVICE_BUS_QUEUE_REVIEWING}"
               ;;
           esac
 
@@ -153,7 +159,7 @@ jobs:
           fi
 
           echo "WORKER_APP_NAME=${app_name}" >> "$GITHUB_ENV"
-          echo "WORKER_QUEUE_NAME=${{ matrix.role }}" >> "$GITHUB_ENV"
+          echo "WORKER_QUEUE_NAME=${queue_name}" >> "$GITHUB_ENV"
 
       - name: Validate worker deployment settings
         run: |
@@ -302,11 +308,11 @@ jobs:
                     - name: AZURE_SERVICE_BUS_NAMESPACE
                       value: "${{ vars.AZURE_SERVICE_BUS_NAMESPACE }}"
                     - name: AZURE_SERVICE_BUS_QUEUE_EXTRACTING
-                      value: "extracting"
+                      value: "${SERVICE_BUS_QUEUE_EXTRACTING}"
                     - name: AZURE_SERVICE_BUS_QUEUE_PROCESSING
-                      value: "processing"
+                      value: "${SERVICE_BUS_QUEUE_PROCESSING}"
                     - name: AZURE_SERVICE_BUS_QUEUE_REVIEWING
-                      value: "reviewing"
+                      value: "${SERVICE_BUS_QUEUE_REVIEWING}"
                     - name: KEYVAULT_NAME
                       value: "${{ vars.AZURE_KEY_VAULT_NAME }}"
                     - name: AZURE_OPENAI_ACCOUNT_NAME
@@ -347,19 +353,95 @@ jobs:
       - name: Verify worker revision state
         run: |
           for i in $(seq 1 30); do
-            provisioning_state="$(az containerapp show \
-              --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
-              --name "${WORKER_APP_NAME}" \
-              --query properties.provisioningState -o tsv)"
             latest_revision="$(az containerapp show \
               --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
               --name "${WORKER_APP_NAME}" \
               --query properties.latestRevisionName -o tsv)"
-            echo "${WORKER_APP_NAME} provisioning attempt ${i}/30: ${provisioning_state} (${latest_revision})"
-            if [ "${provisioning_state}" = "Succeeded" ]; then
+
+            if [ -z "${latest_revision}" ] || [ "${latest_revision}" = "null" ]; then
+              echo "${WORKER_APP_NAME} revision attempt ${i}/30: latest revision not available yet"
+              sleep 10
+              continue
+            fi
+
+            revision_provisioning_state="$(az containerapp revision show \
+              --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+              --name "${WORKER_APP_NAME}" \
+              --revision "${latest_revision}" \
+              --query properties.provisioningState -o tsv)"
+            revision_health_state="$(az containerapp revision show \
+              --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+              --name "${WORKER_APP_NAME}" \
+              --revision "${latest_revision}" \
+              --query properties.healthState -o tsv)"
+            revision_running_state="$(az containerapp revision show \
+              --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+              --name "${WORKER_APP_NAME}" \
+              --revision "${latest_revision}" \
+              --query properties.runningState -o tsv)"
+            revision_replicas="$(az containerapp revision show \
+              --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+              --name "${WORKER_APP_NAME}" \
+              --revision "${latest_revision}" \
+              --query properties.replicas -o tsv)"
+
+            echo "${WORKER_APP_NAME} revision attempt ${i}/30: revision=${latest_revision} provisioning=${revision_provisioning_state} health=${revision_health_state} running=${revision_running_state} replicas=${revision_replicas}"
+
+            if [ "${revision_provisioning_state}" = "Provisioning failed" ] || [ "${revision_running_state}" = "Activation failed" ] || [ "${revision_running_state}" = "Degraded" ] || [ "${revision_running_state}" = "Failed" ]; then
+              echo "ERROR: ${WORKER_APP_NAME} latest revision is unhealthy."
+              az containerapp revision show \
+                --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+                --name "${WORKER_APP_NAME}" \
+                --revision "${latest_revision}" \
+                -o yaml
+              exit 1
+            fi
+
+            if [ "${revision_provisioning_state}" != "Provisioned" ]; then
+              sleep 10
+              continue
+            fi
+
+            if [ "${revision_running_state}" = "Scale to 0" ]; then
               exit 0
             fi
+
+            replica_names="$(az containerapp replica list \
+              --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+              --name "${WORKER_APP_NAME}" \
+              --revision "${latest_revision}" \
+              --query "[].name" -o tsv)"
+
+            if [ -z "${replica_names}" ]; then
+              sleep 10
+              continue
+            fi
+
+            all_replicas_ready=true
+            for replica_name in ${replica_names}; do
+              replica_running_state="$(az containerapp replica show \
+                --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+                --name "${WORKER_APP_NAME}" \
+                --revision "${latest_revision}" \
+                --replica "${replica_name}" \
+                --query properties.runningState -o tsv)"
+              not_ready_containers="$(az containerapp replica show \
+                --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+                --name "${WORKER_APP_NAME}" \
+                --revision "${latest_revision}" \
+                --replica "${replica_name}" \
+                --query "length(properties.containers[?ready != \`true\`])" -o tsv)"
+              echo "${WORKER_APP_NAME} replica ${replica_name}: running=${replica_running_state} not_ready_containers=${not_ready_containers}"
+              if [ "${replica_running_state}" != "Running" ] || [ "${not_ready_containers}" != "0" ]; then
+                all_replicas_ready=false
+              fi
+            done
+
+            if [ "${all_replicas_ready}" = "true" ]; then
+              exit 0
+            fi
+
             sleep 10
           done
-          echo "ERROR: ${WORKER_APP_NAME} did not reach a succeeded provisioning state."
+          echo "ERROR: ${WORKER_APP_NAME} latest revision did not become ready."
           exit 1

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2227,3 +2227,29 @@ Remediated the four deployment-path regressions found after the ACA migration re
 
 - ACA revision/replica verification is based on Azure revision and replica state surfaced by the CLI/API; a live deploy is still needed to confirm the exact state transitions in this environment.
 - The legacy App Service rollback path is now compatible with warmup again, but it remains a rollback-only path and should still be exercised in Azure before being relied on during an incident.
+
+---
+
+## Section 65: Codex Delivery — PR #35 Review Fix for Queue Override Runtime Regression (2026-04-19)
+
+Addressed the blocking review comment on PR `#35` after verifying the workflow/runtime contract mismatch in the worker role env handling.
+
+### Completed
+
+- Corrected [.github/workflows/deploy-workers.yml](/Users/karthicks/kAgents/Projects/PFCD-V2/.github/workflows/deploy-workers.yml) so worker runtime phase selection stays on the logical matrix role:
+  - `PFCD_WORKER_ROLE` now remains `extracting` / `processing` / `reviewing`
+  - custom queue names continue to flow only through the `AZURE_SERVICE_BUS_QUEUE_*` env vars and the ACA scaler `queueName` metadata
+- Expanded [tests/unit/test_deploy_workflows.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/unit/test_deploy_workflows.py) to lock the fix:
+  - rejects `${WORKER_QUEUE_NAME}` as the `PFCD_WORKER_ROLE` source
+  - requires the workflow to keep the logical matrix role for `PFCD_WORKER_ROLE`
+
+### Why
+
+- `backend/app/workers/runner.py` and `backend/app/servicebus.py` treat `PFCD_WORKER_ROLE` as the logical phase key used to select queue config attributes.
+- Feeding a custom queue name into `PFCD_WORKER_ROLE` breaks `getattr(queue_config, phase)` for override deployments even though the default queue names still appeared to work.
+
+### Validation
+
+- `cd /tmp/pfcd-v2-issue34 && /Users/karthicks/kAgents/Projects/PFCD-V2/backend/.venv/bin/pytest tests/unit/test_worker.py tests/unit/test_deploy_workflows.py -v`
+- `cd /tmp/pfcd-v2-issue34 && ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-backend.yml"); YAML.load_file(".github/workflows/deploy-workers.yml")'`
+- `cd /tmp/pfcd-v2-issue34 && git diff --check`

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2189,3 +2189,41 @@ Executed the worker migration slice by replacing the App Service package deploym
 
 - Confirm the worker ACA YAML is accepted by Azure exactly as written and that each Service Bus queue scales its matching worker from zero.
 - Complete PostgreSQL cutover cleanup (`#27` Part B) now that backend and worker Container App workflows exist in repo.
+
+---
+
+## Section 64: Codex Delivery — GitHub Issue #34 ACA Deploy Verification + Rollback Compatibility Fixes (2026-04-19)
+
+Remediated the four deployment-path regressions found after the ACA migration review without reopening unrelated migration scope.
+
+### Completed
+
+- Restored the legacy App Service rollback warmup surface in [backend/app/workers/runner.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/workers/runner.py):
+  - reintroduced a minimal background HTTP listener
+  - starts only when `WEBSITES_PORT` is present, so ACA workers keep their existing runtime behavior
+- Added targeted worker regression coverage in [tests/unit/test_worker.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/unit/test_worker.py) for:
+  - HTTP listener bootstrap wiring
+  - `WEBSITES_PORT`-gated warmup compatibility behavior
+- Tightened [.github/workflows/deploy-backend.yml](/Users/karthicks/kAgents/Projects/PFCD-V2/.github/workflows/deploy-backend.yml):
+  - backend deploy verification now passes only on a healthy `200` `/health` payload
+  - degraded `503` payloads are printed to logs and fail the workflow
+  - backend ACA queue env vars now resolve from optional GitHub Actions queue overrides instead of hardcoded defaults
+- Tightened [.github/workflows/deploy-workers.yml](/Users/karthicks/kAgents/Projects/PFCD-V2/.github/workflows/deploy-workers.yml):
+  - worker queue names now resolve from optional GitHub Actions queue overrides and stay aligned across worker env + scaler metadata
+  - latest revision verification now checks ACA revision provisioning/running state and inspects replica/container readiness when replicas are active
+  - `Scale to 0` remains a valid success path for idle workers with zero min replicas
+- Added workflow regression coverage in [tests/unit/test_deploy_workflows.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/unit/test_deploy_workflows.py) for:
+  - backend health check no longer treating `503` as success
+  - worker deploy verification using revision + replica checks
+  - backend/worker queue override support
+- Updated [REFERENCE.md](/Users/karthicks/kAgents/Projects/PFCD-V2/REFERENCE.md) to document the stricter deploy checks and the optional queue override GitHub variables.
+
+### Validation
+
+- `cd /tmp/pfcd-v2-issue34 && /Users/karthicks/kAgents/Projects/PFCD-V2/backend/.venv/bin/pytest tests/unit/test_worker.py -k "health_server or maybe_start_health_server" -v`
+- `cd /tmp/pfcd-v2-issue34 && /Users/karthicks/kAgents/Projects/PFCD-V2/backend/.venv/bin/pytest tests/unit/test_deploy_workflows.py -v`
+
+### Residual risk
+
+- ACA revision/replica verification is based on Azure revision and replica state surfaced by the CLI/API; a live deploy is still needed to confirm the exact state transitions in this environment.
+- The legacy App Service rollback path is now compatible with warmup again, but it remains a rollback-only path and should still be exercised in Azure before being relied on during an incident.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -268,6 +268,8 @@ Pass `SP_CLIENT_ID=<github-actions-service-principal-client-id>` when you want t
   - external ingress on port 8000
   - HTTP `/health` startup/liveness/readiness probes
   - Key Vault-backed secret refs for `DATABASE_URL`, `AZURE_STORAGE_CONNECTION_STRING`, and `AZURE_SERVICE_BUS_CONNECTION_STRING`
+- Final deploy verification passes only on a healthy `200` `/health` payload and logs degraded `503` payloads before failing the workflow
+- Optional GitHub Actions variables `AZURE_SERVICE_BUS_QUEUE_EXTRACTING`, `AZURE_SERVICE_BUS_QUEUE_PROCESSING`, and `AZURE_SERVICE_BUS_QUEUE_REVIEWING` override the default queue names injected into the backend ACA manifest
 - Required secrets / vars: `AZURE_CREDENTIALS`, `AZURE_RESOURCE_GROUP`, `AZURE_WEBAPP_NAME`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_CHAT_DEPLOYMENT_NAME` (or deprecated alias), `AZURE_CONTAINER_REGISTRY`, `AZURE_CONTAINER_APPS_ENVIRONMENT`, `AZURE_STORAGE_ACCOUNT`, `AZURE_KEY_VAULT_NAME`, `AZURE_SERVICE_BUS_NAMESPACE`, `AZURE_OPENAI_ACCOUNT_NAME`, `AZURE_SPEECH_ACCOUNT_NAME`
 
 **File:** `.github/workflows/deploy-workers.yml`
@@ -281,6 +283,8 @@ Pass `SP_CLIENT_ID=<github-actions-service-principal-client-id>` when you want t
   - `PFCD_WORKER_ROLE` pinned per app (`extracting`, `processing`, `reviewing`)
   - Key Vault-backed secret refs for `DATABASE_URL`, `AZURE_STORAGE_CONNECTION_STRING`, and `AZURE_SERVICE_BUS_CONNECTION_STRING`
   - an `azure-servicebus` custom scale rule using `identity: system`, `messageCount: 1`, and the matching queue name
+- Final deploy verification checks the latest revision's ACA revision state and, when replicas are running, replica/container readiness instead of relying only on ARM provisioning state
+- Optional GitHub Actions variables `AZURE_SERVICE_BUS_QUEUE_EXTRACTING`, `AZURE_SERVICE_BUS_QUEUE_PROCESSING`, and `AZURE_SERVICE_BUS_QUEUE_REVIEWING` override the default queue names injected into the worker env and KEDA scaler metadata
 - Required secrets / vars: `AZURE_CREDENTIALS`, `AZURE_RESOURCE_GROUP`, `AZURE_WORKER_EXTRACTING_NAME`, `AZURE_WORKER_PROCESSING_NAME`, `AZURE_WORKER_REVIEWING_NAME`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_CHAT_DEPLOYMENT_NAME` (or deprecated alias), `AZURE_CONTAINER_REGISTRY`, `AZURE_CONTAINER_APPS_ENVIRONMENT`, `AZURE_STORAGE_ACCOUNT`, `AZURE_KEY_VAULT_NAME`, `AZURE_SERVICE_BUS_NAMESPACE`, `AZURE_OPENAI_ACCOUNT_NAME`, `AZURE_SPEECH_ACCOUNT_NAME`
 
 ### GitHub Variables
@@ -292,6 +296,9 @@ Pass `SP_CLIENT_ID=<github-actions-service-principal-client-id>` when you want t
 | `AZURE_CONTAINER_APPS_ENVIRONMENT` | `deploy-backend.yml`, `deploy-workers.yml` | Shared ACA environment name, e.g. `pfcd-dev-env` |
 | `AZURE_KEY_VAULT_NAME` | `deploy-backend.yml`, `deploy-workers.yml` | Key Vault name used for ACA secret refs, e.g. `pfcd-dev-kv` |
 | `AZURE_SERVICE_BUS_NAMESPACE` | `deploy-backend.yml`, `deploy-workers.yml` | Service Bus namespace name surfaced to the runtime and KEDA scaler, e.g. `pfcd-dev-bus` |
+| `AZURE_SERVICE_BUS_QUEUE_EXTRACTING` | `deploy-backend.yml`, `deploy-workers.yml` | Optional override for the extracting queue name; defaults to `extracting` |
+| `AZURE_SERVICE_BUS_QUEUE_PROCESSING` | `deploy-backend.yml`, `deploy-workers.yml` | Optional override for the processing queue name; defaults to `processing` |
+| `AZURE_SERVICE_BUS_QUEUE_REVIEWING` | `deploy-backend.yml`, `deploy-workers.yml` | Optional override for the reviewing queue name; defaults to `reviewing` |
 | `AZURE_OPENAI_ACCOUNT_NAME` | `deploy-backend.yml`, `deploy-workers.yml` | Azure OpenAI account name used by `/health` diagnostics and runtime env parity |
 | `AZURE_SPEECH_ACCOUNT_NAME` | `deploy-backend.yml`, `deploy-workers.yml` | Azure Speech account name used by `/health` diagnostics and runtime env parity |
 

--- a/backend/app/workers/runner.py
+++ b/backend/app/workers/runner.py
@@ -6,7 +6,9 @@ import json
 import logging
 import os
 import random
+import threading
 import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any, Dict
 from uuid import uuid4
 
@@ -262,6 +264,36 @@ def _resolve_phase() -> str:
     return "extracting"
 
 
+def _start_health_server(port: int) -> HTTPServer:
+    """Expose a minimal HTTP endpoint for legacy App Service warmup checks."""
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    server = HTTPServer(("0.0.0.0", port), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    logger.info("Legacy warmup listener active on port %d", server.server_port)
+    return server
+
+
+def _maybe_start_health_server() -> HTTPServer | None:
+    port = os.environ.get("WEBSITES_PORT", "").strip()
+    if not port:
+        return None
+    try:
+        return _start_health_server(int(port))
+    except ValueError:
+        logger.warning("Skipping legacy warmup listener: invalid WEBSITES_PORT=%r", port)
+        return None
+
+
 def _connection_backoff_seconds(consecutive_errors: int) -> float:
     """Return bounded exponential backoff with small jitter for reconnect attempts."""
     exponent = min(max(1, consecutive_errors), 6)
@@ -271,6 +303,7 @@ def _connection_backoff_seconds(consecutive_errors: int) -> float:
 
 def run() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+    _health_server = _maybe_start_health_server()
     phase = _resolve_phase()
     logger.info(
         "Worker runtime OpenAI config: role=%s endpoint=%s chat_deployment=%s api_version=%s",

--- a/tests/unit/test_deploy_workflows.py
+++ b/tests/unit/test_deploy_workflows.py
@@ -42,6 +42,8 @@ def test_worker_workflow_uses_override_queue_values_in_env_and_scaler():
     assert "SERVICE_BUS_QUEUE_PROCESSING" in workflow
     assert "SERVICE_BUS_QUEUE_REVIEWING" in workflow
     assert 'echo "WORKER_QUEUE_NAME=${{ matrix.role }}"' not in workflow
+    assert 'value: "${WORKER_QUEUE_NAME}"' not in workflow
+    assert 'value: "${{ matrix.role }}"' in workflow
     assert 'value: "extracting"' not in workflow
     assert 'value: "processing"' not in workflow
     assert 'value: "reviewing"' not in workflow

--- a/tests/unit/test_deploy_workflows.py
+++ b/tests/unit/test_deploy_workflows.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_backend_health_check_does_not_treat_503_as_success():
+    workflow = _read(".github/workflows/deploy-backend.yml")
+
+    assert '|| [ "$status_code" = "503" ]' not in workflow
+    assert 'if [ "$status_code" = "503" ]; then' in workflow
+
+
+def test_worker_deploy_verifies_revision_and_replica_health():
+    workflow = _read(".github/workflows/deploy-workers.yml")
+
+    assert "az containerapp revision show" in workflow
+    assert "az containerapp replica list" in workflow
+
+
+def test_backend_workflow_supports_queue_override_values():
+    workflow = _read(".github/workflows/deploy-backend.yml")
+
+    assert "SERVICE_BUS_QUEUE_EXTRACTING" in workflow
+    assert "SERVICE_BUS_QUEUE_PROCESSING" in workflow
+    assert "SERVICE_BUS_QUEUE_REVIEWING" in workflow
+    assert 'value: "extracting"' not in workflow
+    assert 'value: "processing"' not in workflow
+    assert 'value: "reviewing"' not in workflow
+
+
+def test_worker_workflow_uses_override_queue_values_in_env_and_scaler():
+    workflow = _read(".github/workflows/deploy-workers.yml")
+
+    assert "SERVICE_BUS_QUEUE_EXTRACTING" in workflow
+    assert "SERVICE_BUS_QUEUE_PROCESSING" in workflow
+    assert "SERVICE_BUS_QUEUE_REVIEWING" in workflow
+    assert 'echo "WORKER_QUEUE_NAME=${{ matrix.role }}"' not in workflow
+    assert 'value: "extracting"' not in workflow
+    assert 'value: "processing"' not in workflow
+    assert 'value: "reviewing"' not in workflow

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -264,6 +264,49 @@ def test_worker_skips_out_of_order_earlier_phase(tmp_path, monkeypatch):
     assert not run_phase_called, "Out-of-order earlier phase should have been skipped"
 
 
+def test_start_health_server_binds_and_starts_thread():
+    """Legacy App Service rollback path needs a background HTTP listener."""
+    from app.workers import runner as runner_mod
+
+    started = []
+    fake_server = MagicMock()
+    fake_server.server_port = 8123
+    fake_thread = MagicMock()
+    fake_thread.start.side_effect = lambda: started.append(True)
+
+    with patch.object(runner_mod, "HTTPServer", return_value=fake_server) as http_server:
+        with patch.object(runner_mod.threading, "Thread", return_value=fake_thread) as thread_cls:
+            server = runner_mod._start_health_server(8000)
+
+    assert server is fake_server
+    http_server.assert_called_once()
+    assert http_server.call_args.args[0] == ("0.0.0.0", 8000)
+    thread_cls.assert_called_once_with(target=fake_server.serve_forever, daemon=True)
+    assert started == [True]
+
+
+def test_maybe_start_health_server_honors_websites_port(monkeypatch):
+    from app.workers import runner as runner_mod
+
+    calls = []
+    monkeypatch.setenv("WEBSITES_PORT", "8123")
+    monkeypatch.setattr(runner_mod, "_start_health_server", lambda port: calls.append(port) or object())
+
+    server = runner_mod._maybe_start_health_server()
+
+    assert server is not None
+    assert calls == [8123]
+
+
+def test_maybe_start_health_server_skips_without_websites_port(monkeypatch):
+    from app.workers import runner as runner_mod
+
+    monkeypatch.delenv("WEBSITES_PORT", raising=False)
+    monkeypatch.setattr(runner_mod, "_start_health_server", lambda port: (_ for _ in ()).throw(AssertionError(port)))
+
+    assert runner_mod._maybe_start_health_server() is None
+
+
 def test_run_recreates_receiver_after_servicebus_error(monkeypatch):
     """run() should recreate the receiver after Service Bus connection failures."""
     from app.workers import runner as runner_mod


### PR DESCRIPTION
## Summary
- restore the legacy App Service worker warmup listener behind `WEBSITES_PORT` so the documented rollback path can still pass warmup on port `8000`
- fail backend ACA deploy verification on degraded `/health` responses instead of treating `503` as success
- verify worker deploys against latest ACA revision plus replica/container readiness, while still allowing healthy `Scale to 0` idle workers
- preserve queue-name overrides across backend env, worker env, and worker scaler metadata
- append the remediation to `IMPLEMENTATION_SUMMARY.md` and document the deploy/queue override behavior in `REFERENCE.md`

## Why
Issue #34 identified four post-migration regressions in the rollback and deploy verification path. This patch keeps the fix narrow and only addresses those findings.

Fixes #34

## Validation
- `cd /tmp/pfcd-v2-issue34 && /Users/karthicks/kAgents/Projects/PFCD-V2/backend/.venv/bin/pytest tests/unit/test_worker.py tests/unit/test_deploy_workflows.py -v`
- `cd /tmp/pfcd-v2-issue34 && ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-backend.yml"); YAML.load_file(".github/workflows/deploy-workers.yml")'`
- `cd /tmp/pfcd-v2-issue34 && git diff --check`

## Residual risk
- ACA revision/replica verification still needs one live Azure deployment to confirm the exact runtime state transitions in this environment.
- The legacy App Service rollback path is compatible again in code and config, but it should still be exercised in Azure before relying on it during an incident.
