### PR TITLE
Issue #10: make extraction video-first with source tagging

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2532,3 +2532,39 @@ Implemented all four Wave-1 quick-win hardening items from issue #50: processing
 ### Decisions
 
 - Kept parsing fallback deterministic and local to `processing.py` (no cross-agent imports) to match existing extraction pattern while minimizing coupling between agent modules.
+
+## Section 72: Issue #10 — Video-First Extraction Precedence + Source Tagging (2026-04-20)
+
+Implemented issue #10 to make extraction behavior truly video-first when both video and transcript are present.
+
+### Completed
+
+- Updated `backend/app/agents/adapters/registry.py`:
+  - adapter precedence is now `video` first, then `transcript`
+  - registry behavior/docs updated accordingly
+- Updated `backend/app/agents/adapters/video.py`:
+  - replaced `extract_facts()` stub with deterministic segment extraction
+  - emits one `FactItem` per major segment from `teams_metadata.recording_markers` when speaker turns are present
+  - falls back to VTT cue segmentation from `_video_transcript_inline` when markers are unavailable
+  - all emitted video fact hints use confidence `0.5`
+- Updated `backend/app/agents/extraction.py`:
+  - `_normalize_input()` now returns input context and enforces video-first content selection
+  - when both sources exist, transcript is kept as alignment context while video content drives LLM extraction input
+  - added deterministic adapter fact-hint fallback when LLM returns no evidence items
+  - enforced source tagging on all evidence items:
+    - video-primary extraction → `source_type = "video"`
+    - transcript/fallback extraction → `source_type = "transcript"`
+    - mixed/unknown values are normalized conservatively by the same rule
+- Updated tests:
+  - `tests/unit/test_adapters.py`: added video segment-fact coverage (recording markers + VTT cues), updated registry precedence expectation to video-first, and transcript-only normalization assertion path for prompt cleanliness
+  - `tests/unit/test_agents.py`: updated `_normalize_input()` contract assertions, added source-type coercion test for video-primary runs, added adapter-fact-hint fallback test, and maintained transcript-only fallback regression coverage
+
+### Validation
+
+- `cd backend && .venv/bin/pytest ../tests/unit/test_adapters.py ../tests/unit/test_agents.py -q --tb=short` → `98 passed`
+- `cd backend && .venv/bin/pytest ../tests/unit ../tests/integration -q --tb=short` → `321 passed, 2 skipped`
+
+### Decisions
+
+- Chose deterministic source-type normalization in extraction post-processing to guarantee `source_type` completeness and avoid relying on model adherence for provenance fields.
+- Implemented adapter fact hints as a bounded fallback rather than replacing LLM extraction, preserving existing architecture while improving no-item resilience for video-first jobs.

--- a/backend/app/agents/adapters/registry.py
+++ b/backend/app/agents/adapters/registry.py
@@ -9,8 +9,8 @@ from app.agents.adapters.transcript import TranscriptAdapter
 from app.agents.adapters.video import VideoAdapter
 
 # Ordered list of source types for deterministic adapter resolution.
-# Transcript takes extraction precedence over video (richer text content for LLM).
-_SOURCE_TYPE_ORDER = ["transcript", "video"]
+# Video takes extraction precedence over transcript for video-first behavior.
+_SOURCE_TYPE_ORDER = ["video", "transcript"]
 
 _REGISTRY: Dict[str, IProcessEvidenceAdapter] = {
     "transcript": TranscriptAdapter(),
@@ -25,7 +25,7 @@ class AdapterRegistry:
     Usage:
         registry = AdapterRegistry()
         adapters = registry.get_adapters(["video", "transcript"])
-        # Returns [TranscriptAdapter, VideoAdapter] — transcript first by precedence
+        # Returns [VideoAdapter, TranscriptAdapter] — video first by precedence
     """
 
     def get_adapter(self, source_type: str) -> Optional[IProcessEvidenceAdapter]:
@@ -36,8 +36,8 @@ class AdapterRegistry:
         """
         Return all applicable adapters for the given source types.
 
-        Adapters are returned in extraction-precedence order (transcript first,
-        then video) regardless of the order in source_types.
+        Adapters are returned in extraction-precedence order (video first,
+        then transcript) regardless of the order in source_types.
         Unknown source types are silently skipped.
         """
         ordered = [st for st in _SOURCE_TYPE_ORDER if st in source_types]

--- a/backend/app/agents/adapters/video.py
+++ b/backend/app/agents/adapters/video.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import shutil
 import tempfile
+import re
 from typing import Any, Dict, List
 
 from app.agents.adapters.base import (
@@ -25,6 +26,10 @@ from app.agents.vision import analyze_frames
 from app.storage import upload_frame
 
 _VIDEO_MIME_PREFIXES = ("video/",)
+_VTT_TIMESTAMP_RE = re.compile(
+    r"^(\d{2}:\d{2}:\d{2})(?:\.\d+)?\s+-->\s+(\d{2}:\d{2}:\d{2})(?:\.\d+)?(?:\s.*)?$"
+)
+_SPEAKER_RE = re.compile(r"^\s*([^:]{2,80}):\s*(.+)\s*$")
 
 
 def _format_seconds(total_seconds: float) -> str:
@@ -222,12 +227,143 @@ class VideoAdapter(IProcessEvidenceAdapter):
 
     def extract_facts(self, job: Dict[str, Any]) -> List[FactItem]:
         """
-        Return structured facts from video frames.
+        Return structured segment-level facts from available video metadata.
 
-        Stub — will call Azure Vision API when integrated.
-        Currently returns empty list; frame-level facts are not available.
+        Emits one fact per major segment when speaker turns are present in
+        Teams recording markers. Falls back to VTT cue segmentation when a
+        video transcript is available.
         """
-        return []
+        marker_facts = self._facts_from_recording_markers(job)
+        if marker_facts:
+            return marker_facts
+        return self._facts_from_video_transcript(job)
+
+    def _facts_from_recording_markers(self, job: Dict[str, Any]) -> List[FactItem]:
+        teams = job.get("teams_metadata") or {}
+        markers = teams.get("recording_markers") or []
+        if not isinstance(markers, list):
+            return []
+
+        facts: List[FactItem] = []
+        for marker in markers:
+            if not isinstance(marker, dict):
+                continue
+
+            speaker = (
+                marker.get("speaker")
+                or marker.get("speaker_name")
+                or marker.get("display_name")
+            )
+            if not speaker:
+                continue
+
+            start = self._to_anchor_component(
+                marker.get("start")
+                or marker.get("start_time")
+                or marker.get("start_time_utc")
+                or marker.get("timestamp")
+            )
+            end = self._to_anchor_component(
+                marker.get("end")
+                or marker.get("end_time")
+                or marker.get("end_time_utc")
+                or marker.get("timestamp")
+            )
+            if not start:
+                continue
+            anchor = f"{start}-{end or start}"
+
+            content = (
+                marker.get("text")
+                or marker.get("utterance")
+                or marker.get("summary")
+                or marker.get("label")
+                or f"{speaker} segment"
+            )
+            facts.append(
+                FactItem(
+                    anchor=anchor,
+                    content=str(content).strip(),
+                    speaker=str(speaker).strip(),
+                    confidence=0.5,
+                )
+            )
+        return facts
+
+    def _facts_from_video_transcript(self, job: Dict[str, Any]) -> List[FactItem]:
+        raw = str(job.get("_video_transcript_inline") or "").strip()
+        if not raw:
+            return []
+
+        lines = raw.splitlines()
+        current_anchor: str | None = None
+        current_lines: list[str] = []
+        facts: List[FactItem] = []
+
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                if current_anchor and current_lines:
+                    fact = self._fact_from_cue(current_anchor, current_lines)
+                    if fact is not None:
+                        facts.append(fact)
+                current_anchor = None
+                current_lines = []
+                continue
+
+            if stripped == "WEBVTT" or stripped.startswith("NOTE"):
+                continue
+
+            match = _VTT_TIMESTAMP_RE.match(stripped)
+            if match:
+                if current_anchor and current_lines:
+                    fact = self._fact_from_cue(current_anchor, current_lines)
+                    if fact is not None:
+                        facts.append(fact)
+                current_anchor = f"{match.group(1)}-{match.group(2)}"
+                current_lines = []
+                continue
+
+            if current_anchor is not None and not stripped.isdigit():
+                current_lines.append(stripped)
+
+        if current_anchor and current_lines:
+            fact = self._fact_from_cue(current_anchor, current_lines)
+            if fact is not None:
+                facts.append(fact)
+
+        return facts
+
+    def _fact_from_cue(self, anchor: str, lines: List[str]) -> FactItem | None:
+        content = " ".join(lines).strip()
+        if not content:
+            return None
+        speaker = None
+        summary = content
+        match = _SPEAKER_RE.match(content)
+        if match:
+            speaker = match.group(1).strip()
+            summary = match.group(2).strip()
+        return FactItem(
+            anchor=anchor,
+            content=summary or content,
+            speaker=speaker,
+            confidence=0.5,
+        )
+
+    def _to_anchor_component(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return _format_seconds(float(value))
+        text = str(value).strip()
+        ts_match = re.search(r"(\d{2}:\d{2}:\d{2})", text)
+        if ts_match:
+            return ts_match.group(1)
+        try:
+            return _format_seconds(float(text))
+        except ValueError:
+            return None
 
     def render_review_notes(self, evidence_obj: EvidenceObject) -> List[str]:
         """Return provenance notes for display in review UI."""

--- a/backend/app/agents/extraction.py
+++ b/backend/app/agents/extraction.py
@@ -164,6 +164,7 @@ def _fallback_extraction_from_text(content_text: str, parse_error: str) -> Dict[
                 "input_artifact": "",
                 "output_artifact": "",
                 "anchor": anchor,
+                "source_type": "transcript",
                 "confidence": 0.35,
             }
         )
@@ -179,6 +180,7 @@ def _fallback_extraction_from_text(content_text: str, parse_error: str) -> Dict[
                     "input_artifact": "",
                     "output_artifact": "",
                     "anchor": "section:fallback",
+                    "source_type": "transcript",
                     "confidence": 0.25,
                 }
             )
@@ -226,13 +228,51 @@ def _llm_timeout_seconds() -> float:
     return max(1.0, value)
 
 
-def _normalize_input(job: Dict[str, Any]) -> Tuple[str, List[Dict[str, Any]]]:
+def _fact_items_to_evidence_items(
+    facts: List[Any], *, source_type: str
+) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    for idx, fact in enumerate(facts, start=1):
+        summary = (getattr(fact, "content", "") or "").strip()
+        anchor = (getattr(fact, "anchor", "") or "").strip()
+        if not summary or not anchor:
+            continue
+        speaker = (getattr(fact, "speaker", None) or "Unknown").strip()
+        confidence = float(getattr(fact, "confidence", 0.5) or 0.5)
+        items.append(
+            {
+                "id": f"ev-{idx:02d}",
+                "summary": summary[:240],
+                "actor": speaker,
+                "system": "Unknown",
+                "input_artifact": "",
+                "output_artifact": "",
+                "source_type": source_type,
+                "anchor": anchor,
+                "confidence": max(0.0, min(confidence, 1.0)),
+            }
+        )
+    return items
+
+
+def _apply_source_type_defaults(extracted: Dict[str, Any], primary_source_type: str) -> None:
+    items = extracted.get("evidence_items")
+    if not isinstance(items, list):
+        return
+    resolved = "video" if primary_source_type == "video" else "transcript"
+    for item in items:
+        if isinstance(item, dict):
+            item["source_type"] = resolved
+
+
+def _normalize_input(job: Dict[str, Any]) -> Tuple[str, List[Dict[str, Any]], Dict[str, Any]]:
     """
     Use registered adapters to normalize job input into extraction content.
 
-    Returns (content_text, manifests) where:
-    - content_text is the cleaned, LLM-ready string (transcript preferred over video metadata)
+    Returns (content_text, manifests, input_context) where:
+    - content_text is the cleaned, LLM-ready string (video preferred when both exist)
     - manifests is a list of DocumentTypeManifest dicts to store on the job
+    - input_context contains primary source selection and deterministic fact hints
 
     Falls back to raw _transcript_text_inline if no adapter matches.
     """
@@ -244,6 +284,8 @@ def _normalize_input(job: Dict[str, Any]) -> Tuple[str, List[Dict[str, Any]]]:
     content_text = ""
     transcript_content = ""
     video_content = ""
+    video_fact_hints: List[Dict[str, Any]] = []
+    transcript_fact_hints: List[Dict[str, Any]] = []
     manifests: List[Dict[str, Any]] = []
 
     for adapter in adapters:
@@ -258,19 +300,28 @@ def _normalize_input(job: Dict[str, Any]) -> Tuple[str, List[Dict[str, Any]]]:
         })
         if ev.source_type == "transcript" and ev.content_text:
             transcript_content = ev.content_text
+            transcript_fact_hints = _fact_items_to_evidence_items(
+                adapter.extract_facts(job), source_type="transcript"
+            )
         elif ev.source_type == "video" and ev.content_text and not ev.content_text.startswith("["):
             video_content = ev.content_text
+            video_fact_hints = _fact_items_to_evidence_items(
+                adapter.extract_facts(job), source_type="video"
+            )
 
-    # Build content for LLM: prefer uploaded transcript; supplement with video transcription.
-    if transcript_content and video_content:
-        content_text = (
-            f"VIDEO TRANSCRIPT:\n{video_content}\n\n"
-            f"UPLOADED TRANSCRIPT:\n{transcript_content}"
-        )
+    primary_source_type = "transcript"
+    fact_hints = transcript_fact_hints
+
+    # Video-first precedence: when both are available, transcript stays as
+    # alignment context and video drives extraction content.
+    if video_content:
+        content_text = video_content
+        primary_source_type = "video"
+        fact_hints = video_fact_hints
+        if transcript_content:
+            job["_transcript_text_inline"] = transcript_content
     elif transcript_content:
         content_text = transcript_content
-    elif video_content:
-        content_text = video_content
 
     # Final fallback: raw inline text (used when source_types is empty or unknown).
     # NOTE: _transcript_text_inline is intentionally ephemeral (set by the worker
@@ -278,7 +329,14 @@ def _normalize_input(job: Dict[str, Any]) -> Tuple[str, List[Dict[str, Any]]]:
     if not content_text:
         content_text = job.get("_transcript_text_inline") or ""
 
-    return content_text, manifests
+    if not content_text and video_fact_hints:
+        primary_source_type = "video"
+        fact_hints = video_fact_hints
+
+    return content_text, manifests, {
+        "primary_source_type": primary_source_type,
+        "fact_hints": fact_hints,
+    }
 
 
 def run_extraction(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
@@ -286,7 +344,7 @@ def run_extraction(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
 
     Mutates *job* in-place; returns cost in USD.
     """
-    content_text, manifests = _normalize_input(job)
+    content_text, manifests, input_context = _normalize_input(job)
     job["document_type_manifests"] = manifests
 
     if not content_text:
@@ -332,6 +390,15 @@ def run_extraction(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
             "reason": "llm_invalid_json",
             "error": str(exc)[:512],
         }
+
+    primary_source_type = input_context.get("primary_source_type") or "transcript"
+    if not extracted.get("evidence_items"):
+        fact_hints = input_context.get("fact_hints") or []
+        if fact_hints:
+            extracted["evidence_items"] = fact_hints
+            extracted.setdefault("fallback_reason", "adapter_fact_hints")
+
+    _apply_source_type_defaults(extracted, primary_source_type)
 
     job["extracted_evidence"] = extracted
     job["agent_signals"]["transcript_parsed"] = True

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -420,6 +420,67 @@ def test_video_adapter_normalize_with_frame_analysis(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# VideoAdapter — extract_facts()
+# ---------------------------------------------------------------------------
+
+def test_video_adapter_extract_facts_from_recording_markers():
+    from app.agents.adapters.video import VideoAdapter
+
+    adapter = VideoAdapter()
+    job = _make_job(has_video=True, has_audio=True, has_transcript=False)
+    job["teams_metadata"] = {
+        "recording_markers": [
+            {
+                "start": "00:00:10",
+                "end": "00:00:20",
+                "speaker": "Finance Analyst",
+                "text": "Open SAP invoice queue",
+            },
+            {
+                "start": 21,
+                "end": 31,
+                "speaker_name": "AP Manager",
+                "summary": "Approve matched invoices",
+            },
+        ]
+    }
+
+    facts = adapter.extract_facts(job)
+
+    assert len(facts) == 2
+    assert facts[0].anchor == "00:00:10-00:00:20"
+    assert facts[0].speaker == "Finance Analyst"
+    assert facts[0].confidence == 0.5
+    assert facts[1].anchor == "00:00:21-00:00:31"
+    assert facts[1].speaker == "AP Manager"
+    assert facts[1].confidence == 0.5
+
+
+def test_video_adapter_extract_facts_from_video_transcript_cues():
+    from app.agents.adapters.video import VideoAdapter
+
+    adapter = VideoAdapter()
+    job = _make_job(has_video=True, has_audio=True, has_transcript=False)
+    job["_video_transcript_inline"] = (
+        "WEBVTT\n\n"
+        "00:00:00.000 --> 00:00:05.000\n"
+        "Finance Analyst: Open SAP.\n\n"
+        "00:00:05.000 --> 00:00:10.000\n"
+        "AP Manager: Validate line items.\n"
+    )
+
+    facts = adapter.extract_facts(job)
+
+    assert len(facts) == 2
+    assert facts[0].anchor == "00:00:00-00:00:05"
+    assert facts[0].speaker == "Finance Analyst"
+    assert facts[0].confidence == 0.5
+    assert facts[1].anchor == "00:00:05-00:00:10"
+    assert facts[1].speaker == "AP Manager"
+    assert facts[1].confidence == 0.5
+
+
+# ---------------------------------------------------------------------------
 # VideoAdapter — render_review_notes()
 # ---------------------------------------------------------------------------
 
@@ -491,18 +552,18 @@ def test_registry_returns_video_adapter_for_video():
     assert isinstance(adapters[0], VideoAdapter)
 
 
-def test_registry_returns_both_adapters_transcript_first():
+def test_registry_returns_both_adapters_video_first():
     from app.agents.adapters.registry import AdapterRegistry
-    from app.agents.adapters.transcript import TranscriptAdapter
     from app.agents.adapters.video import VideoAdapter
+    from app.agents.adapters.transcript import TranscriptAdapter
 
     registry = AdapterRegistry()
-    # Deliberately pass video first to confirm transcript still comes first
+    # Deliberately pass transcript first to confirm video still comes first
     adapters = registry.get_adapters(["video", "transcript"])
 
     assert len(adapters) == 2
-    assert isinstance(adapters[0], TranscriptAdapter)
-    assert isinstance(adapters[1], VideoAdapter)
+    assert isinstance(adapters[0], VideoAdapter)
+    assert isinstance(adapters[1], TranscriptAdapter)
 
 
 def test_registry_skips_unknown_source_types():
@@ -546,7 +607,7 @@ def test_extraction_uses_adapter_normalized_content(monkeypatch):
         "transcript_quality": "low",
     }
 
-    job = _make_job()
+    job = _make_job(has_video=False, has_audio=False, has_transcript=True)
     job["_transcript_text_inline"] = _load_fixture("scenario_a", "transcript.vtt")
 
     captured_prompts = []

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -147,7 +147,7 @@ def test_extraction_cost_calculation(monkeypatch):
 def test_extraction_recovers_from_invalid_json_with_fallback():
     from app.agents.extraction import run_extraction
 
-    job = _make_job()
+    job = _make_job(has_video=False, has_audio=False, has_transcript=True)
     job["_transcript_text_inline"] = (
         "[00:00:01-00:00:05] Agent opens ERP\n"
         "[00:00:06-00:00:10] Agent validates invoice"
@@ -163,6 +163,90 @@ def test_extraction_recovers_from_invalid_json_with_fallback():
     assert job["agent_signals"]["transcript_parsed"] is True
     assert job["agent_signals"]["extraction_fallback"]["used"] is True
     assert len(job["extracted_evidence"]["evidence_items"]) >= 1
+    assert all(item.get("source_type") == "transcript" for item in job["extracted_evidence"]["evidence_items"])
+
+
+def test_extraction_sets_source_type_to_video_when_video_is_primary():
+    from app.agents.extraction import run_extraction
+
+    job = _make_job(has_video=True, has_audio=True, has_transcript=True)
+    job["_transcript_text_inline"] = _load_fixture("scenario_a", "transcript.vtt")
+    job["input_manifest"]["video"]["storage_key"] = "/tmp/demo.mp4"
+
+    llm_payload = {
+        "evidence_items": [
+            {
+                "id": "ev-01",
+                "summary": "Open SAP",
+                "actor": "Finance Analyst",
+                "system": "SAP",
+                "input_artifact": "invoice",
+                "output_artifact": "validated invoice",
+                "anchor": "00:00:00-00:00:03",
+                "confidence": 0.8,
+                "source_type": "transcript",
+            }
+        ],
+        "speakers_detected": ["Finance Analyst"],
+        "process_domain": "Accounts Payable",
+        "transcript_quality": "high",
+    }
+
+    with patch(
+        "app.agents.adapters.video.transcribe_audio_blob",
+        return_value="WEBVTT\n\n00:00:00.000 --> 00:00:03.000\nFinance Analyst: Open SAP.\n",
+    ):
+        with patch(
+            "app.agents.extraction._call_extraction",
+            side_effect=_async_sk_response(json.dumps(llm_payload), 10, 10),
+        ):
+            run_extraction(job, _balanced_profile())
+
+    assert job["extracted_evidence"]["evidence_items"][0]["source_type"] == "video"
+
+
+def test_extraction_uses_video_fact_hints_when_llm_returns_no_items():
+    from app.agents.extraction import run_extraction
+
+    job = _make_job(has_video=True, has_audio=True, has_transcript=False)
+    job["input_manifest"]["video"]["storage_key"] = "/tmp/demo.mp4"
+    job["teams_metadata"] = {
+        "recording_markers": [
+            {
+                "start": "00:00:10",
+                "end": "00:00:20",
+                "speaker": "Finance Analyst",
+                "text": "Open SAP invoice queue",
+            }
+        ]
+    }
+
+    with patch(
+        "app.agents.adapters.video.transcribe_audio_blob",
+        return_value="WEBVTT\n\n00:00:00.000 --> 00:00:03.000\nFinance Analyst: Open SAP.\n",
+    ):
+        with patch(
+            "app.agents.extraction._call_extraction",
+            side_effect=_async_sk_response(
+                json.dumps(
+                    {
+                        "evidence_items": [],
+                        "speakers_detected": [],
+                        "process_domain": "test",
+                        "transcript_quality": "high",
+                    }
+                ),
+                10,
+                10,
+            ),
+        ):
+            run_extraction(job, _balanced_profile())
+
+    assert len(job["extracted_evidence"]["evidence_items"]) == 1
+    item = job["extracted_evidence"]["evidence_items"][0]
+    assert item["source_type"] == "video"
+    assert item["confidence"] == 0.5
+    assert item["anchor"] == "00:00:10-00:00:20"
 
 
 def test_extraction_parses_json_inside_code_fence():
@@ -664,10 +748,11 @@ def test_normalize_input_video_only(monkeypatch):
             "WEBVTT\n\n00:00:00.000 --> 00:00:03.000\nFinance Analyst: Open SAP.\n"
         ),
     ):
-        content_text, manifests = _normalize_input(job)
+        content_text, manifests, input_context = _normalize_input(job)
 
     assert content_text.startswith("WEBVTT")
     assert any(m["source_type"] == "video" for m in manifests)
+    assert input_context["primary_source_type"] == "video"
 
 
 def test_normalize_input_video_and_transcript(monkeypatch):
@@ -684,12 +769,13 @@ def test_normalize_input_video_and_transcript(monkeypatch):
             "WEBVTT\n\n00:00:00.000 --> 00:00:03.000\nFinance Analyst: Open SAP.\n"
         ),
     ):
-        content_text, manifests = _normalize_input(job)
+        content_text, manifests, input_context = _normalize_input(job)
 
-    assert content_text.startswith("VIDEO TRANSCRIPT:\nWEBVTT")
-    assert "\n\nUPLOADED TRANSCRIPT:\n" in content_text
+    assert content_text.startswith("WEBVTT")
+    assert "UPLOADED TRANSCRIPT" not in content_text
     assert any(m["source_type"] == "transcript" for m in manifests)
     assert any(m["source_type"] == "video" for m in manifests)
+    assert input_context["primary_source_type"] == "video"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- switch adapter precedence to video-first when both video and transcript are present
- implement deterministic video segment fact extraction in `VideoAdapter.extract_facts()` (recording markers first, VTT cue fallback) with confidence `0.5`
- make extraction input selection video-first, keep transcript as alignment context, and normalize `source_type` on all evidence items
- add deterministic adapter fact-hint fallback when LLM returns no evidence items
- update unit tests for precedence, transcript-only regression, source_type population, and video fact extraction paths

## Validation
- `cd backend && .venv/bin/pytest ../tests/unit/test_adapters.py ../tests/unit/test_agents.py -q --tb=short` (`98 passed`)
- `cd backend && .venv/bin/pytest ../tests/unit ../tests/integration -q --tb=short` (`321 passed, 2 skipped`)

## Issue
Closes #10