### PR TITLE
[codex] Resolve GHCO critical issues #36-#40

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -43,7 +43,7 @@ Shared coordination board. Read and updated by both Claude and Codex at session 
 
 | ID | Task | PR / Commit |
 |----|------|-------------|
-| CRITICAL-GHCO-BUNDLE | Resolve GitHub critical issues #36-#40 on consolidated branch `codex/fix-critical-ghco-issues` | Branch `codex/fix-critical-ghco-issues` |
+| CRITICAL-GHCO-BUNDLE | Resolve GitHub critical issues #36-#40 on consolidated branch `codex/fix-critical-ghco-issues` | PR #43 |
 | ISSUE-19-ACA-INFRA | Provision Azure Container Registry and shared Container Apps environment for GitHub issue #19 | — |
 
 ---

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -43,6 +43,7 @@ Shared coordination board. Read and updated by both Claude and Codex at session 
 
 | ID | Task | PR / Commit |
 |----|------|-------------|
+| CRITICAL-GHCO-BUNDLE | Resolve GitHub critical issues #36-#40 on consolidated branch `codex/fix-critical-ghco-issues` | Branch `codex/fix-critical-ghco-issues` |
 | ISSUE-19-ACA-INFRA | Provision Azure Container Registry and shared Container Apps environment for GitHub issue #19 | — |
 
 ---

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2253,3 +2253,48 @@ Addressed the blocking review comment on PR `#35` after verifying the workflow/r
 - `cd /tmp/pfcd-v2-issue34 && /Users/karthicks/kAgents/Projects/PFCD-V2/backend/.venv/bin/pytest tests/unit/test_worker.py tests/unit/test_deploy_workflows.py -v`
 - `cd /tmp/pfcd-v2-issue34 && ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-backend.yml"); YAML.load_file(".github/workflows/deploy-workers.yml")'`
 - `cd /tmp/pfcd-v2-issue34 && git diff --check`
+
+---
+
+## Section 66: Codex Delivery — Critical GHCO Bug Bundle (#36-#40) (2026-04-19)
+
+Resolved the five `priority:critical` GitHub issues on branch `codex/fix-critical-ghco-issues` as one coordinated patch because the concurrency fixes in `#37` and `#38` share the same state-management surface.
+
+### Completed
+
+- Fixed upload path traversal in [backend/app/main.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/main.py):
+  - `POST /api/upload` now sanitizes filenames before joining them under `UPLOADS_DIR`
+  - stored `file_name` and `location` now reflect the safe basename instead of attacker-controlled relative paths
+- Fixed orchestrator resource cleanup in [backend/app/main.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/main.py):
+  - FastAPI lifespan shutdown now always calls `ORCHESTRATOR.close()`
+  - added unit coverage to verify shutdown cleanup runs
+- Fixed worker message-body bounds handling in [backend/app/workers/runner.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/workers/runner.py):
+  - extracted `_read_message_body()` helper
+  - size guard now checks `total + len(chunk)` before appending a chunk, enforcing the cap more defensively
+- Added job-level optimistic locking for concurrent state writes in [backend/app/models.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/models.py), [backend/app/repository.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/repository.py), and [backend/alembic/versions/20260419_0004_add_job_version.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/alembic/versions/20260419_0004_add_job_version.py):
+  - new `jobs.version` column with SQLAlchemy version tracking
+  - `JobRepository.upsert_job()` now rejects stale payload versions and surfaces a `ConcurrentModificationError`
+  - API write paths now translate stale writes into HTTP `409`
+- Fixed draft update isolation in [backend/app/job_logic.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/job_logic.py), [backend/app/main.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/main.py), and [frontend/src/api.js](/Users/karthicks/kAgents/Projects/PFCD-V2/frontend/src/api.js):
+  - `DraftUpdateRequest` now requires `draft_version`
+  - `PUT /api/jobs/{job_id}/draft` rejects stale versions with `409`
+  - successful draft saves increment `draft.version`
+  - frontend `saveDraft()` now sends the current draft version automatically
+- Expanded regression coverage across [tests/unit/test_main.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/unit/test_main.py), [tests/unit/test_worker_message_body.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/unit/test_worker_message_body.py), [tests/unit/test_repository.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/unit/test_repository.py), [tests/unit/test_draft_edit.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/unit/test_draft_edit.py), and the affected integration suites to lock the new request contract and critical bug paths.
+
+### Decisions
+
+- Used one job-level optimistic lock for all stateful job writes instead of separate ad-hoc guards per endpoint, because worker transitions and finalize/draft writes operate on the same `jobs` row.
+- Kept the draft-specific concurrency check separate from the job version so the UI can detect stale editor state directly and refresh the draft without guessing.
+- Limited this pass to the five `priority:critical` issues only; higher-severity-but-noncritical follow-ups remain in their own issue groups.
+
+### Validation
+
+- `PYTHONPATH=backend pytest tests/unit/test_main.py tests/unit/test_worker_message_body.py tests/unit/test_repository.py tests/unit/test_draft_edit.py tests/integration/test_lifecycle.py tests/integration/test_error_cases.py tests/integration/test_exports.py -q`
+- `PYTHONPATH=backend pytest tests/unit tests/integration -q`
+- `git diff --check`
+
+### Residual risk
+
+- Existing deployed databases need the new Alembic migration applied before optimistic locking is available outside fresh-schema environments.
+- The frontend now sends `draft_version`, so any external clients calling `PUT /api/jobs/{job_id}/draft` must update to the new contract or they will receive request validation errors.

--- a/backend/alembic/versions/20260419_0004_add_job_version.py
+++ b/backend/alembic/versions/20260419_0004_add_job_version.py
@@ -1,0 +1,26 @@
+"""add optimistic-lock version column to jobs
+
+Revision ID: 20260419_0004
+Revises: 20260411_0003
+Create Date: 2026-04-19 23:40:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260419_0004"
+down_revision = "20260411_0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("jobs") as batch_op:
+        batch_op.add_column(sa.Column("version", sa.Integer(), nullable=False, server_default=sa.text("1")))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("jobs") as batch_op:
+        batch_op.drop_column("version")

--- a/backend/app/job_logic.py
+++ b/backend/app/job_logic.py
@@ -62,6 +62,7 @@ class JobCreateRequest(BaseModel):
 
 
 class DraftUpdateRequest(BaseModel):
+    draft_version: int
     pdd: Optional[Dict[str, Any]] = None
     sipoc: Optional[List[Dict[str, Any]]] = None
     assumptions: Optional[List[str]] = None
@@ -157,6 +158,7 @@ def default_job_payload(payload: JobCreateRequest) -> Dict[str, Any]:
     profile_conf = profile_config(payload.profile)
 
     return {
+        "version": 1,
         "status": JobStatus.QUEUED.value,
         "created_at": _utc_now(),
         "updated_at": _utc_now(),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,7 +32,7 @@ from app.job_logic import (
     _utc_now,
     default_job_payload,
 )
-from app.repository import JobRepository
+from app.repository import ConcurrentModificationError, JobRepository
 from app.servicebus import ServiceBusOrchestrator, build_message
 from app.storage import ExportStorage
 
@@ -49,7 +49,10 @@ ORCHESTRATOR = ServiceBusOrchestrator()
 async def _lifespan(app: FastAPI):
     await anyio.to_thread.run_sync(JOB_REPO.init_db)
     logger.info("Database initialised")
-    yield
+    try:
+        yield
+    finally:
+        ORCHESTRATOR.close()
 
 
 app = FastAPI(
@@ -82,7 +85,16 @@ async def _repo_get_job(job_id: str) -> Optional[Dict[str, Any]]:
 
 
 async def _repo_upsert_job(job_id: str, payload: Dict[str, Any]) -> None:
-    await anyio.to_thread.run_sync(JOB_REPO.upsert_job, job_id, payload)
+    try:
+        await anyio.to_thread.run_sync(JOB_REPO.upsert_job, job_id, payload)
+    except ConcurrentModificationError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+def _safe_upload_name(filename: str | None) -> str:
+    candidate = os.path.basename((filename or "upload").replace("\\", "/")).strip()
+    candidate = candidate.lstrip(".")
+    return candidate or "upload"
 
 
 
@@ -140,9 +152,10 @@ async def upload_file(file: UploadFile = File(...)) -> Dict[str, Any]:
     if size_bytes > MAX_UPLOAD_BYTES:
         raise HTTPException(status_code=413, detail=f"File exceeds 500MB limit.")
 
+    safe_name = _safe_upload_name(file.filename)
     dest_dir = os.path.join(UPLOADS_DIR, upload_id)
     await anyio.to_thread.run_sync(lambda: os.makedirs(dest_dir, exist_ok=True))
-    dest_path = os.path.join(dest_dir, file.filename or "upload")
+    dest_path = os.path.join(dest_dir, safe_name)
     def _write():
         with open(dest_path, "wb") as fh:
             fh.write(content)
@@ -151,7 +164,7 @@ async def upload_file(file: UploadFile = File(...)) -> Dict[str, Any]:
     source_type = MIME_TO_SOURCE_TYPE.get(file.content_type or "", "document")
     return {
         "upload_id": upload_id,
-        "file_name": file.filename,
+        "file_name": safe_name,
         "size_bytes": size_bytes,
         "mime_type": file.content_type,
         "source_type": source_type,
@@ -234,6 +247,15 @@ async def update_draft(job_id: str, payload: DraftUpdateRequest) -> Dict[str, An
     job = await _job_or_404(job_id)
     if job["draft"] is None:
         raise HTTPException(status_code=409, detail="Draft not available for update.")
+    current_draft_version = int((job.get("draft") or {}).get("version", 1))
+    if payload.draft_version != current_draft_version:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Draft version conflict for {job_id}: expected {payload.draft_version}, "
+                f"current {current_draft_version}"
+            ),
+        )
     if payload.pdd is not None:
         job["draft"]["pdd"] = payload.pdd
     if payload.sipoc is not None:
@@ -246,6 +268,7 @@ async def update_draft(job_id: str, payload: DraftUpdateRequest) -> Dict[str, An
     job["user_saved_draft"] = True
     job["user_saved_at"] = job["updated_at"]
     job["draft"]["user_reconciled_at"] = _utc_now()
+    job["draft"]["version"] = current_draft_version + 1
     await _repo_upsert_job(job_id, job)
     # Re-run the pure-Python reviewing gate so flags reflect the edited draft.
     from app.agents.reviewing import run_reviewing
@@ -548,6 +571,7 @@ async def dev_simulate(job_id: str) -> Dict[str, Any]:
         },
         "assumptions": [],
         "generated_at": _utc_now(),
+        "version": 1,
     }
 
     job["status"] = JobStatus.NEEDS_REVIEW.value

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -12,6 +12,7 @@ class Job(Base):
     __tablename__ = "jobs"
 
     job_id = Column(String(64), primary_key=True)
+    version = Column(Integer, nullable=False, default=1)
     status = Column(String(32), nullable=False)
     created_at = Column(DateTime(timezone=True), nullable=False)
     updated_at = Column(DateTime(timezone=True), nullable=False)
@@ -36,6 +37,7 @@ class Job(Base):
     cleanup_pending = Column(Boolean, nullable=False, default=False)
     ttl_expires_at = Column(DateTime(timezone=True), nullable=True)
     error = Column(Text, nullable=True)
+    __mapper_args__ = {"version_id_col": version}
 
 
 class InputManifest(Base):

--- a/backend/app/repository.py
+++ b/backend/app/repository.py
@@ -11,10 +11,15 @@ from uuid import uuid4
 logger = logging.getLogger(__name__)
 
 from sqlalchemy import delete, select
+from sqlalchemy.orm.exc import StaleDataError
 
 from app.db import ENGINE, session_scope
 from app.job_logic import JobStatus, _utc_now
 from app.models import AgentRun, Draft, ExportPayload, InputManifest, Job, JobEvent, ReviewNotes
+
+
+class ConcurrentModificationError(RuntimeError):
+    """Raised when a job update loses an optimistic-lock race."""
 
 
 class JobRepository:
@@ -79,6 +84,7 @@ class JobRepository:
 
         payload = {
             "job_id": job.job_id,
+            "version": job.version,
             "status": job.status,
             "created_at": self._to_iso(job.created_at),
             "updated_at": self._to_iso(job.updated_at),
@@ -169,128 +175,141 @@ class JobRepository:
 
     def upsert_job(self, job_id: str, payload: Dict[str, Any]) -> None:
         logger.debug("Upserting job %s status=%s", job_id, payload.get("status"))
-        with session_scope() as session:
-            job = session.get(Job, job_id)
-            if not job:
-                job = Job(job_id=job_id)
-                session.add(job)
-
-            job.status = payload.get("status", job.status)
-            job.created_at = self._to_datetime(payload.get("created_at")) or job.created_at or self._to_datetime(_utc_now())
-            job.updated_at = self._to_datetime(payload.get("updated_at")) or job.updated_at or self._to_datetime(_utc_now())
-            job.profile_requested = payload.get("profile_requested", job.profile_requested or "balanced")
-            job.provider_effective = self._serialize(payload.get("provider_effective", {}))
-            job.has_video = bool(payload.get("has_video"))
-            job.has_audio = bool(payload.get("has_audio"))
-            job.has_transcript = bool(payload.get("has_transcript"))
-            job.teams_metadata = self._serialize(payload.get("teams_metadata", {}))
-            job.transcript_media_consistency = self._serialize(payload.get("transcript_media_consistency", {}))
-            job.agent_signals = self._serialize(payload.get("agent_signals", {}))
-            job.agent_review = self._serialize(payload.get("agent_review", {}))
-            job.speaker_resolutions = self._serialize(payload.get("speaker_resolutions", {}))
-            job.user_saved_draft = bool(payload.get("user_saved_draft"))
-            job.user_saved_at = self._to_datetime(payload.get("user_saved_at"))
-            job.current_phase = payload.get("current_phase")
-            job.last_completed_phase = payload.get("last_completed_phase")
-            job.phase_attempt = int(payload.get("phase_attempt", 0))
-            job.payload_hash = payload.get("payload_hash")
-            job.active_agent_run_id = payload.get("active_agent_run_id")
-            job.deleted_at = self._to_datetime(payload.get("deleted_at"))
-            job.cleanup_pending = bool(payload.get("cleanup_pending"))
-            job.ttl_expires_at = self._to_datetime(payload.get("ttl_expires_at"))
-            if payload.get("error") is not None:
-                job.error = self._serialize(payload.get("error"))
-            else:
-                job.error = None
-
-            input_manifest = session.get(InputManifest, job_id)
-            if not input_manifest:
-                input_manifest = InputManifest(job_id=job_id, payload=self._serialize(payload.get("input_manifest", {})))
-                session.add(input_manifest)
-            else:
-                input_manifest.payload = self._serialize(payload.get("input_manifest", {}))
-
-            review_notes = session.get(ReviewNotes, job_id)
-            review_payload = payload.get("review_notes", {"flags": [], "assumptions": []})
-            if not review_notes:
-                review_notes = ReviewNotes(job_id=job_id, payload=self._serialize(review_payload))
-                session.add(review_notes)
-            else:
-                review_notes.payload = self._serialize(review_payload)
-
-            existing_drafts = {
-                d.draft_kind: d
-                for d in session.execute(
-                    select(Draft).where(Draft.job_id == job_id)
-                ).scalars().all()
-            }
-            draft_by_kind: Dict[str, Dict[str, Any]] = {}
-            if payload.get("draft") is not None:
-                draft_by_kind["draft"] = payload["draft"]
-            if payload.get("finalized_draft") is not None:
-                draft_by_kind["finalized"] = payload["finalized_draft"]
-
-            for draft_kind, draft_payload in draft_by_kind.items():
-                draft_row = existing_drafts.get(draft_kind)
-                if not draft_row:
-                    draft_row = Draft(job_id=job_id, draft_kind=draft_kind)
-                    session.add(draft_row)
-                draft_row.payload = self._serialize(draft_payload)
-                draft_row.version = int(draft_payload.get("version", 1))
-                draft_row.generated_at = self._to_datetime(draft_payload.get("generated_at"))
-                draft_row.user_reconciled_at = self._to_datetime(draft_payload.get("user_reconciled_at"))
-                draft_row.finalized_at = self._to_datetime(draft_payload.get("finalized_at"))
-                draft_row.updated_at = self._to_datetime(payload.get("updated_at"))
-
-            # Incremental insert: only write runs that don't already exist in the DB.
-            # This preserves audit history across upsert calls and is safe against
-            # concurrent writes — each agent_run_id is a UUID generated once.
-            existing_run_ids: set[str] = set(
-                session.execute(
-                    select(AgentRun.agent_run_id).where(AgentRun.job_id == job_id)
-                ).scalars().all()
-            )
-            for run in payload.get("agent_runs", []):
-                run_id = run.get("agent_run_id") or str(uuid4())
-                if run_id in existing_run_ids:
-                    existing = session.get(AgentRun, run_id)
-                    if existing:
-                        existing.agent = run.get("agent", existing.agent)
-                        existing.model = run.get("model", existing.model)
-                        existing.profile = run.get("profile", existing.profile)
-                        existing.status = run.get("status", existing.status)
-                        existing.duration_ms = int(run.get("duration_ms") or 0)
-                        existing.cost_estimate_usd = float(run.get("cost_estimate_usd") or 0.0)
-                        existing.confidence_delta = float(run.get("confidence_delta") or 0.0)
-                        existing.message = run.get("message")
-                        existing.created_at = self._to_datetime(run.get("created_at")) or existing.created_at
-                        existing.updated_at = self._to_datetime(run.get("updated_at") or _utc_now())
-                    continue
-                existing_run_ids.add(run_id)  # guard against duplicates within this payload
-                session.add(
-                    AgentRun(
-                        agent_run_id=run_id,
-                        job_id=job_id,
-                        agent=run.get("agent", "unknown"),
-                        model=run.get("model", "unknown"),
-                        profile=run.get("profile", "balanced"),
-                        status=run.get("status", "unknown"),
-                        duration_ms=int(run.get("duration_ms") or 0),
-                        cost_estimate_usd=float(run.get("cost_estimate_usd") or 0.0),
-                        confidence_delta=float(run.get("confidence_delta") or 0.0),
-                        message=run.get("message"),
-                        created_at=self._to_datetime(run.get("created_at") or _utc_now()),
-                        updated_at=self._to_datetime(run.get("updated_at")),
-                    )
-                )
-
-            exports = session.get(ExportPayload, job_id)
-            if payload.get("exports") is not None:
-                exports_payload = self._serialize(payload.get("exports", {}))
-                if not exports:
-                    session.add(ExportPayload(job_id=job_id, payload=exports_payload))
+        persisted_version: int | None = None
+        try:
+            with session_scope() as session:
+                job = session.get(Job, job_id)
+                if not job:
+                    job = Job(job_id=job_id, version=int(payload.get("version") or 1))
+                    session.add(job)
                 else:
-                    exports.payload = exports_payload
+                    expected_version = int(payload.get("version") or job.version)
+                    if expected_version != job.version:
+                        raise ConcurrentModificationError(
+                            f"Job version conflict for {job_id}: expected {expected_version}, current {job.version}"
+                        )
+
+                job.status = payload.get("status", job.status)
+                job.created_at = self._to_datetime(payload.get("created_at")) or job.created_at or self._to_datetime(_utc_now())
+                job.updated_at = self._to_datetime(payload.get("updated_at")) or job.updated_at or self._to_datetime(_utc_now())
+                job.profile_requested = payload.get("profile_requested", job.profile_requested or "balanced")
+                job.provider_effective = self._serialize(payload.get("provider_effective", {}))
+                job.has_video = bool(payload.get("has_video"))
+                job.has_audio = bool(payload.get("has_audio"))
+                job.has_transcript = bool(payload.get("has_transcript"))
+                job.teams_metadata = self._serialize(payload.get("teams_metadata", {}))
+                job.transcript_media_consistency = self._serialize(payload.get("transcript_media_consistency", {}))
+                job.agent_signals = self._serialize(payload.get("agent_signals", {}))
+                job.agent_review = self._serialize(payload.get("agent_review", {}))
+                job.speaker_resolutions = self._serialize(payload.get("speaker_resolutions", {}))
+                job.user_saved_draft = bool(payload.get("user_saved_draft"))
+                job.user_saved_at = self._to_datetime(payload.get("user_saved_at"))
+                job.current_phase = payload.get("current_phase")
+                job.last_completed_phase = payload.get("last_completed_phase")
+                job.phase_attempt = int(payload.get("phase_attempt", 0))
+                job.payload_hash = payload.get("payload_hash")
+                job.active_agent_run_id = payload.get("active_agent_run_id")
+                job.deleted_at = self._to_datetime(payload.get("deleted_at"))
+                job.cleanup_pending = bool(payload.get("cleanup_pending"))
+                job.ttl_expires_at = self._to_datetime(payload.get("ttl_expires_at"))
+                if payload.get("error") is not None:
+                    job.error = self._serialize(payload.get("error"))
+                else:
+                    job.error = None
+
+                input_manifest = session.get(InputManifest, job_id)
+                if not input_manifest:
+                    input_manifest = InputManifest(job_id=job_id, payload=self._serialize(payload.get("input_manifest", {})))
+                    session.add(input_manifest)
+                else:
+                    input_manifest.payload = self._serialize(payload.get("input_manifest", {}))
+
+                review_notes = session.get(ReviewNotes, job_id)
+                review_payload = payload.get("review_notes", {"flags": [], "assumptions": []})
+                if not review_notes:
+                    review_notes = ReviewNotes(job_id=job_id, payload=self._serialize(review_payload))
+                    session.add(review_notes)
+                else:
+                    review_notes.payload = self._serialize(review_payload)
+
+                existing_drafts = {
+                    d.draft_kind: d
+                    for d in session.execute(
+                        select(Draft).where(Draft.job_id == job_id)
+                    ).scalars().all()
+                }
+                draft_by_kind: Dict[str, Dict[str, Any]] = {}
+                if payload.get("draft") is not None:
+                    draft_by_kind["draft"] = payload["draft"]
+                if payload.get("finalized_draft") is not None:
+                    draft_by_kind["finalized"] = payload["finalized_draft"]
+
+                for draft_kind, draft_payload in draft_by_kind.items():
+                    draft_row = existing_drafts.get(draft_kind)
+                    if not draft_row:
+                        draft_row = Draft(job_id=job_id, draft_kind=draft_kind)
+                        session.add(draft_row)
+                    draft_row.payload = self._serialize(draft_payload)
+                    draft_row.version = int(draft_payload.get("version", 1))
+                    draft_row.generated_at = self._to_datetime(draft_payload.get("generated_at"))
+                    draft_row.user_reconciled_at = self._to_datetime(draft_payload.get("user_reconciled_at"))
+                    draft_row.finalized_at = self._to_datetime(draft_payload.get("finalized_at"))
+                    draft_row.updated_at = self._to_datetime(payload.get("updated_at"))
+
+                existing_run_ids: set[str] = set(
+                    session.execute(
+                        select(AgentRun.agent_run_id).where(AgentRun.job_id == job_id)
+                    ).scalars().all()
+                )
+                for run in payload.get("agent_runs", []):
+                    run_id = run.get("agent_run_id") or str(uuid4())
+                    if run_id in existing_run_ids:
+                        existing = session.get(AgentRun, run_id)
+                        if existing:
+                            existing.agent = run.get("agent", existing.agent)
+                            existing.model = run.get("model", existing.model)
+                            existing.profile = run.get("profile", existing.profile)
+                            existing.status = run.get("status", existing.status)
+                            existing.duration_ms = int(run.get("duration_ms") or 0)
+                            existing.cost_estimate_usd = float(run.get("cost_estimate_usd") or 0.0)
+                            existing.confidence_delta = float(run.get("confidence_delta") or 0.0)
+                            existing.message = run.get("message")
+                            existing.created_at = self._to_datetime(run.get("created_at")) or existing.created_at
+                            existing.updated_at = self._to_datetime(run.get("updated_at") or _utc_now())
+                        continue
+                    existing_run_ids.add(run_id)
+                    session.add(
+                        AgentRun(
+                            agent_run_id=run_id,
+                            job_id=job_id,
+                            agent=run.get("agent", "unknown"),
+                            model=run.get("model", "unknown"),
+                            profile=run.get("profile", "balanced"),
+                            status=run.get("status", "unknown"),
+                            duration_ms=int(run.get("duration_ms") or 0),
+                            cost_estimate_usd=float(run.get("cost_estimate_usd") or 0.0),
+                            confidence_delta=float(run.get("confidence_delta") or 0.0),
+                            message=run.get("message"),
+                            created_at=self._to_datetime(run.get("created_at") or _utc_now()),
+                            updated_at=self._to_datetime(run.get("updated_at")),
+                        )
+                    )
+
+                exports = session.get(ExportPayload, job_id)
+                if payload.get("exports") is not None:
+                    exports_payload = self._serialize(payload.get("exports", {}))
+                    if not exports:
+                        session.add(ExportPayload(job_id=job_id, payload=exports_payload))
+                    else:
+                        exports.payload = exports_payload
+
+                session.flush()
+                persisted_version = int(job.version)
+        except StaleDataError as exc:
+            raise ConcurrentModificationError(f"Concurrent job update detected for {job_id}") from exc
+
+        if persisted_version is not None:
+            payload["version"] = persisted_version
 
     def append_job_event(self, job_id: str, event_type: str, payload: Dict[str, Any]) -> None:
         with session_scope() as session:

--- a/backend/app/workers/runner.py
+++ b/backend/app/workers/runner.py
@@ -67,6 +67,18 @@ def _load_message(raw_body: Any) -> Dict[str, Any]:
     return json.loads(bytes(raw_body).decode("utf-8"))
 
 
+def _read_message_body(message_body: Any) -> bytes:
+    chunks = []
+    total = 0
+    for chunk in message_body:
+        chunk_len = len(chunk)
+        if total + chunk_len > MAX_MESSAGE_BODY_BYTES:
+            raise ValueError(f"Message body exceeds {MAX_MESSAGE_BODY_BYTES // (1024 * 1024)}MB limit")
+        total += chunk_len
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 class Worker:
     def __init__(self, phase: str) -> None:
         self.phase = phase
@@ -348,16 +360,7 @@ def run() -> None:
                         break
                     for message in messages:
                         try:
-                            chunks = []
-                            total = 0
-                            for chunk in message.body:
-                                total += len(chunk)
-                                if total > MAX_MESSAGE_BODY_BYTES:
-                                    raise ValueError(
-                                        f"Message body exceeds {MAX_MESSAGE_BODY_BYTES // (1024 * 1024)}MB limit"
-                                    )
-                                chunks.append(chunk)
-                            body = b"".join(chunks)
+                            body = _read_message_body(message.body)
                             worker.handle_message(message, body)
                             receiver.complete_message(message)
                         except json.JSONDecodeError as exc:

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -39,7 +39,12 @@ export async function finalizeJob(jobId) {
 }
 
 export async function saveDraft(jobId, draft, speakerResolutions = null) {
-  const body = { pdd: draft.pdd, sipoc: draft.sipoc, assumptions: draft.assumptions }
+  const body = {
+    draft_version: draft.version ?? 1,
+    pdd: draft.pdd,
+    sipoc: draft.sipoc,
+    assumptions: draft.assumptions,
+  }
   if (speakerResolutions !== null) body.speaker_resolutions = speakerResolutions
   const res = await _fetch(`/jobs/${jobId}/draft`, {
     method: 'PUT',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,9 +117,15 @@ def seeded_needs_review_job(app_client):
 def seeded_completed_job(seeded_needs_review_job):
     """(job_id, AppContext) with the job fully finalized (status=completed)."""
     job_id, ctx = seeded_needs_review_job
+    draft_resp = ctx.client.get(f"/api/jobs/{job_id}/draft")
+    assert draft_resp.status_code == 200, f"get draft failed: {draft_resp.text}"
+    draft_version = draft_resp.json()["draft"]["version"]
     save_resp = ctx.client.put(
         f"/api/jobs/{job_id}/draft",
-        json={"assumptions": ["Saved by seeded_completed_job fixture"]},
+        json={
+            "draft_version": draft_version,
+            "assumptions": ["Saved by seeded_completed_job fixture"],
+        },
     )
     assert save_resp.status_code == 200, f"save draft failed: {save_resp.text}"
     resp = ctx.client.post(f"/api/jobs/{job_id}/finalize")

--- a/tests/integration/test_auth_enforcement.py
+++ b/tests/integration/test_auth_enforcement.py
@@ -71,7 +71,7 @@ def test_dev_simulate_with_auth_key_passes(app_client_with_auth):
     ("POST", "/api/jobs", {"input_files": [{"source_type": "transcript", "size_bytes": 1}]}),
     ("GET", "/api/jobs/{uid}", None),
     ("GET", "/api/jobs/{uid}/draft", None),
-    ("PUT", "/api/jobs/{uid}/draft", {"pdd": {}}),
+    ("PUT", "/api/jobs/{uid}/draft", {"draft_version": 1, "pdd": {}}),
     ("POST", "/api/jobs/{uid}/finalize", None),
     ("DELETE", "/api/jobs/{uid}", None),
 ])

--- a/tests/integration/test_error_cases.py
+++ b/tests/integration/test_error_cases.py
@@ -41,7 +41,10 @@ def test_get_draft_on_queued_job_returns_409(app_client):
 
 def test_put_draft_on_queued_job_returns_409(app_client):
     job_id = _create_queued(app_client.client)
-    resp = app_client.client.put(f"/api/jobs/{job_id}/draft", json={"pdd": {}})
+    resp = app_client.client.put(
+        f"/api/jobs/{job_id}/draft",
+        json={"draft_version": 1, "pdd": {}},
+    )
     assert resp.status_code == 409
 
 
@@ -69,9 +72,14 @@ def test_simulate_then_finalize_without_save_returns_409(app_client):
 def test_finalize_blocked_by_blocker_flag_returns_409(app_client):
     job_id = _create_queued(app_client.client)
     _simulate(app_client.client, job_id)
+    draft_resp = app_client.client.get(f"/api/jobs/{job_id}/draft")
+    assert draft_resp.status_code == 200
     save_resp = app_client.client.put(
         f"/api/jobs/{job_id}/draft",
-        json={"assumptions": ["Saved before blocker check"]},
+        json={
+            "draft_version": draft_resp.json()["draft"]["version"],
+            "assumptions": ["Saved before blocker check"],
+        },
     )
     assert save_resp.status_code == 200
 
@@ -135,3 +143,20 @@ def test_upload_oversize_file_returns_413(app_client):
         files={"file": ("big.txt", b"x" * 11, "text/plain")},
     )
     assert resp.status_code == 413
+
+
+def test_upload_sanitizes_path_traversal_filename(app_client, tmp_path):
+    uploads_dir = tmp_path / "uploads"
+    app_client.module.UPLOADS_DIR = str(uploads_dir)
+
+    resp = app_client.client.post(
+        "/api/upload",
+        files={"file": ("../evil.txt", b"owned", "text/plain")},
+    )
+
+    assert resp.status_code == 201
+    body = resp.json()
+    stored_path = uploads_dir / body["upload_id"] / "evil.txt"
+    assert body["location"] == str(stored_path)
+    assert stored_path.read_bytes() == b"owned"
+    assert not (tmp_path / "evil.txt").exists()

--- a/tests/integration/test_exports.py
+++ b/tests/integration/test_exports.py
@@ -95,9 +95,14 @@ def test_scenario_a_happy_path(app_client):
     }
     job_id = app_client.client.post("/api/jobs", json=payload).json()["job_id"]
     app_client.client.post(f"/dev/jobs/{job_id}/simulate")
+    draft_resp = app_client.client.get(f"/api/jobs/{job_id}/draft")
+    assert draft_resp.status_code == 200
     save_resp = app_client.client.put(
         f"/api/jobs/{job_id}/draft",
-        json={"assumptions": ["Saved before finalize in export scenario"]},
+        json={
+            "draft_version": draft_resp.json()["draft"]["version"],
+            "assumptions": ["Saved before finalize in export scenario"],
+        },
     )
     assert save_resp.status_code == 200
 

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -117,23 +117,58 @@ def test_update_draft_saves_changes(app_client):
     job_id = app_client.client.post("/api/jobs", json=payload).json()["job_id"]
     app_client.client.post(f"/dev/jobs/{job_id}/simulate")
 
+    draft_resp = app_client.client.get(f"/api/jobs/{job_id}/draft")
+    assert draft_resp.status_code == 200
     updated_pdd = {"purpose": "Integration-test updated purpose", "steps": []}
     put_resp = app_client.client.put(
         f"/api/jobs/{job_id}/draft",
-        json={"pdd": updated_pdd},
+        json={"draft_version": draft_resp.json()["draft"]["version"], "pdd": updated_pdd},
     )
     assert put_resp.status_code == 200
     assert put_resp.json()["user_saved_draft"] is True
 
     get_resp = app_client.client.get(f"/api/jobs/{job_id}/draft")
     assert get_resp.json()["draft"]["pdd"]["purpose"] == "Integration-test updated purpose"
+    assert get_resp.json()["draft"]["version"] == 2
+
+
+def test_update_draft_rejects_stale_draft_version(app_client):
+    payload = {
+        "input_files": [
+            {"source_type": "transcript", "file_name": "t.vtt", "size_bytes": 512}
+        ]
+    }
+    job_id = app_client.client.post("/api/jobs", json=payload).json()["job_id"]
+    app_client.client.post(f"/dev/jobs/{job_id}/simulate")
+
+    first_draft = app_client.client.get(f"/api/jobs/{job_id}/draft")
+    assert first_draft.status_code == 200
+    stale_version = first_draft.json()["draft"]["version"]
+
+    first_save = app_client.client.put(
+        f"/api/jobs/{job_id}/draft",
+        json={"draft_version": stale_version, "assumptions": ["first save"]},
+    )
+    assert first_save.status_code == 200
+
+    stale_save = app_client.client.put(
+        f"/api/jobs/{job_id}/draft",
+        json={"draft_version": stale_version, "assumptions": ["stale save"]},
+    )
+    assert stale_save.status_code == 409
+    assert "version" in stale_save.json()["detail"].lower()
 
 
 def test_finalize_job_returns_completed(seeded_needs_review_job):
     job_id, ctx = seeded_needs_review_job
+    draft_resp = ctx.client.get(f"/api/jobs/{job_id}/draft")
+    assert draft_resp.status_code == 200
     save_resp = ctx.client.put(
         f"/api/jobs/{job_id}/draft",
-        json={"assumptions": ["Saved before finalize"]},
+        json={
+            "draft_version": draft_resp.json()["draft"]["version"],
+            "assumptions": ["Saved before finalize"],
+        },
     )
     assert save_resp.status_code == 200
     resp = ctx.client.post(f"/api/jobs/{job_id}/finalize")

--- a/tests/integration/test_postgres_smoke.py
+++ b/tests/integration/test_postgres_smoke.py
@@ -90,9 +90,14 @@ def test_postgres_alembic_and_api_lifecycle_smoke(monkeypatch: pytest.MonkeyPatc
     simulate_response = client.post(f"/dev/jobs/{job_id}/simulate")
     assert simulate_response.status_code == 200, simulate_response.text
 
+    draft_response = client.get(f"/api/jobs/{job_id}/draft")
+    assert draft_response.status_code == 200, draft_response.text
     save_response = client.put(
         f"/api/jobs/{job_id}/draft",
-        json={"assumptions": ["Validated against PostgreSQL smoke DB"]},
+        json={
+            "draft_version": draft_response.json()["draft"]["version"],
+            "assumptions": ["Validated against PostgreSQL smoke DB"],
+        },
     )
     assert save_response.status_code == 200, save_response.text
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -61,7 +61,7 @@ def test_all_write_methods_require_auth(monkeypatch, tmp_path):
     job_id = str(uuid4())
     cases = [
         ("POST", "/api/jobs", {}),
-        ("PUT", f"/api/jobs/{job_id}/draft", {}),
+        ("PUT", f"/api/jobs/{job_id}/draft", {"draft_version": 1}),
         ("POST", f"/api/jobs/{job_id}/finalize", {}),
         ("DELETE", f"/api/jobs/{job_id}", {}),
     ]

--- a/tests/unit/test_draft_edit.py
+++ b/tests/unit/test_draft_edit.py
@@ -78,9 +78,10 @@ def test_update_draft_response_includes_review_notes(monkeypatch, tmp_path):
 
     with TestClient(main_mod.app, raise_server_exceptions=False) as client:
         job_id = _create_and_simulate(client)
+        draft = client.get(f"/api/jobs/{job_id}/draft").json()["draft"]
         response = client.put(
             f"/api/jobs/{job_id}/draft",
-            json={"pdd": _full_pdd(), "sipoc": _full_sipoc()},
+            json={"draft_version": draft["version"], "pdd": _full_pdd(), "sipoc": _full_sipoc()},
         )
 
     assert response.status_code == 200
@@ -96,9 +97,10 @@ def test_update_draft_re_review_clears_pdd_blocker(monkeypatch, tmp_path):
 
     with TestClient(main_mod.app, raise_server_exceptions=False) as client:
         job_id = _create_and_simulate(client)
+        draft = client.get(f"/api/jobs/{job_id}/draft").json()["draft"]
         response = client.put(
             f"/api/jobs/{job_id}/draft",
-            json={"pdd": _full_pdd("Test Purpose"), "sipoc": _full_sipoc()},
+            json={"draft_version": draft["version"], "pdd": _full_pdd("Test Purpose"), "sipoc": _full_sipoc()},
         )
 
     assert response.status_code == 200
@@ -113,14 +115,16 @@ def test_update_draft_re_review_triggers_pdd_blocker(monkeypatch, tmp_path):
 
     with TestClient(main_mod.app, raise_server_exceptions=False) as client:
         job_id = _create_and_simulate(client)
+        draft = client.get(f"/api/jobs/{job_id}/draft").json()["draft"]
         first_save = client.put(
             f"/api/jobs/{job_id}/draft",
-            json={"pdd": _full_pdd("Initial Purpose"), "sipoc": _full_sipoc()},
+            json={"draft_version": draft["version"], "pdd": _full_pdd("Initial Purpose"), "sipoc": _full_sipoc()},
         )
         assert first_save.status_code == 200
+        next_version = first_save.json()["draft"]["version"]
         response = client.put(
             f"/api/jobs/{job_id}/draft",
-            json={"pdd": _full_pdd(""), "sipoc": _full_sipoc()},
+            json={"draft_version": next_version, "pdd": _full_pdd(""), "sipoc": _full_sipoc()},
         )
 
     assert response.status_code == 200

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+from unittest.mock import MagicMock
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+BACKEND = ROOT / "backend"
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+
+def test_app_shutdown_closes_orchestrator(monkeypatch, tmp_path):
+    db_path = tmp_path / "pfcd-main.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME", "test-deployment")
+
+    import app.main as main_mod
+
+    importlib.reload(main_mod)
+    main_mod.ORCHESTRATOR = MagicMock()
+
+    from starlette.testclient import TestClient
+
+    with TestClient(main_mod.app, raise_server_exceptions=False) as client:
+        client.get("/health")
+
+    main_mod.ORCHESTRATOR.close.assert_called_once_with()

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -66,3 +66,38 @@ def test_job_events(tmp_path, monkeypatch):
         count = result.scalar()
 
     assert count == 1
+
+
+def test_job_upsert_rejects_stale_version(tmp_path, monkeypatch):
+    db_path = tmp_path / "pfcd-stale.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    _, repo = _reload_modules()
+    from app.job_logic import InputFile, JobCreateRequest, default_job_payload
+
+    repository = repo.JobRepository.from_env()
+    repository.init_db()
+
+    payload = default_job_payload(
+        JobCreateRequest(
+            profile="balanced",
+            input_files=[InputFile(source_type="video", size_bytes=123)],
+        )
+    )
+    job_id = str(uuid4())
+    payload["job_id"] = job_id
+
+    repository.upsert_job(job_id, payload)
+    loaded = repository.get_job(job_id)
+    newer = dict(loaded)
+    newer["status"] = "processing"
+    repository.upsert_job(job_id, newer)
+
+    stale = dict(loaded)
+    stale["status"] = "failed"
+
+    try:
+        repository.upsert_job(job_id, stale)
+        assert False, "Expected stale write to fail"
+    except repo.ConcurrentModificationError:
+        pass

--- a/tests/unit/test_worker_message_body.py
+++ b/tests/unit/test_worker_message_body.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+BACKEND = ROOT / "backend"
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+
+def test_read_message_body_rejects_oversized_payload():
+    from app.workers.runner import MAX_MESSAGE_BODY_BYTES, _read_message_body
+
+    chunks = [b"a" * MAX_MESSAGE_BODY_BYTES, b"b"]
+
+    with pytest.raises(ValueError, match="exceeds"):
+        _read_message_body(chunks)


### PR DESCRIPTION
## Summary
- sanitize uploaded filenames before writing to disk so traversal strings cannot escape `UPLOADS_DIR`
- close the global Service Bus orchestrator during FastAPI shutdown to release long-lived sender resources
- add a bounded worker message-body reader that rejects oversized payloads before appending the over-limit chunk
- add optimistic locking on `jobs` plus draft-version checks so stale worker/API writes fail with HTTP `409` instead of silently overwriting newer state
- update the frontend draft-save client to send `draft_version`, and add regression tests for the critical bug paths

## Why
GHCO raised five `priority:critical` issues (#36-#40). The race-condition fixes in #37 and #38 share the same state-management surface, so they were implemented together as one coordinated patch while keeping the rest of the scope limited to the critical issue set.

Closes #36
Closes #37
Closes #38
Closes #39
Closes #40

## Validation
- `PYTHONPATH=backend pytest tests/unit/test_main.py tests/unit/test_worker_message_body.py tests/unit/test_repository.py tests/unit/test_draft_edit.py tests/integration/test_lifecycle.py tests/integration/test_error_cases.py tests/integration/test_exports.py -q`
- `PYTHONPATH=backend pytest tests/unit tests/integration -q`
- `git diff --check`

## Residual risk
- Existing deployed databases still need the new Alembic migration applied before optimistic locking is active outside fresh-schema environments.
- Any external client calling `PUT /api/jobs/{job_id}/draft` must now send `draft_version` or it will fail request validation.