### PR TITLE
fix: align extraction/processing prompts with PRD and add deployed-model live test

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -43,6 +43,7 @@ Shared coordination board. Read and updated by both Claude and Codex at session 
 
 | ID | Task | PR / Commit |
 |----|------|-------------|
+| ISSUE-48-PROMPT-ALIGNMENT | Resolve GitHub issue #48 prompt alignment gaps for extraction/processing + tests | Pending PR (branch: `codex/issue-48-prompt-alignment`) |
 | INVENTORY-PENDING-PROMPTS | Produce consolidated repo+runtime pending issues inventory and current automation prompt catalog | — |
 | CRITICAL-GHCO-BUNDLE | Resolve GitHub critical issues #36-#40 on consolidated branch `codex/fix-critical-ghco-issues` | PR #43 |
 | ISSUE-41-HIGH-SEVERITY-BUGS | Resolve GitHub issue #41 high-severity bugs on isolated branch `codex/fix-high-severity-bugs` | PR #45 |

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -43,7 +43,7 @@ Shared coordination board. Read and updated by both Claude and Codex at session 
 
 | ID | Task | PR / Commit |
 |----|------|-------------|
-| ISSUE-48-PROMPT-ALIGNMENT | Resolve GitHub issue #48 prompt alignment gaps for extraction/processing + tests | Pending PR (branch: `codex/issue-48-prompt-alignment`) |
+| ISSUE-48-PROMPT-ALIGNMENT | Resolve GitHub issue #48 prompt alignment gaps for extraction/processing + tests | PR #49 |
 | INVENTORY-PENDING-PROMPTS | Produce consolidated repo+runtime pending issues inventory and current automation prompt catalog | — |
 | CRITICAL-GHCO-BUNDLE | Resolve GitHub critical issues #36-#40 on consolidated branch `codex/fix-critical-ghco-issues` | PR #43 |
 | ISSUE-41-HIGH-SEVERITY-BUGS | Resolve GitHub issue #41 high-severity bugs on isolated branch `codex/fix-high-severity-bugs` | PR #45 |

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2401,3 +2401,51 @@ Delivered a consolidated inventory document covering both repo-documented pendin
 ### Open questions / follow-up
 
 - If required for governance, split the single combined inventory into two files (`pending-issues.md` and `automation-prompts.md`) and add ownership metadata per issue row.
+
+---
+
+## Section 70: Codex Delivery — GitHub Issue #48 Prompt Alignment + Deployed-Model Live Test (2026-04-20)
+
+Implemented the issue #48 prompt contract updates for extraction/processing and added an opt-in live integration test path that executes against configured deployed models.
+
+### Completed
+
+- Updated [backend/app/agents/extraction.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/agents/extraction.py):
+  - system prompt is now explicitly media-first (`video/audio primary`, transcript supportive)
+  - evidence schema now requires `source_type: video|audio|transcript|frame`
+  - speaker default now uses `Unknown Speaker`
+  - added explicit rules for transcript-noise filtering and adjacent-step collapse
+- Updated [backend/app/agents/processing.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/agents/processing.py):
+  - prompt now receives `alignment_verdict`
+  - added evidence-priority and mismatch-downgrade rules
+  - added profile-conditional guidance (`balanced` concise vs `quality` thorough)
+  - added `confidence_summary.confidence_delta` to schema and defaulting logic
+- Extended [tests/unit/test_agents.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/unit/test_agents.py):
+  - assertions for extraction prompt contract and processing prompt contract
+  - assertions for alignment verdict wiring into runtime prompt
+  - assertions for profile-guidance injection and confidence_delta defaults
+  - removed hardcoded model literals from test profile fixtures; fixtures now read deployment names from env when present
+- Added [tests/integration/test_deployed_models_live.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/integration/test_deployed_models_live.py):
+  - opt-in live extraction+processing test against deployed models
+  - gated behind `PFCD_RUN_DEPLOYED_MODEL_TESTS=1`
+  - skips with explicit reason when provider env is not configured
+
+### Validation
+
+- `pytest -q tests/unit/test_agents.py`
+  - `54 passed`
+- `pytest -q tests/unit`
+  - `260 passed`
+- `pytest -q tests/unit/test_agents.py tests/integration/test_deployed_models_live.py`
+  - `54 passed, 1 skipped`
+- `PFCD_RUN_DEPLOYED_MODEL_TESTS=1 PYTHONPATH=backend pytest -rs tests/integration/test_deployed_models_live.py`
+  - skipped due to missing provider/deployment env in current shell
+
+### Decisions
+
+- Kept unit tests deterministic and fast; deployed-model execution is explicit and opt-in via env flag to avoid CI/network fragility.
+- Pulled model names in tests from environment-backed deployment variables to avoid embedding stale model literals in fixtures.
+
+### Open follow-up
+
+- To run the live test in this environment, set provider credentials/deployment env vars (`PFCD_PROVIDER`, endpoint/key, and balanced deployment name) and rerun the gated integration test.

--- a/backend/app/agents/extraction.py
+++ b/backend/app/agents/extraction.py
@@ -15,8 +15,9 @@ _adapter_registry = AdapterRegistry()
 logger = logging.getLogger(__name__)
 
 _SYSTEM_PROMPT = (
-    "You are a process documentation specialist. Extract structured evidence from this "
-    "business process transcript. Return only valid JSON."
+    "You are a process documentation specialist. Extract structured process evidence from "
+    "business process recordings. Video and audio are the primary sources; transcript is "
+    "a supporting signal. Return only valid JSON."
 )
 
 _USER_PROMPT_TEMPLATE = """\
@@ -33,20 +34,26 @@ Extract all distinct process steps from this transcript. Return a JSON object wi
       "system": "string",
       "input_artifact": "string",
       "output_artifact": "string",
+      "source_type": "video|audio|transcript|frame",
       "anchor": "HH:MM:SS-HH:MM:SS or section label",
       "confidence": 0.0
     }}
   ],
-  "speakers_detected": ["name or Unknown"],
+  "speakers_detected": ["name or Unknown Speaker"],
   "process_domain": "string",
   "transcript_quality": "high|medium|low"
 }}
 
 Rules:
 - id must be sequential: ev-01, ev-02, …
+- each evidence item must represent a distinct process action, not a transcript fragment
+- remove transcript artifacts: VTT cue numbers, timestamps-only lines, facilitator questions,
+  filler phrases, and non-process chitchat
+- collapse adjacent steps with the same actor and substantially the same action into one item
 - anchor must reference a timestamp range or section label from the transcript
+- source_type must be one of video|audio|transcript|frame based on the evidence source
 - confidence is a float between 0.0 and 1.0
-- speakers_detected must list all unique speakers; use "Unknown" if unidentifiable
+- speakers_detected must list all unique speakers; use "Unknown Speaker" if unidentifiable
 """
 
 

--- a/backend/app/agents/processing.py
+++ b/backend/app/agents/processing.py
@@ -66,7 +66,12 @@ Evidence items:
 Input manifest:
 {manifest_json}
 
+Alignment verdict: {alignment_verdict}
+
 Profile: {profile}
+
+Profile guidance:
+{profile_guidance}
 
 Generate a complete PDD and SIPOC from the evidence above. Return a JSON object with this exact shape:
 {{
@@ -76,13 +81,21 @@ Generate a complete PDD and SIPOC from the evidence above. Return a JSON object 
   "confidence_summary": {{
     "overall": 0.0,
     "source_quality": "high|medium|low",
-    "evidence_strength": "high|medium|low"
+    "evidence_strength": "high|medium|low",
+    "confidence_delta": 0.0
   }},
   "generated_at": "ISO 8601 UTC timestamp",
   "version": 1
 }}
 
 Rules:
+- Evidence priority: video/audio/frame-derived items (source_type video|audio|frame)
+  take precedence over transcript-derived items (source_type transcript) for step sequence.
+- If alignment_verdict is "suspected_mismatch", downgrade confidence on transcript-only
+  inferences and avoid using transcript-only claims as primary sequencing evidence.
+- Use conservative language: do not invent roles, systems, or business rules not supported by evidence.
+- If evidence is sparse or transcript-only, still produce best-effort structure and list explicit
+  assumptions in assumptions[] instead of fabricating detail.
 - Every evidence item must map to at least one PDD step
 - Every PDD step must appear in at least one SIPOC row
 - step_anchor MUST be a non-empty JSON array with at least one PDD step ID from the steps list above (e.g. ["step-01"]). Never leave step_anchor as [] or null.
@@ -90,7 +103,21 @@ Rules:
 - If the closest available anchor is approximate, still use it and explain in anchor_missing_reason. Do not leave source_anchor blank as a way of signalling uncertainty.
 - anchor_missing_reason must be null when both anchors are present; a short explanation string when source_anchor is approximate or step_anchor coverage is partial.
 - confidence values are floats between 0.0 and 1.0
+- confidence_delta is the change from baseline confidence (negative: reduced confidence,
+  positive: corroborating evidence increased confidence).
 """
+
+
+def _profile_guidance(profile: str) -> str:
+    if profile == "quality":
+        return (
+            "- Be thorough. Include observable sub-steps, exceptions, and system interactions.\n"
+            "- Capture nuance when evidence supports it, while preserving schema precision."
+        )
+    return (
+        "- Be concise. Prefer fewer, higher-confidence steps.\n"
+        "- Avoid speculative detail when evidence is ambiguous."
+    )
 
 
 def _safe_int(value: Any) -> int:
@@ -161,6 +188,9 @@ def run_processing(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
     evidence = job.get("extracted_evidence") or {}
     manifest = job.get("input_manifest") or {}
     profile = profile_conf.get("profile", "balanced")
+    alignment_verdict = (
+        job.get("transcript_media_consistency", {}).get("verdict") or "inconclusive"
+    )
     deployment = profile_conf.get("model")
     if not deployment:
         raise RuntimeError("profile_conf.model is required for processing.")
@@ -174,7 +204,9 @@ def run_processing(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
     user_prompt = _USER_PROMPT_TEMPLATE.format(
         evidence_json=json.dumps(evidence, ensure_ascii=True, separators=(",", ":")),
         manifest_json=json.dumps(manifest, ensure_ascii=True, separators=(",", ":")),
+        alignment_verdict=alignment_verdict,
         profile=profile,
+        profile_guidance=_profile_guidance(profile),
         pdd_schema=_PDD_SCHEMA,
         sipoc_schema=_SIPOC_SCHEMA,
     )
@@ -199,7 +231,9 @@ def run_processing(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
         "overall": 0.65,
         "source_quality": "medium",
         "evidence_strength": job.get("agent_signals", {}).get("evidence_strength"),  # overwritten by reviewer
+        "confidence_delta": 0.0,
     })
+    draft["confidence_summary"].setdefault("confidence_delta", 0.0)
 
     job["draft"] = draft
     from app.job_logic import estimate_cost_usd

--- a/tests/integration/test_deployed_models_live.py
+++ b/tests/integration/test_deployed_models_live.py
@@ -1,0 +1,80 @@
+"""Optional live test against deployed LLM models.
+
+Run explicitly with:
+  PFCD_RUN_DEPLOYED_MODEL_TESTS=1 PYTHONPATH=backend pytest -q tests/integration/test_deployed_models_live.py
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Any
+from uuid import uuid4
+
+import pytest
+
+
+def _provider() -> str:
+    return (os.environ.get("PFCD_PROVIDER", "azure_openai").strip().lower() or "azure_openai")
+
+
+def _live_env_ready() -> bool:
+    provider = _provider()
+    if provider == "openai":
+        return bool(os.environ.get("OPENAI_API_KEY"))
+    return bool(
+        os.environ.get("AZURE_OPENAI_ENDPOINT")
+        and (
+            os.environ.get("AZURE_OPENAI_DEPLOYMENT_BALANCED")
+            or os.environ.get("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME")
+        )
+    )
+
+
+def _make_live_job() -> Dict[str, Any]:
+    from app.job_logic import InputFile, JobCreateRequest, default_job_payload
+
+    req = JobCreateRequest(
+        profile="balanced",
+        input_files=[InputFile(source_type="transcript", size_bytes=100)],
+    )
+    job = default_job_payload(req)
+    job["job_id"] = str(uuid4())
+    job["_transcript_text_inline"] = (
+        "[00:00:01-00:00:08] Analyst opens ticketing portal and reviews pending requests.\n"
+        "[00:00:09-00:00:18] Analyst validates customer details and categorizes the issue.\n"
+        "[00:00:19-00:00:31] Analyst updates status, assigns owner, and sends acknowledgement email."
+    )
+    return job
+
+
+@pytest.mark.skipif(
+    os.environ.get("PFCD_RUN_DEPLOYED_MODEL_TESTS") != "1",
+    reason="Set PFCD_RUN_DEPLOYED_MODEL_TESTS=1 to run deployed-model live tests.",
+)
+def test_live_extraction_and_processing_on_deployed_models():
+    if not _live_env_ready():
+        pytest.skip("Live deployed-model test skipped: provider environment is not configured.")
+
+    from app.agents.extraction import run_extraction
+    from app.agents.processing import run_processing
+
+    model = (
+        os.environ.get("AZURE_OPENAI_DEPLOYMENT_BALANCED")
+        or os.environ.get("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME")
+        or os.environ.get("OPENAI_CHAT_MODEL_BALANCED")
+    )
+    assert model, "No balanced deployment/model configured for live test."
+
+    profile_conf = {"profile": "balanced", "model": model, "cost_cap_usd": 4.0}
+
+    job = _make_live_job()
+    extraction_cost = run_extraction(job, profile_conf)
+    assert extraction_cost >= 0.0
+    assert job.get("extracted_evidence", {}).get("evidence_items"), "No evidence extracted by deployed model."
+
+    processing_cost = run_processing(job, profile_conf)
+    assert processing_cost >= 0.0
+    draft = job.get("draft") or {}
+    assert "pdd" in draft
+    assert isinstance(draft.get("sipoc"), list)
+    assert "confidence_summary" in draft

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -59,7 +59,21 @@ def _make_job(
 
 
 def _balanced_profile() -> Dict[str, Any]:
-    return {"profile": "balanced", "model": "gpt-4o-mini", "cost_cap_usd": 4.0}
+    model = (
+        os.environ.get("AZURE_OPENAI_DEPLOYMENT_BALANCED")
+        or os.environ.get("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME")
+        or "test-deployment"
+    )
+    return {"profile": "balanced", "model": model, "cost_cap_usd": 4.0}
+
+
+def _quality_profile() -> Dict[str, Any]:
+    model = (
+        os.environ.get("AZURE_OPENAI_DEPLOYMENT_QUALITY")
+        or os.environ.get("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME")
+        or "test-deployment"
+    )
+    return {"profile": "quality", "model": model, "cost_cap_usd": 8.0}
 
 
 def _async_sk_response(content: str, prompt_tokens: int = 100, completion_tokens: int = 200):
@@ -196,6 +210,21 @@ def test_extraction_times_out_long_llm_call(monkeypatch):
             run_extraction(job, _balanced_profile())
 
 
+def test_extraction_prompt_contract_is_media_first():
+    from app.agents import extraction
+
+    system_prompt = extraction._SYSTEM_PROMPT
+    user_prompt = extraction._USER_PROMPT_TEMPLATE
+
+    assert "Video and audio are the primary sources" in system_prompt
+    assert "supporting signal" in system_prompt
+    assert "source_type" in user_prompt
+    assert "video|audio|transcript|frame" in user_prompt
+    assert "Unknown Speaker" in user_prompt
+    assert "Remove transcript artifacts".lower() in user_prompt.lower()
+    assert "collapse adjacent steps" in user_prompt.lower()
+
+
 def test_processing_usage_tokens_supports_dict_usage():
     from app.agents.processing import _extract_usage_tokens
 
@@ -299,6 +328,72 @@ def test_processing_agent_sets_defaults_on_minimal_response(monkeypatch):
     assert job["draft"]["version"] == 1
     assert "generated_at" in job["draft"]
     assert "confidence_summary" in job["draft"]
+    assert "confidence_delta" in job["draft"]["confidence_summary"]
+
+
+def test_processing_prompt_contract_includes_alignment_and_priority_rules():
+    from app.agents import processing
+
+    user_prompt = processing._USER_PROMPT_TEMPLATE
+    assert "Alignment verdict: {alignment_verdict}" in user_prompt
+    assert "Evidence priority: video/audio/frame-derived items" in user_prompt
+    assert 'If alignment_verdict is "suspected_mismatch"' in user_prompt
+    assert '"confidence_delta": 0.0' in user_prompt
+
+
+def test_processing_profile_guidance_balanced_and_quality():
+    from app.agents.processing import _profile_guidance
+
+    assert "Be concise" in _profile_guidance("balanced")
+    assert "Be thorough" in _profile_guidance("quality")
+
+
+def test_processing_passes_alignment_and_profile_guidance_to_prompt():
+    from app.agents.processing import run_processing
+
+    captured: dict[str, str] = {}
+
+    async def _capture_call(_deployment: str, _system_prompt: str, user_content: str):
+        captured["user_content"] = user_content
+        return '{"pdd":{"purpose":"x"},"sipoc":[]}', 10, 10
+
+    job = _make_job(consistency_verdict="suspected_mismatch")
+    job["extracted_evidence"] = {
+        "evidence_items": [],
+        "speakers_detected": [],
+        "process_domain": "test",
+        "transcript_quality": "low",
+    }
+
+    with patch("app.agents.processing._call_processing", side_effect=_capture_call):
+        run_processing(job, _balanced_profile())
+
+    prompt = captured["user_content"]
+    assert "Alignment verdict: suspected_mismatch" in prompt
+    assert "Be concise. Prefer fewer, higher-confidence steps." in prompt
+
+
+def test_processing_uses_quality_profile_guidance():
+    from app.agents.processing import run_processing
+
+    captured: dict[str, str] = {}
+
+    async def _capture_call(_deployment: str, _system_prompt: str, user_content: str):
+        captured["user_content"] = user_content
+        return '{"pdd":{"purpose":"x"},"sipoc":[]}', 10, 10
+
+    job = _make_job()
+    job["extracted_evidence"] = {
+        "evidence_items": [],
+        "speakers_detected": [],
+        "process_domain": "test",
+        "transcript_quality": "low",
+    }
+    with patch("app.agents.processing._call_processing", side_effect=_capture_call):
+        run_processing(job, _quality_profile())
+
+    prompt = captured["user_content"]
+    assert "Be thorough. Include observable sub-steps, exceptions, and system interactions." in prompt
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- align extraction prompt contract with PRD media-first evidence policy
- add source typing, speaker default, and transcript-noise filtering instructions to extraction schema/rules
- align processing prompt with PRD evidence-priority + alignment-verdict behavior, including profile-specific guidance and confidence_delta
- add/extend tests for prompt contracts and runtime prompt wiring
- add an opt-in deployed-model live integration test (`PFCD_RUN_DEPLOYED_MODEL_TESTS=1`)

## Files changed
- `backend/app/agents/extraction.py`
- `backend/app/agents/processing.py`
- `tests/unit/test_agents.py`
- `tests/integration/test_deployed_models_live.py`
- `HANDOVER.md`
- `IMPLEMENTATION_SUMMARY.md`

## Validation
- `pytest -q tests/unit/test_agents.py`
- `pytest -q tests/unit`
- `pytest -q tests/unit/test_agents.py tests/integration/test_deployed_models_live.py`
- `PFCD_RUN_DEPLOYED_MODEL_TESTS=1 PYTHONPATH=backend pytest -rs tests/integration/test_deployed_models_live.py` (skipped in this shell due to missing provider env)

## Notes
- unit tests now resolve model names from deployment env vars instead of hardcoded model literals.
- live deployed-model integration test is explicitly opt-in to keep default CI stable.

Closes #48