### PR TITLE
fix: resolve issue 42 medium severity bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ build/
 
 # Local export storage
 backend/storage/
+storage/
 
 # Environment files
 .env

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -45,6 +45,7 @@ Shared coordination board. Read and updated by both Claude and Codex at session 
 |----|------|-------------|
 | CRITICAL-GHCO-BUNDLE | Resolve GitHub critical issues #36-#40 on consolidated branch `codex/fix-critical-ghco-issues` | PR #43 |
 | ISSUE-41-HIGH-SEVERITY-BUGS | Resolve GitHub issue #41 high-severity bugs on isolated branch `codex/fix-high-severity-bugs` | PR #45 |
+| ISSUE-42-MEDIUM-SEVERITY | Resolve GitHub issue #42 medium-severity bugs on isolated branch `codex/fix-medium-severity-issues` | PR #46 |
 | ISSUE-19-ACA-INFRA | Provision Azure Container Registry and shared Container Apps environment for GitHub issue #19 | — |
 
 ---

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2336,3 +2336,43 @@ Resolved the five-item high-severity backend reliability bundle on isolated bran
 ### Open follow-up
 
 - The new worker receive/backoff knobs are implemented in code but not yet documented in `REFERENCE.md`; add them if operations wants these surfaced in the environment table.
+
+---
+
+## Section 68: Codex Delivery — GitHub Issue #42 Medium-Severity Reliability and Configuration Fixes (2026-04-19)
+
+Closed the medium-severity backlog from GitHub issue `#42` on an isolated branch with targeted runtime, schema, configuration, and frontend contract hardening.
+
+### Completed
+
+- Added first-class `input_files[].upload_id` resolution in [backend/app/main.py](/Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues/backend/app/main.py) so `POST /api/jobs` can reuse previously uploaded files safely:
+  - resolves `upload_id` to the existing upload path under `UPLOADS_DIR`
+  - rejects missing upload references with `400`
+  - persists resolved `storage_key`, file name, and size metadata for downstream workers
+- Updated [frontend/src/components/CreateJob.jsx](/Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues/frontend/src/components/CreateJob.jsx) to send `upload_id` alongside each uploaded file so the frontend and backend now use the same persisted upload contract.
+- Hardened job payload persistence in [backend/app/job_logic.py](/Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues/backend/app/job_logic.py):
+  - `ttl_expires_at` now respects `PFCD_JOB_TTL_DAYS` instead of a hardcoded seven-day window
+  - transcript loading prefers persisted `storage_key` data instead of reconstructing keys from file names
+  - video manifest entries now retain the original `storage_key`
+- Added the missing TTL cleanup index on `jobs.ttl_expires_at` in [backend/app/models.py](/Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues/backend/app/models.py) and [backend/alembic/versions/20260419_0004_add_jobs_ttl_index.py](/Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues/backend/alembic/versions/20260419_0004_add_jobs_ttl_index.py).
+- Tightened runtime configuration behavior:
+  - [backend/app/main.py](/Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues/backend/app/main.py) now validates `PFCD_CORS_ORIGINS`, warns on insecure HTTP origins outside production, and fails fast on HTTP origins in production
+  - [backend/app/workers/runner.py](/Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues/backend/app/workers/runner.py) now requires `PFCD_WORKER_ROLE` instead of silently defaulting to `extracting`
+  - [frontend/src/api.js](/Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues/frontend/src/api.js) now warns in dev builds that `VITE_API_KEY` is an internal/demo convenience, not a public auth mechanism
+- Added LLM timeout enforcement in [backend/app/agents/extraction.py](/Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues/backend/app/agents/extraction.py) and [backend/app/agents/processing.py](/Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues/backend/app/agents/processing.py):
+  - both phases now respect `PFCD_LLM_TIMEOUT_SECONDS`
+  - stalled model calls fail with explicit timeout errors instead of hanging indefinitely
+- Improved migration visibility in [backend/app/repository.py](/Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues/backend/app/repository.py) by warning when the runtime database revision does not match Alembic head, while preserving the current `create_all()` bootstrap behavior.
+- Updated [REFERENCE.md](/Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues/REFERENCE.md) with the new TTL/timeout/CORS settings, the `upload_id` job contract, and explicit notes that upload endpoints still require platform-side rate limiting on public deployments.
+- Ignored the repo-root `storage/` runtime directory in [.gitignore](/Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues/.gitignore) so local test artefacts do not pollute the branch.
+
+### Validation
+
+- `cd /Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues && pytest tests/unit/test_repository.py tests/unit/test_main_config.py tests/unit/test_job_logic.py tests/unit/test_worker.py tests/unit/test_agents.py tests/integration/test_lifecycle.py -q`
+- `cd /Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues && pytest tests/unit tests/integration -q`
+- `cd /Users/karthicks/kAgents/Projects/PFCD-V2/.worktrees/codex-fix-medium-severity-issues && git diff --check`
+
+### Decisions
+
+- Kept the migration warning in `Repository.init_db()` advisory-only rather than auto-running Alembic, because silently mutating schema state at process start would broaden current deployment behavior.
+- Limited the rate-limiting fix to documentation and operator guidance because this repo still relies on shared/demo API-key semantics and does not yet have an application-layer quota model.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -132,7 +132,10 @@ uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
 | `AZURE_SERVICE_BUS_QUEUE_REVIEWING` | Queue name | `reviewing` |
 | `PFCD_WORKER_ROLE` | Worker phase (`extracting`/`processing`/`reviewing`) | — |
 | `PFCD_CLEANUP_INTERVAL_SECONDS` | Cleanup worker poll interval | `300` |
+| `PFCD_JOB_TTL_DAYS` | Job retention window before expiry/cleanup | `7` |
+| `PFCD_LLM_TIMEOUT_SECONDS` | Max seconds allowed for a single extraction/processing LLM call | `120` |
 | `PFCD_API_KEY` | Static API key for `X-API-Key` header | `""` (auth disabled if unset) |
+| `PFCD_CORS_ORIGINS` | Comma-separated allowed CORS origins | `http://localhost:5173` |
 | `PFCD_PROVIDER` | Chat/transcription provider (`azure_openai` or `openai`) | `azure_openai` |
 | `AZURE_OPENAI_ENDPOINT` | Azure OpenAI REST endpoint | required for agents |
 | `AZURE_OPENAI_CHAT_DEPLOYMENT_NAME` | Chat model deployment name (canonical) | required for agents |
@@ -159,7 +162,11 @@ uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
 | `VITE_API_BASE` | Frontend API origin override | `""` |
 | `VITE_API_KEY` | Client-side API key sent as `X-API-Key` | `""` |
 
+`VITE_API_KEY` / `PFCD_API_KEY` is intended only for internal/demo deployments. The key is embedded in the browser bundle and can be recovered by any user who can load the app. Do not use this pattern for public deployments; place the API behind real authentication or a trusted backend proxy.
+
 **ffmpeg dependency:** `media_preprocessor.py` calls `ffmpeg` via subprocess. Azure App Service (Linux) does not include `ffmpeg` by default. For local dev, install with `brew install ffmpeg` on macOS or `apt install ffmpeg` on Linux. For Azure production, Docker workers with a custom image are required (Phase 5b). When `ffmpeg` is absent, files larger than 24 MB fall back to `[transcription_skipped:file_too_large]`, matching the pre-Phase 5 behavior.
+
+**Upload protection note:** `/api/upload` only enforces the per-file 500 MB limit in application code. For shared or public deployments, configure request rate limiting, body-size caps, and storage/disk quotas at the ingress or platform layer because the backend does not implement per-key quota accounting.
 
 ### Starting Workers (Service Bus Phases)
 
@@ -203,6 +210,8 @@ Base path: `/api`
 | GET | `/api/jobs/{job_id}/exports/{format}` | Export draft (`json`, `markdown`, `pdf`, `docx`) |
 | DELETE | `/api/jobs/{job_id}` | Soft-delete / mark job expired |
 | GET | `/health` | Health check — returns `{"status": "ok"}` (200) or `{"status": "degraded", ...}` (503) with env diagnostics when Azure connections are unavailable |
+
+`POST /api/jobs` accepts additive `input_files[].upload_id` references from `POST /api/upload`. When present, the backend validates that the upload exists before persisting the job and resolves the upload to the internal `storage_key` path used by workers.
 
 ---
 

--- a/backend/alembic/versions/20260420_0005_add_jobs_ttl_index.py
+++ b/backend/alembic/versions/20260420_0005_add_jobs_ttl_index.py
@@ -1,0 +1,23 @@
+"""add ttl_expires_at index on jobs
+
+Revision ID: 20260420_0005
+Revises: 20260419_0004
+Create Date: 2026-04-20 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260420_0005"
+down_revision = "20260419_0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_jobs_ttl_expires_at", "jobs", ["ttl_expires_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_ttl_expires_at", table_name="jobs")

--- a/backend/app/agents/extraction.py
+++ b/backend/app/agents/extraction.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from typing import Any, Dict, List, Tuple
 
 from app.agents.adapters.registry import AdapterRegistry
@@ -97,6 +98,15 @@ async def _call_extraction(deployment: str, system_prompt: str, user_content: st
     )
 
 
+def _llm_timeout_seconds() -> float:
+    raw = os.environ.get("PFCD_LLM_TIMEOUT_SECONDS", "120").strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        return 120.0
+    return max(1.0, value)
+
+
 def _normalize_input(job: Dict[str, Any]) -> Tuple[str, List[Dict[str, Any]]]:
     """
     Use registered adapters to normalize job input into extraction content.
@@ -174,13 +184,20 @@ def run_extraction(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
     deployment = profile_conf.get("model")
     if not deployment:
         raise RuntimeError("profile_conf.model is required for extraction.")
-    raw, pt, ct = asyncio.run(
-        _call_extraction(
-            deployment,
-            _SYSTEM_PROMPT,
-            _USER_PROMPT_TEMPLATE.format(transcript_text=content_text) + _build_speaker_hint(job),
+    timeout_seconds = _llm_timeout_seconds()
+    try:
+        raw, pt, ct = asyncio.run(
+            asyncio.wait_for(
+                _call_extraction(
+                    deployment,
+                    _SYSTEM_PROMPT,
+                    _USER_PROMPT_TEMPLATE.format(transcript_text=content_text) + _build_speaker_hint(job),
+                ),
+                timeout=timeout_seconds,
+            )
         )
-    )
+    except asyncio.TimeoutError as exc:
+        raise RuntimeError(f"Extraction LLM call timed out after {timeout_seconds:.0f}s") from exc
 
     extracted = json.loads(raw)
     job["extracted_evidence"] = extracted

--- a/backend/app/agents/processing.py
+++ b/backend/app/agents/processing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from typing import Any, Dict
 
 from app.job_logic import _utc_now
@@ -133,6 +134,15 @@ async def _call_processing(deployment: str, system_prompt: str, user_content: st
     )
 
 
+def _llm_timeout_seconds() -> float:
+    raw = os.environ.get("PFCD_LLM_TIMEOUT_SECONDS", "120").strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        return 120.0
+    return max(1.0, value)
+
+
 def run_processing(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
     """Call Azure OpenAI to generate PDD + SIPOC from extracted evidence.
 
@@ -159,7 +169,16 @@ def run_processing(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
         sipoc_schema=_SIPOC_SCHEMA,
     )
 
-    raw, pt, ct = asyncio.run(_call_processing(deployment, _SYSTEM_PROMPT, user_prompt))
+    timeout_seconds = _llm_timeout_seconds()
+    try:
+        raw, pt, ct = asyncio.run(
+            asyncio.wait_for(
+                _call_processing(deployment, _SYSTEM_PROMPT, user_prompt),
+                timeout=timeout_seconds,
+            )
+        )
+    except asyncio.TimeoutError as exc:
+        raise RuntimeError(f"Processing LLM call timed out after {timeout_seconds:.0f}s") from exc
     draft = json.loads(raw)
 
     # Ensure required top-level keys are present

--- a/backend/app/job_logic.py
+++ b/backend/app/job_logic.py
@@ -50,6 +50,8 @@ class InputFile(BaseModel):
     file_name: Optional[str] = None
     size_bytes: int = Field(default=0, ge=0)
     mime_type: Optional[str] = None
+    upload_id: Optional[str] = None
+    storage_key: Optional[str] = None
     audio_detected: Optional[bool] = None
     audio_declared: Optional[bool] = None
 
@@ -75,6 +77,15 @@ def _utc_now() -> str:
 
 def _utc_in_days(days: int) -> str:
     return (datetime.now(timezone.utc) + timedelta(days=days)).isoformat()
+
+
+def _job_ttl_days() -> int:
+    raw = os.environ.get("PFCD_JOB_TTL_DAYS", "7").strip()
+    try:
+        days = int(raw)
+    except ValueError:
+        return 7
+    return max(1, days)
 
 
 def _safe_dict(value: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -176,6 +187,10 @@ def default_job_payload(payload: JobCreateRequest) -> Dict[str, Any]:
                     item.source_type == "video" and bool(item.audio_declared)
                     for item in payload.input_files
                 ),
+                "storage_key": next(
+                    (item.storage_key for item in payload.input_files if item.source_type == "video" and item.storage_key),
+                    None,
+                ),
                 "frame_extraction_policy": frame_policy,
             },
             "inputs": [item.model_dump() for item in payload.input_files],
@@ -221,7 +236,7 @@ def default_job_payload(payload: JobCreateRequest) -> Dict[str, Any]:
         "active_agent_run_id": None,
         "deleted_at": None,
         "cleanup_pending": False,
-        "ttl_expires_at": _utc_in_days(7),
+        "ttl_expires_at": _utc_in_days(_job_ttl_days()),
         "error": None,
     }
 
@@ -322,6 +337,13 @@ def apply_cost_tracking_and_cap_warning(job: Dict[str, Any], *, phase: str, cost
 def load_transcript_text(job: Dict[str, Any], storage: Any) -> Optional[str]:
     """Load transcript text from storage. Returns None if no transcript input."""
     for inp in job.get("input_manifest", {}).get("inputs", []):
+        if inp.get("source_type") == "transcript":
+            if inp.get("storage_key"):
+                try:
+                    with open(inp["storage_key"], "rb") as handle:
+                        return handle.read().decode("utf-8")
+                except Exception:
+                    return None
         if inp.get("source_type") == "transcript" and inp.get("file_name"):
             meta = {
                 "location": f"{job['job_id']}/inputs/{inp['file_name']}",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ import logging
 import os
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 from uuid import uuid4
 
 import anyio
@@ -64,7 +65,44 @@ app = FastAPI(
 
 def _cors_origins() -> list[str]:
     raw = os.environ.get("PFCD_CORS_ORIGINS", "http://localhost:5173")
-    return [o.strip() for o in raw.split(",") if o.strip()]
+    env = os.environ.get("PFCD_ENV", "development").strip().lower()
+    origins = [o.strip() for o in raw.split(",") if o.strip()]
+    validated = []
+    for origin in origins:
+        parsed = urlparse(origin)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise RuntimeError(f"Invalid CORS origin: {origin!r}")
+        if parsed.scheme == "http":
+            logger.warning("Configured non-HTTPS CORS origin: %s", origin)
+            if env == "production":
+                raise RuntimeError("HTTPS origins are required for PFCD_CORS_ORIGINS in production.")
+        validated.append(origin)
+    return validated
+
+
+def _resolve_upload_path(upload_id: str, file_name: str | None) -> str:
+    file_part = file_name or "upload"
+    return os.path.join(UPLOADS_DIR, upload_id, file_part)
+
+
+def _resolve_input_files(payload: JobCreateRequest) -> JobCreateRequest:
+    resolved_inputs = []
+    for item in payload.input_files:
+        resolved = item.model_copy(deep=True)
+        if resolved.upload_id:
+            storage_key = _resolve_upload_path(resolved.upload_id, resolved.file_name)
+            if not os.path.isfile(storage_key):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"input_files upload_id {resolved.upload_id!r} does not reference an existing upload.",
+                )
+            resolved.storage_key = storage_key
+            if not resolved.file_name:
+                resolved.file_name = os.path.basename(storage_key)
+            if not resolved.size_bytes:
+                resolved.size_bytes = os.path.getsize(storage_key)
+        resolved_inputs.append(resolved)
+    return payload.model_copy(update={"input_files": resolved_inputs})
 
 
 app.add_middleware(
@@ -191,6 +229,7 @@ async def create_job(payload: JobCreateRequest) -> Dict[str, Any]:
                 "remediation": "Trim/re-encode source media or use segmented upload in a future release.",
             },
         )
+    payload = _resolve_input_files(payload)
     job_id = str(uuid4())
     job = default_job_payload(payload)
     job["job_id"] = job_id

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -10,6 +10,7 @@ Base = declarative_base()
 
 class Job(Base):
     __tablename__ = "jobs"
+    __table_args__ = (Index("ix_jobs_ttl_expires_at", "ttl_expires_at"),)
 
     job_id = Column(String(64), primary_key=True)
     version = Column(Integer, nullable=False, default=1)

--- a/backend/app/repository.py
+++ b/backend/app/repository.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
@@ -16,6 +17,24 @@ from sqlalchemy.orm.exc import StaleDataError
 from app.db import ENGINE, session_scope
 from app.job_logic import JobStatus, _utc_now
 from app.models import AgentRun, Draft, ExportPayload, InputManifest, Job, JobEvent, ReviewNotes
+
+
+def _current_and_head_revisions(engine) -> tuple[str | None, str | None]:
+    try:
+        from alembic.config import Config
+        from alembic.script import ScriptDirectory
+        from alembic.runtime.migration import MigrationContext
+    except Exception:
+        return None, None
+
+    backend_dir = Path(__file__).resolve().parents[1]
+    config = Config(str(backend_dir / "alembic.ini"))
+    config.set_main_option("script_location", str(backend_dir / "alembic"))
+    script = ScriptDirectory.from_config(config)
+
+    with engine.connect() as connection:
+        current_revision = MigrationContext.configure(connection).get_current_revision()
+    return current_revision, script.get_current_head()
 
 
 class ConcurrentModificationError(RuntimeError):
@@ -34,6 +53,13 @@ class JobRepository:
         from app.models import Base
 
         Base.metadata.create_all(self.engine)
+        current_revision, head_revision = _current_and_head_revisions(self.engine)
+        if head_revision and current_revision != head_revision:
+            logger.warning(
+                "Database revision is %s while Alembic head is %s. Run `alembic upgrade head` to align the schema.",
+                current_revision or "<none>",
+                head_revision,
+            )
 
     def _serialize(self, payload: Dict[str, Any]) -> str:
         return json.dumps(payload, ensure_ascii=True, separators=(",", ":"))

--- a/backend/app/workers/runner.py
+++ b/backend/app/workers/runner.py
@@ -271,9 +271,9 @@ class Worker:
 
 def _resolve_phase() -> str:
     role = os.environ.get("PFCD_WORKER_ROLE", "").strip().lower()
-    if role:
-        return role
-    return "extracting"
+    if not role:
+        raise RuntimeError("PFCD_WORKER_ROLE environment variable is required")
+    return role
 
 
 def _start_health_server(port: int) -> HTTPServer:

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,12 @@
 const BASE = (import.meta.env.VITE_API_BASE ?? '') + '/api'
 const DEV_BASE = import.meta.env.VITE_API_BASE ?? ''
 
+if (import.meta.env.DEV && import.meta.env.VITE_API_KEY) {
+  console.warn(
+    'VITE_API_KEY is embedded in the client bundle for internal/demo use only. Do not use this pattern for public deployments.'
+  )
+}
+
 function authHeaders(headers = {}) {
   return {
     ...(import.meta.env.VITE_API_KEY ? { 'X-API-Key': import.meta.env.VITE_API_KEY } : {}),

--- a/frontend/src/components/CreateJob.jsx
+++ b/frontend/src/components/CreateJob.jsx
@@ -80,6 +80,7 @@ export default function CreateJob({ onCreated }) {
           file_name: u.file_name,
           size_bytes: u.size_bytes,
           mime_type: u.mime_type,
+          upload_id: u.upload_id,
         })),
       })
       onCreated(data.job_id)

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -48,6 +48,22 @@ def test_create_job_rejects_oversized_file(app_client):
     assert resp.status_code == 413
 
 
+def test_create_job_rejects_missing_upload_id(app_client):
+    payload = {
+        "input_files": [
+            {
+                "source_type": "transcript",
+                "file_name": "t.vtt",
+                "size_bytes": 512,
+                "upload_id": "missing-upload-id",
+            }
+        ]
+    }
+    resp = app_client.client.post("/api/jobs", json=payload)
+    assert resp.status_code == 400
+    assert "upload_id" in resp.text
+
+
 def test_get_job_returns_queued_state(app_client):
     payload = {
         "input_files": [
@@ -60,6 +76,31 @@ def test_get_job_returns_queued_state(app_client):
     resp = app_client.client.get(f"/api/jobs/{job_id}")
     assert resp.status_code == 200
     assert resp.json()["status"] == "queued"
+
+
+def test_create_job_accepts_existing_upload_id(app_client):
+    upload_resp = app_client.client.post(
+        "/api/upload",
+        files={"file": ("t.vtt", b"WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhello", "text/vtt")},
+    )
+    assert upload_resp.status_code == 201
+    upload = upload_resp.json()
+
+    payload = {
+        "input_files": [
+            {
+                "source_type": "transcript",
+                "file_name": upload["file_name"],
+                "size_bytes": upload["size_bytes"],
+                "mime_type": upload["mime_type"],
+                "upload_id": upload["upload_id"],
+            }
+        ]
+    }
+    resp = app_client.client.post("/api/jobs", json=payload)
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["input_manifest"]["inputs"][0]["upload_id"] == upload["upload_id"]
 
 
 def test_get_missing_job_returns_404(app_client):

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -12,6 +12,8 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
 from uuid import uuid4
 
+import pytest
+
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 BACKEND = ROOT / "backend"
 FIXTURES = ROOT / "tests" / "fixtures"
@@ -139,6 +141,24 @@ def test_extraction_usage_tokens_supports_object_usage():
     assert completion_tokens == 45
 
 
+def test_extraction_times_out_long_llm_call(monkeypatch):
+    import asyncio
+
+    from app.agents.extraction import run_extraction
+
+    job = _make_job()
+    job["_transcript_text_inline"] = "some transcript text"
+
+    async def _never_returns(*_args, **_kwargs):
+        await asyncio.sleep(10)
+
+    monkeypatch.setenv("PFCD_LLM_TIMEOUT_SECONDS", "0.01")
+
+    with patch("app.agents.extraction._call_extraction", side_effect=_never_returns):
+        with pytest.raises(RuntimeError, match="timed out"):
+            run_extraction(job, _balanced_profile())
+
+
 def test_processing_usage_tokens_supports_dict_usage():
     from app.agents.processing import _extract_usage_tokens
 
@@ -157,6 +177,29 @@ def test_processing_usage_tokens_defaults_to_zero_when_missing():
 
     assert prompt_tokens == 0
     assert completion_tokens == 0
+
+
+def test_processing_times_out_long_llm_call(monkeypatch):
+    import asyncio
+
+    from app.agents.processing import run_processing
+
+    job = _make_job()
+    job["extracted_evidence"] = {
+        "evidence_items": [],
+        "speakers_detected": [],
+        "process_domain": "test",
+        "transcript_quality": "low",
+    }
+
+    async def _never_returns(*_args, **_kwargs):
+        await asyncio.sleep(10)
+
+    monkeypatch.setenv("PFCD_LLM_TIMEOUT_SECONDS", "0.01")
+
+    with patch("app.agents.processing._call_processing", side_effect=_never_returns):
+        with pytest.raises(RuntimeError, match="timed out"):
+            run_processing(job, _balanced_profile())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_job_logic.py
+++ b/tests/unit/test_job_logic.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
 
 from app.job_logic import (
@@ -141,3 +143,20 @@ def test_cost_cap_warning_is_not_duplicated(monkeypatch):
     warnings = [f for f in job["review_notes"]["flags"] if f.get("code") == "cost_cap_exceeded"]
     assert len(warnings) == 1
     assert job["agent_signals"]["cost_tracking"]["total_estimated_usd"] == pytest.approx(6.0)
+
+
+def test_default_job_payload_uses_ttl_env_override(monkeypatch):
+    monkeypatch.setenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME", "test-deployment")
+    monkeypatch.setenv("PFCD_JOB_TTL_DAYS", "14")
+
+    job = default_job_payload(
+        JobCreateRequest(
+            profile=Profile.BALANCED,
+            input_files=[InputFile(source_type="video", size_bytes=100)],
+        )
+    )
+
+    ttl_dt = datetime.fromisoformat(job["ttl_expires_at"])
+    delta_days = (ttl_dt - datetime.now(timezone.utc)).total_seconds() / 86400
+
+    assert 13.9 <= delta_days <= 14.1

--- a/tests/unit/test_main_config.py
+++ b/tests/unit/test_main_config.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+BACKEND = ROOT / "backend"
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+
+def test_cors_origins_warns_for_http_in_non_production(monkeypatch, caplog):
+    from app import main as main_mod
+
+    monkeypatch.setenv("PFCD_ENV", "development")
+    monkeypatch.setenv("PFCD_CORS_ORIGINS", "http://localhost:5173")
+
+    with caplog.at_level("WARNING"):
+        origins = main_mod._cors_origins()
+
+    assert origins == ["http://localhost:5173"]
+    assert "non-HTTPS" in caplog.text
+
+
+def test_cors_origins_rejects_http_in_production(monkeypatch):
+    from app import main as main_mod
+
+    monkeypatch.setenv("PFCD_ENV", "production")
+    monkeypatch.setenv("PFCD_CORS_ORIGINS", "http://example.com")
+
+    with pytest.raises(RuntimeError, match="HTTPS"):
+        main_mod._cors_origins()
+
+
+def test_cors_origins_accepts_https_in_production(monkeypatch):
+    from app import main as main_mod
+
+    monkeypatch.setenv("PFCD_ENV", "production")
+    monkeypatch.setenv("PFCD_CORS_ORIGINS", "https://example.com")
+
+    assert main_mod._cors_origins() == ["https://example.com"]

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -3,6 +3,8 @@ import pathlib
 import sys
 from uuid import uuid4
 
+import pytest
+
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 BACKEND = ROOT / "backend"
 sys.path.append(str(BACKEND))
@@ -101,3 +103,26 @@ def test_job_upsert_rejects_stale_version(tmp_path, monkeypatch):
         assert False, "Expected stale write to fail"
     except repo.ConcurrentModificationError:
         pass
+
+
+def test_jobs_table_declares_ttl_index():
+    from app.models import Job
+
+    index_names = {index.name for index in Job.__table__.indexes}
+
+    assert "ix_jobs_ttl_expires_at" in index_names
+
+
+def test_init_db_warns_when_alembic_revision_mismatch(tmp_path, monkeypatch, caplog):
+    db_path = tmp_path / "pfcd-mismatch.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    _, repo = _reload_modules()
+
+    repository = repo.JobRepository.from_env()
+    monkeypatch.setattr(repo, "_current_and_head_revisions", lambda _engine: (None, "20260419_0004"))
+
+    with caplog.at_level("WARNING"):
+        repository.init_db()
+
+    assert "Alembic head" in caplog.text

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -348,6 +348,15 @@ def test_maybe_start_health_server_skips_without_websites_port(monkeypatch):
     assert runner_mod._maybe_start_health_server() is None
 
 
+def test_resolve_phase_requires_worker_role(monkeypatch):
+    from app.workers import runner as runner_mod
+
+    monkeypatch.delenv("PFCD_WORKER_ROLE", raising=False)
+
+    with pytest.raises(RuntimeError, match="PFCD_WORKER_ROLE"):
+        runner_mod._resolve_phase()
+
+
 def test_run_recreates_receiver_after_servicebus_error(monkeypatch):
     """run() should recreate the receiver after Service Bus connection failures."""
     from app.workers import runner as runner_mod


### PR DESCRIPTION
## Summary
- resolve issue #42 medium-severity reliability and configuration bugs
- add `input_files[].upload_id` resolution plus persisted `storage_key` handling
- make TTL, CORS validation, worker role selection, and LLM timeouts configurable and fail-fast
- add the missing `jobs.ttl_expires_at` index and migration warning coverage
- update frontend upload payloads, docs, and regression tests

## Validation
- `pytest tests/unit tests/integration -q`
- `git diff --check`

Closes #42.