### PR TITLE
[codex] Fix issue #41 high-severity reliability bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ backend/storage/
 # macOS / editor artefacts
 .DS_Store
 .Rhistory
+.worktrees/
 
 # Build artefacts (CI zip deploys)
 *.zip

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -44,6 +44,7 @@ Shared coordination board. Read and updated by both Claude and Codex at session 
 | ID | Task | PR / Commit |
 |----|------|-------------|
 | CRITICAL-GHCO-BUNDLE | Resolve GitHub critical issues #36-#40 on consolidated branch `codex/fix-critical-ghco-issues` | PR #43 |
+| ISSUE-41-HIGH-SEVERITY-BUGS | Resolve GitHub issue #41 high-severity bugs on isolated branch `codex/fix-high-severity-bugs` | PR #45 |
 | ISSUE-19-ACA-INFRA | Provision Azure Container Registry and shared Container Apps environment for GitHub issue #19 | — |
 
 ---

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2298,3 +2298,41 @@ Resolved the five `priority:critical` GitHub issues on branch `codex/fix-critica
 
 - Existing deployed databases need the new Alembic migration applied before optimistic locking is available outside fresh-schema environments.
 - The frontend now sends `draft_version`, so any external clients calling `PUT /api/jobs/{job_id}/draft` must update to the new contract or they will receive request validation errors.
+
+---
+
+## Section 67: Codex Delivery — GitHub Issue #41 High-Severity Reliability Fixes (2026-04-19)
+
+Resolved the five-item high-severity backend reliability bundle on isolated branch `codex/fix-high-severity-bugs`.
+
+### Completed
+
+- Hardened [backend/app/main.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/main.py) finalize flow so export-generation failures no longer strand jobs in `FINALIZING`:
+  - export build/save is wrapped in a single failure boundary
+  - any exception now marks the job `FAILED`, records `error.phase = "finalize"`, appends `finalize_failed`, and best-effort deletes partial export files
+- Fixed retry deduplication in [backend/app/servicebus.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/servicebus.py) by excluding non-semantic fields (`attempt`, `payload_hash`) from the message hash, so retried deliveries of the same logical work item reuse the same `payload_hash`
+- Added an operator-tunable receive/backoff strategy in [backend/app/workers/runner.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/workers/runner.py):
+  - `PFCD_WORKER_RECEIVE_WAIT_SECONDS` controls the Service Bus long-poll receive window
+  - empty polls now use bounded exponential idle backoff instead of the previous fixed unconditional sleep
+- Locked the cleanup atomicity expectation in [backend/app/workers/cleanup.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/workers/cleanup.py) with an explicit retry comment and regression coverage proving `cleanup_pending` stays set when storage deletion fails
+- Added transient retry handling to [backend/app/storage.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/storage.py) frame uploads:
+  - bounded retries for Azure/storage/network-style exceptions before returning `None`
+  - retry cadence controlled by `PFCD_FRAME_UPLOAD_MAX_ATTEMPTS` and `PFCD_FRAME_UPLOAD_RETRY_BASE_SECONDS`
+- Added `.worktrees/` to [.gitignore](/Users/karthicks/kAgents/Projects/PFCD-V2/.gitignore) on this branch so isolated workspaces remain untracked
+
+### Tests
+
+- Added/updated regression coverage in:
+  - [tests/integration/test_error_cases.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/integration/test_error_cases.py) for finalize export failure -> persisted `FAILED` status
+  - [tests/unit/test_worker.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/unit/test_worker.py) for retry hash stability, retry-message dedup, and receive/backoff configuration
+  - [tests/unit/test_cleanup.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/unit/test_cleanup.py) for preserving `cleanup_pending` on storage purge failure
+  - [tests/unit/test_frame_persist.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/unit/test_frame_persist.py) for transient blob upload retries
+
+### Validation
+
+- `pytest tests/unit/test_worker.py tests/unit/test_cleanup.py tests/unit/test_frame_persist.py tests/integration/test_error_cases.py tests/integration/test_lifecycle.py tests/integration/test_exports.py -q`
+  - Result: `68 passed, 1 warning`
+
+### Open follow-up
+
+- The new worker receive/backoff knobs are implemented in code but not yet documented in `REFERENCE.md`; add them if operations wants these surfaced in the environment table.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -337,72 +337,91 @@ async def finalize_job(job_id: str) -> Dict[str, Any]:
         {"job_id": job_id, "at": _utc_now()},
     )
 
-    job["finalized_draft"] = copy.deepcopy(job["draft"])
-    job["finalized_draft"]["finalized_at"] = _utc_now()
-    evidence_bundle = build_evidence_bundle(job["finalized_draft"], job)
-    exports_payload = {
-        "job_id": job_id,
-        "status": JobStatus.COMPLETED.value,
-        "provider_effective": job["provider_effective"],
-        "draft": job["finalized_draft"],
-        "review_notes": job["review_notes"],
-        "exports_manifest": {"format": "json", "evidence_bundle": evidence_bundle},
-    }
-    json_bytes = json.dumps(exports_payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
-    markdown_bytes = await anyio.to_thread.run_sync(
-        lambda: build_export_markdown(job["finalized_draft"], evidence_bundle).encode("utf-8")
-    )
-    pdf_bytes = await anyio.to_thread.run_sync(
-        lambda: build_export_pdf(job["finalized_draft"], evidence_bundle)
-    )
-    docx_bytes = await anyio.to_thread.run_sync(
-        lambda: build_export_docx(job["finalized_draft"], evidence_bundle, job_id)
-    )
-
-    json_meta = await anyio.to_thread.run_sync(
-        EXPORT_STORAGE.save_bytes, job_id, "json", json_bytes, "application/json"
-    )
-    md_meta = await anyio.to_thread.run_sync(
-        EXPORT_STORAGE.save_bytes, job_id, "markdown", markdown_bytes, "text/markdown; charset=utf-8"
-    )
-    pdf_meta = await anyio.to_thread.run_sync(
-        lambda: EXPORT_STORAGE.save_bytes(
-            job_id, "pdf", pdf_bytes, "application/pdf", download_name=f"pdd-{job_id}.pdf"
+    try:
+        finalized_draft = copy.deepcopy(job["draft"])
+        finalized_draft["finalized_at"] = _utc_now()
+        evidence_bundle = build_evidence_bundle(finalized_draft, job)
+        exports_payload = {
+            "job_id": job_id,
+            "status": JobStatus.COMPLETED.value,
+            "provider_effective": job["provider_effective"],
+            "draft": finalized_draft,
+            "review_notes": job["review_notes"],
+            "exports_manifest": {"format": "json", "evidence_bundle": evidence_bundle},
+        }
+        json_bytes = json.dumps(exports_payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+        markdown_bytes = await anyio.to_thread.run_sync(
+            lambda: build_export_markdown(finalized_draft, evidence_bundle).encode("utf-8")
         )
-    )
-    docx_meta = await anyio.to_thread.run_sync(
-        lambda: EXPORT_STORAGE.save_bytes(
+        pdf_bytes = await anyio.to_thread.run_sync(
+            lambda: build_export_pdf(finalized_draft, evidence_bundle)
+        )
+        docx_bytes = await anyio.to_thread.run_sync(
+            lambda: build_export_docx(finalized_draft, evidence_bundle, job_id)
+        )
+
+        json_meta = await anyio.to_thread.run_sync(
+            EXPORT_STORAGE.save_bytes, job_id, "json", json_bytes, "application/json"
+        )
+        md_meta = await anyio.to_thread.run_sync(
+            EXPORT_STORAGE.save_bytes, job_id, "markdown", markdown_bytes, "text/markdown; charset=utf-8"
+        )
+        pdf_meta = await anyio.to_thread.run_sync(
+            lambda: EXPORT_STORAGE.save_bytes(
+                job_id, "pdf", pdf_bytes, "application/pdf", download_name=f"pdd-{job_id}.pdf"
+            )
+        )
+        docx_meta = await anyio.to_thread.run_sync(
+            lambda: EXPORT_STORAGE.save_bytes(
+                job_id,
+                "docx",
+                docx_bytes,
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                download_name=f"pdd-{job_id}.docx",
+            )
+        )
+
+        job["finalized_draft"] = finalized_draft
+        job["exports"] = {
+            "json": json_meta.__dict__,
+            "markdown": md_meta.__dict__,
+            "pdf": pdf_meta.__dict__,
+            "docx": docx_meta.__dict__,
+            "endpoints": {
+                "json": f"/api/jobs/{job_id}/exports/json",
+                "markdown": f"/api/jobs/{job_id}/exports/markdown",
+                "pdf": f"/api/jobs/{job_id}/exports/pdf",
+                "docx": f"/api/jobs/{job_id}/exports/docx",
+            },
+        }
+        job["status"] = JobStatus.COMPLETED.value
+        job["updated_at"] = _utc_now()
+        await _repo_upsert_job(job_id, job)
+        await anyio.to_thread.run_sync(
+            JOB_REPO.append_job_event,
             job_id,
-            "docx",
-            docx_bytes,
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            download_name=f"pdd-{job_id}.docx",
+            "finalize_completed",
+            {"job_id": job_id, "at": _utc_now()},
         )
-    )
-
-    job["exports"] = {
-        "json": json_meta.__dict__,
-        "markdown": md_meta.__dict__,
-        "pdf": pdf_meta.__dict__,
-        "docx": docx_meta.__dict__,
-        "endpoints": {
-            "json": f"/api/jobs/{job_id}/exports/json",
-            "markdown": f"/api/jobs/{job_id}/exports/markdown",
-            "pdf": f"/api/jobs/{job_id}/exports/pdf",
-            "docx": f"/api/jobs/{job_id}/exports/docx",
-        },
-    }
-    job["status"] = JobStatus.COMPLETED.value
-    job["updated_at"] = _utc_now()
-    await _repo_upsert_job(job_id, job)
-    await anyio.to_thread.run_sync(
-        JOB_REPO.append_job_event,
-        job_id,
-        "finalize_completed",
-        {"job_id": job_id, "at": _utc_now()},
-    )
-    logger.info("Job finalized: job_id=%s", job_id)
-    return {"job_id": job_id, "status": job["status"], "exports": job["exports"]}
+        logger.info("Job finalized: job_id=%s", job_id)
+        return {"job_id": job_id, "status": job["status"], "exports": job["exports"]}
+    except Exception as exc:
+        logger.error("Finalize failed for job %s: %s", job_id, exc, exc_info=True)
+        try:
+            await anyio.to_thread.run_sync(EXPORT_STORAGE.delete_job_exports, job_id)
+        except Exception:
+            logger.warning("Failed to clean partial exports for job %s after finalize error", job_id, exc_info=True)
+        job["status"] = JobStatus.FAILED.value
+        job["error"] = {"message": str(exc), "phase": "finalize"}
+        job["updated_at"] = _utc_now()
+        await _repo_upsert_job(job_id, job)
+        await anyio.to_thread.run_sync(
+            JOB_REPO.append_job_event,
+            job_id,
+            "finalize_failed",
+            {"job_id": job_id, "at": _utc_now(), "message": str(exc)},
+        )
+        raise HTTPException(status_code=500, detail="Failed to generate exports.") from exc
 
 
 @api_router.get("/jobs/{job_id}/exports/{fmt}")

--- a/backend/app/servicebus.py
+++ b/backend/app/servicebus.py
@@ -16,6 +16,7 @@ from azure.servicebus import ServiceBusClient, ServiceBusMessage, ServiceBusRece
 logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_RETRIES = 3
+_NON_DEDUP_FIELDS = {"attempt", "payload_hash"}
 
 
 @dataclass(frozen=True)
@@ -42,7 +43,10 @@ def _connection_string() -> Optional[str]:
 
 
 def _payload_hash(message: Dict[str, Any]) -> str:
-    payload = json.dumps(message, sort_keys=True, separators=(",", ":"))
+    dedup_payload = {
+        key: value for key, value in message.items() if key not in _NON_DEDUP_FIELDS
+    }
+    payload = json.dumps(dedup_payload, sort_keys=True, separators=(",", ":"))
     return sha256(payload.encode("utf-8")).hexdigest()
 
 

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import time
 from dataclasses import dataclass
 from typing import Dict, Optional
 
+from azure.core.exceptions import AzureError
 from azure.storage.blob import BlobServiceClient, ContentSettings
 
 logger = logging.getLogger(__name__)
@@ -16,6 +18,11 @@ logger = logging.getLogger(__name__)
 DEFAULT_EXPORT_CONTAINER = "exports"
 DEFAULT_EXPORT_BASE_PATH = "./storage/exports"
 _EVIDENCE_CONTAINER = os.environ.get("AZURE_STORAGE_CONTAINER_EVIDENCE", "evidence")
+_FRAME_UPLOAD_MAX_ATTEMPTS = max(1, int(os.environ.get("PFCD_FRAME_UPLOAD_MAX_ATTEMPTS", "3")))
+_FRAME_UPLOAD_RETRY_BASE_SECONDS = max(
+    0.0,
+    float(os.environ.get("PFCD_FRAME_UPLOAD_RETRY_BASE_SECONDS", "0.5")),
+)
 
 
 @dataclass(frozen=True)
@@ -145,6 +152,25 @@ def upload_frame(job_id: str, frame_index: int, jpg_bytes: bytes) -> str | None:
     Returns the storage key (blob path or local file path) on success, None on any
     failure. Never raises.
     """
+    def _run_with_retries(operation):
+        for attempt in range(1, _FRAME_UPLOAD_MAX_ATTEMPTS + 1):
+            try:
+                return operation()
+            except (AzureError, OSError, TimeoutError) as exc:
+                if attempt >= _FRAME_UPLOAD_MAX_ATTEMPTS:
+                    raise
+                delay = min(5.0, _FRAME_UPLOAD_RETRY_BASE_SECONDS * float(2 ** (attempt - 1)))
+                logger.warning(
+                    "Retrying frame upload for job %s frame %d in %.2fs after attempt %d/%d failed: %s",
+                    job_id,
+                    frame_index,
+                    delay,
+                    attempt,
+                    _FRAME_UPLOAD_MAX_ATTEMPTS,
+                    exc,
+                )
+                time.sleep(delay)
+
     try:
         account_url = os.environ.get("AZURE_STORAGE_ACCOUNT_URL")
         if not account_url:
@@ -155,34 +181,38 @@ def upload_frame(job_id: str, frame_index: int, jpg_bytes: bytes) -> str | None:
 
         blob_name = f"{job_id}/frames/frame_{frame_index:04d}.jpg"
 
+        def _upload_blob(blob_client) -> str:
+            _run_with_retries(
+                lambda: blob_client.upload_blob(
+                    jpg_bytes,
+                    overwrite=True,
+                    content_settings=ContentSettings(content_type="image/jpeg"),
+                )
+            )
+            return blob_name
+
         if account_url:
             from azure.identity import DefaultAzureCredential
 
             client = BlobServiceClient(account_url=account_url, credential=DefaultAzureCredential())
             blob_client = client.get_blob_client(_EVIDENCE_CONTAINER, blob_name)
-            blob_client.upload_blob(
-                jpg_bytes,
-                overwrite=True,
-                content_settings=ContentSettings(content_type="image/jpeg"),
-            )
-            return blob_name
+            return _upload_blob(blob_client)
 
         if connection_string:
             client = BlobServiceClient.from_connection_string(connection_string)
             blob_client = client.get_blob_client(_EVIDENCE_CONTAINER, blob_name)
-            blob_client.upload_blob(
-                jpg_bytes,
-                overwrite=True,
-                content_settings=ContentSettings(content_type="image/jpeg"),
-            )
-            return blob_name
+            return _upload_blob(blob_client)
 
         base = os.environ.get("EXPORTS_BASE_PATH", DEFAULT_EXPORT_BASE_PATH)
         local_path = os.path.join(base, job_id, "frames", f"frame_{frame_index:04d}.jpg")
-        os.makedirs(os.path.dirname(local_path), exist_ok=True)
-        with open(local_path, "wb") as handle:
-            handle.write(jpg_bytes)
-        return local_path
+
+        def _write_local() -> str:
+            os.makedirs(os.path.dirname(local_path), exist_ok=True)
+            with open(local_path, "wb") as handle:
+                handle.write(jpg_bytes)
+            return local_path
+
+        return _run_with_retries(_write_local)
     except Exception as exc:
         logger.warning("Frame upload failed for job %s frame %d: %s", job_id, frame_index, exc)
         return None

--- a/backend/app/workers/cleanup.py
+++ b/backend/app/workers/cleanup.py
@@ -60,6 +60,7 @@ class CleanupWorker:
                 logger.info("Purged data for job %s", job_id)
             except Exception as exc:
                 logger.error("Failed to purge job %s: %s", job_id, exc, exc_info=True)
+                # Keep cleanup_pending=True so the next cleanup pass can retry the purge.
                 try:
                     self.repo.append_job_event(job_id, "cleanup_failed", {"phase": "purge", "message": str(exc)})
                 except Exception:

--- a/backend/app/workers/runner.py
+++ b/backend/app/workers/runner.py
@@ -313,16 +313,41 @@ def _connection_backoff_seconds(consecutive_errors: int) -> float:
     return base + random.uniform(0.0, 1.0)
 
 
+def _receive_wait_seconds() -> int:
+    value = os.environ.get("PFCD_WORKER_RECEIVE_WAIT_SECONDS", "5").strip()
+    if value.isdigit():
+        return max(1, min(int(value), 30))
+    return 5
+
+
+def _idle_backoff_seconds(consecutive_empty_receives: int) -> float:
+    if consecutive_empty_receives <= 0:
+        return 0.0
+    base_value = os.environ.get("PFCD_WORKER_IDLE_BACKOFF_BASE_SECONDS", "0.5").strip()
+    max_value = os.environ.get("PFCD_WORKER_IDLE_BACKOFF_MAX_SECONDS", "5.0").strip()
+    try:
+        base = max(0.0, float(base_value))
+    except ValueError:
+        base = 0.5
+    try:
+        max_backoff = max(base, float(max_value))
+    except ValueError:
+        max_backoff = 5.0
+    return min(max_backoff, base * float(2 ** (consecutive_empty_receives - 1)))
+
+
 def run() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
     _health_server = _maybe_start_health_server()
     phase = _resolve_phase()
+    receive_wait_seconds = _receive_wait_seconds()
     logger.info(
-        "Worker runtime OpenAI config: role=%s endpoint=%s chat_deployment=%s api_version=%s",
+        "Worker runtime OpenAI config: role=%s endpoint=%s chat_deployment=%s api_version=%s receive_wait=%ss",
         phase,
         os.environ.get("AZURE_OPENAI_ENDPOINT"),
         os.environ.get("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"),
         os.environ.get("AZURE_OPENAI_API_VERSION"),
+        receive_wait_seconds,
     )
     worker = Worker(phase)
     if not worker.orchestrator.enabled:
@@ -331,7 +356,7 @@ def run() -> None:
     consecutive_connection_errors = 0
     while True:
         try:
-            with worker.orchestrator.receive(phase) as receiver:
+            with worker.orchestrator.receive(phase, max_wait_time=receive_wait_seconds) as receiver:
                 if receiver is None:
                     raise RuntimeError("Service Bus receiver not initialized.")
                 if consecutive_connection_errors > 0:
@@ -342,9 +367,13 @@ def run() -> None:
                     )
                 consecutive_connection_errors = 0
                 logger.info("Worker listening on phase %s", phase)
+                consecutive_empty_receives = 0
                 while True:
                     try:
-                        messages = receiver.receive_messages(max_message_count=1, max_wait_time=5)
+                        messages = receiver.receive_messages(
+                            max_message_count=1,
+                            max_wait_time=receive_wait_seconds,
+                        )
                     except SBConnectionError as exc:
                         consecutive_connection_errors += 1
                         delay = _connection_backoff_seconds(consecutive_connection_errors)
@@ -358,6 +387,13 @@ def run() -> None:
                         )
                         time.sleep(delay)
                         break
+                    if not messages:
+                        consecutive_empty_receives += 1
+                        delay = _idle_backoff_seconds(consecutive_empty_receives)
+                        if delay > 0:
+                            time.sleep(delay)
+                        continue
+                    consecutive_empty_receives = 0
                     for message in messages:
                         try:
                             body = _read_message_body(message.body)
@@ -369,7 +405,6 @@ def run() -> None:
                         except Exception as exc:
                             logger.error("Unhandled error processing message; abandoning: %s", exc, exc_info=True)
                             receiver.abandon_message(message)
-                    time.sleep(0.5)
         except SBConnectionError as exc:
             consecutive_connection_errors += 1
             delay = _connection_backoff_seconds(consecutive_connection_errors)

--- a/tests/integration/test_error_cases.py
+++ b/tests/integration/test_error_cases.py
@@ -103,6 +103,28 @@ def test_finalize_on_missing_job_returns_404(app_client):
     assert resp.status_code == 404
 
 
+def test_finalize_export_failure_marks_job_failed(app_client, monkeypatch):
+    job_id = _create_queued(app_client.client)
+    _simulate(app_client.client, job_id)
+    save_resp = app_client.client.put(
+        f"/api/jobs/{job_id}/draft",
+        json={"assumptions": ["Saved before finalize failure test"], "draft_version": 1},
+    )
+    assert save_resp.status_code == 200
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("pdf export broke")
+
+    monkeypatch.setattr(app_client.module, "build_export_pdf", _boom)
+
+    resp = app_client.client.post(f"/api/jobs/{job_id}/finalize")
+    assert resp.status_code == 500
+
+    job = app_client.repo.get_job(job_id)
+    assert job["status"] == "failed"
+    assert job["error"] == {"message": "pdf export broke", "phase": "finalize"}
+
+
 # ---------------------------------------------------------------------------
 # Export guard conditions
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -166,3 +166,22 @@ def test_full_cleanup_cycle(tmp_path, monkeypatch):
         ).fetchall()
     event_types = [r[0] for r in rows]
     assert event_types == ["cleanup_completed"]
+
+
+def test_cleanup_storage_failure_leaves_cleanup_pending(tmp_path, monkeypatch):
+    repository = _make_repo(tmp_path, monkeypatch)
+
+    import importlib
+    import app.workers.cleanup as cleanup_mod
+    importlib.reload(cleanup_mod)
+
+    mock_storage = MagicMock()
+    mock_storage.delete_job_exports.side_effect = RuntimeError("blob delete failed")
+    worker = cleanup_mod.CleanupWorker(repo=repository, storage=mock_storage)
+
+    job_id = _create_job(repository, cleanup_pending=True, status="expired")
+
+    worker.purge_pending_jobs()
+
+    job = repository.get_job(job_id)
+    assert job["cleanup_pending"] is True

--- a/tests/unit/test_frame_persist.py
+++ b/tests/unit/test_frame_persist.py
@@ -44,6 +44,39 @@ def test_upload_frame_returns_none_on_exception(monkeypatch, tmp_path):
     assert upload_frame("job-1", 0, b"JPEG") is None
 
 
+def test_upload_frame_retries_transient_blob_errors(monkeypatch):
+    from azure.core.exceptions import ServiceRequestError
+
+    from app.storage import upload_frame
+
+    monkeypatch.delenv("AZURE_STORAGE_ACCOUNT_URL", raising=False)
+    monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", "UseDevelopmentStorage=true")
+    monkeypatch.delenv("AZURE_STORAGE_ACCOUNT_NAME", raising=False)
+
+    upload_attempts = []
+
+    class _FakeBlobClient:
+        def upload_blob(self, *_args, **_kwargs):
+            upload_attempts.append(True)
+            if len(upload_attempts) < 3:
+                raise ServiceRequestError("transient failure")
+
+    class _FakeServiceClient:
+        def get_blob_client(self, _container, _blob_name):
+            return _FakeBlobClient()
+
+    monkeypatch.setattr(
+        "app.storage.BlobServiceClient.from_connection_string",
+        lambda _conn: _FakeServiceClient(),
+    )
+    monkeypatch.setattr("app.storage.time.sleep", lambda _seconds: None)
+
+    blob_name = upload_frame("job-1", 7, b"JPEG")
+
+    assert blob_name == "job-1/frames/frame_0007.jpg"
+    assert len(upload_attempts) == 3
+
+
 def test_video_adapter_sets_frame_storage_keys_in_metadata(monkeypatch):
     from app.agents.adapters.video import VideoAdapter
 

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -236,6 +236,47 @@ def test_worker_duplicate_message_skipped(tmp_path, monkeypatch):
     assert not run_phase_called, "Duplicate message should have been skipped"
 
 
+def test_retry_attempts_keep_same_payload_hash():
+    from app.servicebus import build_message
+
+    trace_id = str(uuid4())
+    first = build_message("job-1", "extracting", 0, requested_by="test", trace_id=trace_id)
+    retry = build_message("job-1", "extracting", 1, requested_by="test", trace_id=trace_id)
+
+    assert first["payload_hash"] == retry["payload_hash"]
+
+
+def test_worker_skips_retry_message_when_only_attempt_differs(tmp_path, monkeypatch):
+    db_path = tmp_path / "worker-retry-dedup.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    _, repo_mod = _reload_modules()
+    from app.servicebus import build_message
+    from app.workers.runner import Worker
+
+    repository = repo_mod.JobRepository.from_env()
+    repository.init_db()
+
+    job = _make_job()
+    job_id = job["job_id"]
+    trace_id = str(uuid4())
+    first = build_message(job_id, "extracting", attempt=0, requested_by="test", trace_id=trace_id)
+    retry = build_message(job_id, "extracting", attempt=1, requested_by="test", trace_id=trace_id)
+    job["last_completed_phase"] = "extracting"
+    job["payload_hash"] = first["payload_hash"]
+    repository.upsert_job(job_id, job)
+
+    worker = Worker("extracting")
+    worker.repo = repository
+    worker.orchestrator = MagicMock()
+
+    run_phase_called = []
+    with patch.object(worker, "_run_phase", side_effect=lambda *a: run_phase_called.append(True)):
+        worker.handle_message(MagicMock(), retry)
+
+    assert not run_phase_called, "Retry variant of an already-processed message should be skipped"
+
+
 def test_worker_skips_out_of_order_earlier_phase(tmp_path, monkeypatch):
     """If a later phase is already completed, earlier-phase messages are skipped."""
     db_path = tmp_path / "worker-out-of-order.db"
@@ -363,6 +404,67 @@ def test_run_recreates_receiver_after_servicebus_error(monkeypatch):
     assert fake_orchestrator.receive_calls == 2
 
 
+def test_run_uses_configured_receive_wait_and_idle_backoff(monkeypatch):
+    from app.workers import runner as runner_mod
+
+    monkeypatch.setenv("PFCD_WORKER_ROLE", "processing")
+    monkeypatch.setenv("PFCD_WORKER_RECEIVE_WAIT_SECONDS", "9")
+    monkeypatch.setenv("PFCD_WORKER_IDLE_BACKOFF_BASE_SECONDS", "0.25")
+    monkeypatch.setattr(runner_mod.logging, "basicConfig", lambda **_: None)
+    monkeypatch.setattr(runner_mod, "_maybe_start_health_server", lambda: None)
+
+    sleeps = []
+    monkeypatch.setattr(runner_mod.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    class _FakeReceiver:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def receive_messages(self, **kwargs: Any):
+            self.calls += 1
+            assert kwargs["max_wait_time"] == 9
+            if self.calls == 1:
+                return []
+            raise KeyboardInterrupt()
+
+        def complete_message(self, _message: Any) -> None:
+            raise AssertionError("No messages should be completed in this test")
+
+        def dead_letter_message(self, _message: Any, **__: Any) -> None:
+            raise AssertionError("No messages should be dead-lettered in this test")
+
+        def abandon_message(self, _message: Any) -> None:
+            raise AssertionError("No messages should be abandoned in this test")
+
+    class _FakeOrchestrator:
+        def __init__(self) -> None:
+            self.enabled = True
+            self.waits = []
+            self.receiver = _FakeReceiver()
+
+        @contextmanager
+        def receive(self, _phase: str, max_wait_time: int = 5):
+            self.waits.append(max_wait_time)
+            yield self.receiver
+
+    fake_orchestrator = _FakeOrchestrator()
+
+    class _FakeWorker:
+        def __init__(self, _phase: str) -> None:
+            self.orchestrator = fake_orchestrator
+
+        def handle_message(self, _message: Any, _body: Any) -> None:
+            raise AssertionError("No messages should be handled in this test")
+
+    monkeypatch.setattr(runner_mod, "Worker", _FakeWorker)
+
+    with pytest.raises(KeyboardInterrupt):
+        runner_mod.run()
+
+    assert fake_orchestrator.waits == [9]
+    assert sleeps == [0.25]
+
+
 def test_connection_backoff_seconds_is_bounded(monkeypatch):
     from app.workers.runner import _connection_backoff_seconds
 
@@ -375,6 +477,14 @@ def test_connection_backoff_seconds_is_bounded(monkeypatch):
     assert first == 2.25
     assert second == 4.25
     assert capped == 60.25
+
+
+def test_idle_backoff_seconds_is_bounded():
+    from app.workers import runner as runner_mod
+
+    assert runner_mod._idle_backoff_seconds(0) == 0.0
+    assert runner_mod._idle_backoff_seconds(1) == 0.5
+    assert runner_mod._idle_backoff_seconds(4) == 4.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR resolves the high-severity reliability bugs tracked in #41.

### What changed
- fail finalize cleanly when export generation or export persistence breaks instead of leaving jobs stuck in `FINALIZING`
- make Service Bus retry dedup stable by excluding non-semantic retry fields from the payload hash
- add configurable worker receive wait and bounded idle backoff to reduce hot polling during slow upstream processing
- keep cleanup retryable when storage purge fails and add regression coverage for that path
- retry transient frame upload failures before returning `None`
- add/update regression tests for finalize failure handling, retry dedup, worker backoff behavior, cleanup atomicity, and frame upload retries

### Root cause
- finalize had no exception boundary around export generation/storage writes, so a mid-stream failure stranded job state
- dedup hashed the full message, including `attempt`, which changed on every retry
- the worker loop used a fixed receive/sleep pattern with no operator tuning for empty queues or long-latency workloads
- frame uploads treated transient storage/network failures the same as permanent failures

### Impact
- jobs now fail deterministically with persisted error details when finalize export generation breaks
- duplicate retry deliveries of the same logical message are skipped correctly
- workers back off more cleanly under idle or long-latency conditions
- transient storage blips are less likely to silently drop frame evidence

### Validation
- `pytest tests/unit/test_worker.py tests/unit/test_cleanup.py tests/unit/test_frame_persist.py tests/integration/test_error_cases.py tests/integration/test_lifecycle.py tests/integration/test_exports.py -q`
- Result: `68 passed, 1 warning`

Closes #41