### PR TITLE
fix: resolve issue #50 quick-win hardening items

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -27,7 +27,7 @@ Shared coordination board. Read and updated by both Claude and Codex at session 
 
 | ID | Task | Started |
 |----|------|---------|
-| — | | |
+| ISSUE-50-QUICK-WINS | Resolve GitHub issue #50 quick wins (processing JSON fallback, vision max_completion_tokens, REFERENCE/env docs updates) on branch `codex/issue-50-quick-wins` | 2026-04-20 |
 
 ---
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -27,7 +27,7 @@ Shared coordination board. Read and updated by both Claude and Codex at session 
 
 | ID | Task | Started |
 |----|------|---------|
-| ISSUE-50-QUICK-WINS | Resolve GitHub issue #50 quick wins (processing JSON fallback, vision max_completion_tokens, REFERENCE/env docs updates) on branch `codex/issue-50-quick-wins` | 2026-04-20 |
+| — | | |
 
 ---
 
@@ -44,6 +44,7 @@ Shared coordination board. Read and updated by both Claude and Codex at session 
 | ID | Task | PR / Commit |
 |----|------|-------------|
 | ISSUE-48-PROMPT-ALIGNMENT | Resolve GitHub issue #48 prompt alignment gaps for extraction/processing + tests | PR #49 |
+| ISSUE-50-QUICK-WINS | Resolve GitHub issue #50 quick wins (processing JSON fallback, vision max_completion_tokens, REFERENCE/env docs updates) | PR #52 |
 | INVENTORY-PENDING-PROMPTS | Produce consolidated repo+runtime pending issues inventory and current automation prompt catalog | — |
 | CRITICAL-GHCO-BUNDLE | Resolve GitHub critical issues #36-#40 on consolidated branch `codex/fix-critical-ghco-issues` | PR #43 |
 | ISSUE-41-HIGH-SEVERITY-BUGS | Resolve GitHub issue #41 high-severity bugs on isolated branch `codex/fix-high-severity-bugs` | PR #45 |

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2449,3 +2449,43 @@ Implemented the issue #48 prompt contract updates for extraction/processing and 
 ### Open follow-up
 
 - To run the live test in this environment, set provider credentials/deployment env vars (`PFCD_PROVIDER`, endpoint/key, and balanced deployment name) and rerun the gated integration test.
+
+---
+
+## Section 71: Codex Delivery — GitHub Issue #50 Quick Wins (2026-04-20)
+
+Implemented all four Wave-1 quick-win hardening items from issue #50: processing JSON fallback, vision token parameter update, missing env var documentation, and local docker shell-override warning.
+
+### Completed
+
+- Updated [backend/app/agents/processing.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/agents/processing.py):
+  - added `_parse_processing_json(raw)` with a 3-stage parse strategy:
+    - direct JSON parse
+    - fenced JSON extraction parse
+    - balanced-brace JSON object extraction parse
+  - added `_extract_balanced_json_object()` helper for repair-stage extraction
+  - integrated fallback path into `run_processing()` and set `job["agent_signals"]["processing_fallback"] = True` when non-primary parse path is used
+- Updated [backend/app/agents/vision.py](/Users/karthicks/kAgents/Projects/PFCD-V2/backend/app/agents/vision.py):
+  - added `_max_completion_tokens()` env-backed helper (`PFCD_MAX_COMPLETION_TOKENS`, default `2048`)
+  - replaced deprecated `max_tokens` with `max_completion_tokens` in both OpenAI and Azure vision request payloads
+- Updated [REFERENCE.md](/Users/karthicks/kAgents/Projects/PFCD-V2/REFERENCE.md):
+  - documented missing worker env vars:
+    - `PFCD_WORKER_RECEIVE_WAIT_SECONDS` (`5`)
+    - `PFCD_WORKER_IDLE_BACKOFF_BASE_SECONDS` (`0.5`)
+    - `PFCD_WORKER_IDLE_BACKOFF_MAX_SECONDS` (`5.0`)
+  - documented `PFCD_MAX_COMPLETION_TOKENS` (`2048`) as shared extraction/processing/vision control
+- Updated [docker-compose.local.env.example](/Users/karthicks/kAgents/Projects/PFCD-V2/docker-compose.local.env.example):
+  - added prominent warning block about shell-exported env vars overriding env-file values
+  - included explicit `unset OPENAI_API_KEY` and `env -u OPENAI_API_KEY docker compose ...` guidance
+- Added/updated tests:
+  - [tests/unit/test_agents.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/unit/test_agents.py): new malformed JSON processing fallback test
+  - [tests/unit/test_vision.py](/Users/karthicks/kAgents/Projects/PFCD-V2/tests/unit/test_vision.py): new request-payload tests asserting `max_completion_tokens` usage for OpenAI and Azure vision paths
+
+### Validation
+
+- `cd backend && .venv/bin/pytest ../tests/unit ../tests/integration -q --tb=short`
+  - `313 passed, 2 skipped`
+
+### Decisions
+
+- Kept parsing fallback deterministic and local to `processing.py` (no cross-agent imports) to match existing extraction pattern while minimizing coupling between agent modules.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -131,9 +131,13 @@ uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
 | `AZURE_SERVICE_BUS_QUEUE_PROCESSING` | Queue name | `processing` |
 | `AZURE_SERVICE_BUS_QUEUE_REVIEWING` | Queue name | `reviewing` |
 | `PFCD_WORKER_ROLE` | Worker phase (`extracting`/`processing`/`reviewing`) | — |
+| `PFCD_WORKER_RECEIVE_WAIT_SECONDS` | Max Service Bus receive wait time per poll | `5` |
+| `PFCD_WORKER_IDLE_BACKOFF_BASE_SECONDS` | Worker idle backoff base delay | `0.5` |
+| `PFCD_WORKER_IDLE_BACKOFF_MAX_SECONDS` | Worker idle backoff max delay | `5.0` |
 | `PFCD_CLEANUP_INTERVAL_SECONDS` | Cleanup worker poll interval | `300` |
 | `PFCD_JOB_TTL_DAYS` | Job retention window before expiry/cleanup | `7` |
 | `PFCD_LLM_TIMEOUT_SECONDS` | Max seconds allowed for a single extraction/processing LLM call | `120` |
+| `PFCD_MAX_COMPLETION_TOKENS` | Max completion tokens for extraction/processing/vision LLM calls | `2048` |
 | `PFCD_API_KEY` | Static API key for `X-API-Key` header | `""` (auth disabled if unset) |
 | `PFCD_CORS_ORIGINS` | Comma-separated allowed CORS origins | `http://localhost:5173` |
 | `PFCD_PROVIDER` | Chat/transcription provider (`azure_openai` or `openai`) | `azure_openai` |

--- a/backend/app/agents/processing.py
+++ b/backend/app/agents/processing.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 from typing import Any, Dict
 
 from app.job_logic import _utc_now
@@ -180,6 +181,59 @@ def _llm_timeout_seconds() -> float:
     return max(1.0, value)
 
 
+def _extract_balanced_json_object(text: str) -> str | None:
+    start = text.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    in_string = False
+    escaped = False
+    for idx in range(start, len(text)):
+        ch = text[idx]
+        if escaped:
+            escaped = False
+            continue
+        if ch == "\\":
+            escaped = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : idx + 1]
+    return None
+
+
+def _parse_processing_json(raw: str) -> tuple[Dict[str, Any], bool]:
+    candidates: list[tuple[str, bool]] = [(raw.strip(), False)]
+    fenced = re.findall(r"```(?:json)?\s*(.*?)```", raw, flags=re.IGNORECASE | re.DOTALL)
+    candidates.extend((chunk.strip(), True) for chunk in fenced if chunk.strip())
+    balanced = _extract_balanced_json_object(raw)
+    if balanced:
+        candidates.append((balanced.strip(), True))
+
+    last_error: json.JSONDecodeError | None = None
+    for candidate, fallback_used in candidates:
+        if not candidate:
+            continue
+        try:
+            parsed = json.loads(candidate)
+            if isinstance(parsed, dict):
+                return parsed, fallback_used
+        except json.JSONDecodeError as exc:
+            last_error = exc
+
+    if last_error is not None:
+        raise last_error
+    raise json.JSONDecodeError("No valid JSON object found", raw, 0)
+
+
 def run_processing(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
     """Call Azure OpenAI to generate PDD + SIPOC from extracted evidence.
 
@@ -221,7 +275,9 @@ def run_processing(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
         )
     except asyncio.TimeoutError as exc:
         raise RuntimeError(f"Processing LLM call timed out after {timeout_seconds:.0f}s") from exc
-    draft = json.loads(raw)
+    draft, processing_fallback_used = _parse_processing_json(raw)
+    if processing_fallback_used:
+        job.setdefault("agent_signals", {})["processing_fallback"] = True
 
     # Ensure required top-level keys are present
     draft.setdefault("generated_at", _utc_now())

--- a/backend/app/agents/vision.py
+++ b/backend/app/agents/vision.py
@@ -27,6 +27,15 @@ Be concise. Focus on process-relevant actions, not aesthetics.
 Output one paragraph per frame, prefixed with the frame timestamp."""
 
 
+def _max_completion_tokens() -> int:
+    raw = os.environ.get("PFCD_MAX_COMPLETION_TOKENS", "2048").strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        return 2048
+    return max(1, value)
+
+
 def _encode_image(path: str) -> str:
     with open(path, "rb") as fh:
         return base64.b64encode(fh.read()).decode("ascii")
@@ -65,7 +74,11 @@ def _call_vision_openai(messages: list[dict]) -> str:
     response = httpx.post(
         "https://api.openai.com/v1/chat/completions",
         headers={"Authorization": f"Bearer {api_key}"},
-        json={"model": _OPENAI_VISION_MODEL, "messages": messages, "max_tokens": 1024},
+        json={
+            "model": _OPENAI_VISION_MODEL,
+            "messages": messages,
+            "max_completion_tokens": _max_completion_tokens(),
+        },
         timeout=60.0,
     )
     response.raise_for_status()
@@ -90,7 +103,7 @@ def _call_vision_azure(messages: list[dict]) -> str:
     response = httpx.post(
         url,
         headers={"Authorization": f"Bearer {token.token}"},
-        json={"messages": messages, "max_tokens": 1024},
+        json={"messages": messages, "max_completion_tokens": _max_completion_tokens()},
         timeout=60.0,
     )
     response.raise_for_status()

--- a/docker-compose.local.env.example
+++ b/docker-compose.local.env.example
@@ -6,6 +6,13 @@
 # This is the file you edit for local Docker runs.
 # Do not look in Azure Key Vault for these local values.
 #
+# WARNING: Shell-exported env vars override values in this file.
+# If you have OPENAI_API_KEY or AZURE_OPENAI_API_KEY set in your shell,
+# unset them before starting the stack:
+#   unset OPENAI_API_KEY
+# Or start with:
+#   env -u OPENAI_API_KEY docker compose --env-file .env.docker.local -f docker-compose.local.yml up
+#
 # See docs/ISSUE-26-USER-DEPENDENCIES.md for a workflow-based explanation of
 # which values are placeholders versus which ones are operationally required.
 

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -331,6 +331,30 @@ def test_processing_agent_sets_defaults_on_minimal_response(monkeypatch):
     assert "confidence_delta" in job["draft"]["confidence_summary"]
 
 
+def test_processing_recovers_from_invalid_json_with_fallback():
+    from app.agents.processing import run_processing
+
+    job = _make_job()
+    job["extracted_evidence"] = {
+        "evidence_items": [],
+        "speakers_detected": [],
+        "process_domain": "test",
+        "transcript_quality": "low",
+    }
+    wrapped = (
+        'NOT_JSON ```json\n{"pdd":{"purpose":"fallback"},"sipoc":[]}\n``` trailing text'
+    )
+
+    with patch(
+        "app.agents.processing._call_processing",
+        side_effect=_async_sk_response(wrapped, 80, 40),
+    ):
+        run_processing(job, _balanced_profile())
+
+    assert job["draft"]["pdd"]["purpose"] == "fallback"
+    assert job["agent_signals"]["processing_fallback"] is True
+
+
 def test_processing_prompt_contract_includes_alignment_and_priority_rules():
     from app.agents import processing
 

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -72,3 +72,73 @@ def test_analyze_frames_batches_frames(monkeypatch):
 
     assert result == "ok\n\nok\n\nok"
     assert mock_call.call_count == 3
+
+
+def test_call_vision_openai_uses_max_completion_tokens(monkeypatch):
+    from app.agents.vision import _call_vision_openai
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("PFCD_MAX_COMPLETION_TOKENS", "333")
+
+    captured: dict = {}
+
+    class _Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+    def _fake_post(_url, headers, json, timeout):
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return _Resp()
+
+    monkeypatch.setattr("app.agents.vision.httpx.post", _fake_post)
+
+    result = _call_vision_openai([{"role": "user", "content": "x"}])
+
+    assert result == "ok"
+    assert captured["json"]["max_completion_tokens"] == 333
+    assert "max_tokens" not in captured["json"]
+
+
+def test_call_vision_azure_uses_max_completion_tokens(monkeypatch):
+    from app.agents import vision
+
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-10-21")
+    monkeypatch.setenv("PFCD_MAX_COMPLETION_TOKENS", "444")
+    monkeypatch.setattr("app.agents.vision._AZURE_VISION_DEPLOYMENT", "vision-deployment")
+
+    captured: dict = {}
+
+    class _Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+    class _Credential:
+        def get_token(self, _scope):
+            class _Token:
+                token = "fake-token"
+
+            return _Token()
+
+    def _fake_post(_url, headers, json, timeout):
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return _Resp()
+
+    monkeypatch.setattr("app.agents.vision.httpx.post", _fake_post)
+    monkeypatch.setattr("azure.identity.DefaultAzureCredential", lambda: _Credential())
+
+    result = vision._call_vision_azure([{"role": "user", "content": "x"}])
+
+    assert result == "ok"
+    assert captured["json"]["max_completion_tokens"] == 444
+    assert "max_tokens" not in captured["json"]


### PR DESCRIPTION
## Summary
- add 3-stage JSON fallback parsing to processing agent and mark `agent_signals.processing_fallback` when fallback path is used
- switch vision OpenAI/Azure payloads from `max_tokens` to env-driven `max_completion_tokens`
- document missing worker env vars and shared `PFCD_MAX_COMPLETION_TOKENS` in `REFERENCE.md`
- add shell env override warning block to `docker-compose.local.env.example`
- add unit tests for malformed processing JSON fallback and vision payload token fields

## Validation
- `cd backend && .venv/bin/pytest ../tests/unit ../tests/integration -q --tb=short`
  - `313 passed, 2 skipped`

Closes #50