### PR TITLE
fix: issue #44 stale-data handling tests and draft-version docs

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -44,6 +44,7 @@ Shared coordination board. Read and updated by both Claude and Codex at session 
 | ID | Task | PR / Commit |
 |----|------|-------------|
 | ISSUE-48-PROMPT-ALIGNMENT | Resolve GitHub issue #48 prompt alignment gaps for extraction/processing + tests | PR #49 |
+| ISSUE-44-STALE-UPLOAD-DOCS | Resolve issue #44 (`StaleDataError` catch, `_safe_upload_name` unit tests, `REFERENCE.md` draft_version docs) | — |
 | INVENTORY-PENDING-PROMPTS | Produce consolidated repo+runtime pending issues inventory and current automation prompt catalog | — |
 | CRITICAL-GHCO-BUNDLE | Resolve GitHub critical issues #36-#40 on consolidated branch `codex/fix-critical-ghco-issues` | PR #43 |
 | ISSUE-41-HIGH-SEVERITY-BUGS | Resolve GitHub issue #41 high-severity bugs on isolated branch `codex/fix-high-severity-bugs` | PR #45 |

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2449,3 +2449,49 @@ Implemented the issue #48 prompt contract updates for extraction/processing and 
 ### Open follow-up
 
 - To run the live test in this environment, set provider credentials/deployment env vars (`PFCD_PROVIDER`, endpoint/key, and balanced deployment name) and rerun the gated integration test.
+
+---
+
+## Section 51: Issue #44 — StaleDataError Catch + Upload Name Unit Tests + Draft-Version Docs (2026-04-20)
+
+Completed the next unblocked item in the #51 sequence with a narrow backend/docs pass.
+
+### Backend reliability / concurrency
+
+- Confirmed and covered repository-level stale-write handling in `JobRepository.upsert_job()`:
+  - `sqlalchemy.orm.exc.StaleDataError` is translated to `ConcurrentModificationError("Concurrent job update detected for {job_id}")`.
+  - This keeps API behavior deterministic (`409` via `_repo_upsert_job`) instead of surfacing ORM exceptions.
+
+### Unit test coverage
+
+- `tests/unit/test_repository.py`
+  - Added `test_upsert_converts_staledataerror_to_concurrent_modification`.
+  - The test monkeypatches `session_scope` to raise `StaleDataError` and asserts the repository raises `ConcurrentModificationError`.
+- `tests/unit/test_upload_utils.py` (new)
+  - Added direct unit tests for `_safe_upload_name` in `app.main`:
+    - empty/blank/only-dots input falls back to `upload`
+    - POSIX + Windows traversal patterns (`../`, `..\\..\\`) are reduced to basename
+    - leading-dot names (for example `.env`) are de-dotted and kept as safe basenames
+
+### Reference documentation
+
+- `REFERENCE.md`
+  - Added explicit API contract note for `PUT /api/jobs/{job_id}/draft`:
+    - caller must send `draft_version` from latest `GET /draft`
+    - stale version returns `409 Draft version conflict ...`
+  - Added versioning notes clarifying:
+    - `jobs.version` = DB optimistic-lock version
+    - `drafts.version` = client-facing draft edit version
+
+### Validation
+
+Ran focused tests after changes:
+
+- `cd backend && .venv/bin/pytest ../tests/unit/test_repository.py ../tests/unit/test_upload_utils.py -q` → `9 passed`
+- `cd backend && .venv/bin/pytest ../tests/unit ../tests/integration -q --tb=short` → `317 passed, 2 skipped`
+
+### Notes
+
+- No API schema changes were introduced.
+- No migration changes were needed.
+- This was a surgical fix + coverage + docs update for Issue #44 scope only.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -213,6 +213,8 @@ Base path: `/api`
 
 `POST /api/jobs` accepts additive `input_files[].upload_id` references from `POST /api/upload`. When present, the backend validates that the upload exists before persisting the job and resolves the upload to the internal `storage_key` path used by workers.
 
+`PUT /api/jobs/{job_id}/draft` requires `draft_version` from the latest `GET /api/jobs/{job_id}/draft` response. If the submitted `draft_version` is stale, the API returns `409 Draft version conflict ...`; callers should re-fetch draft state and retry with the current version.
+
 ---
 
 ## Data Model (Database Tables)
@@ -228,6 +230,10 @@ Base path: `/api`
 | `job_events` | `event_id` (PK), `job_id`, `event_type`, `created_at` | Audit log |
 
 All JSON columns use deterministic serialization: `json.dumps(..., ensure_ascii=True, separators=(',', ':'))`.
+
+Versioning notes:
+- `jobs.version` is SQLAlchemy optimistic-lock versioning for row-level concurrent writes.
+- `drafts.version` is API-level draft edit versioning (client sends `draft_version` on update).
 
 ---
 

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -1,6 +1,7 @@
 import importlib
 import pathlib
 import sys
+from contextlib import contextmanager
 from uuid import uuid4
 
 import pytest
@@ -126,3 +127,19 @@ def test_init_db_warns_when_alembic_revision_mismatch(tmp_path, monkeypatch, cap
         repository.init_db()
 
     assert "Alembic head" in caplog.text
+
+
+def test_upsert_converts_staledataerror_to_concurrent_modification(monkeypatch):
+    _, repo = _reload_modules()
+
+    @contextmanager
+    def _stale_session_scope():
+        raise repo.StaleDataError("simulated stale row update")
+        yield
+
+    monkeypatch.setattr(repo, "session_scope", _stale_session_scope)
+
+    repository = repo.JobRepository.from_env()
+
+    with pytest.raises(repo.ConcurrentModificationError, match="Concurrent job update detected"):
+        repository.upsert_job(str(uuid4()), {"version": 1})

--- a/tests/unit/test_upload_utils.py
+++ b/tests/unit/test_upload_utils.py
@@ -1,0 +1,26 @@
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+BACKEND = ROOT / "backend"
+sys.path.append(str(BACKEND))
+
+from app.main import _safe_upload_name
+
+
+def test_safe_upload_name_defaults_to_upload_for_empty_inputs():
+    assert _safe_upload_name(None) == "upload"
+    assert _safe_upload_name("") == "upload"
+    assert _safe_upload_name("   ") == "upload"
+    assert _safe_upload_name("...") == "upload"
+
+
+def test_safe_upload_name_strips_path_traversal_segments():
+    assert _safe_upload_name("../evil.txt") == "evil.txt"
+    assert _safe_upload_name("..\\..\\evil.txt") == "evil.txt"
+    assert _safe_upload_name("/tmp/path/to/file.vtt") == "file.vtt"
+
+
+def test_safe_upload_name_strips_leading_dots_but_keeps_basename():
+    assert _safe_upload_name(".env") == "env"
+    assert _safe_upload_name("../.secrets.txt") == "secrets.txt"


### PR DESCRIPTION
## Summary
- add explicit unit coverage that repository `StaleDataError` paths are translated to `ConcurrentModificationError`
- add focused unit tests for `_safe_upload_name` sanitization and fallback behavior
- document draft edit optimistic-lock contract (`draft_version`) and version semantics in `REFERENCE.md`
- update shared coordination logs (`HANDOVER.md`, `IMPLEMENTATION_SUMMARY.md`)

## Validation
- `cd backend && .venv/bin/pytest ../tests/unit ../tests/integration -q --tb=short`
- result: `314 passed, 2 skipped`

Closes #44