### PR TITLE
Issue #14: add dedicated audio and document adapters

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2568,3 +2568,46 @@ Implemented issue #10 to make extraction behavior truly video-first when both vi
 
 - Chose deterministic source-type normalization in extraction post-processing to guarantee `source_type` completeness and avoid relying on model adherence for provenance fields.
 - Implemented adapter fact hints as a bounded fallback rather than replacing LLM extraction, preserving existing architecture while improving no-item resilience for video-first jobs.
+
+## Section 73: Issue #14 — Audio + Document Adapter Coverage (2026-04-20)
+
+Implemented dedicated adapter paths for `audio` and `document` source inputs without changing public job APIs.
+
+### Completed
+
+- Added `backend/app/agents/adapters/audio.py`:
+  - dedicated `AudioAdapter` with `detect/normalize/extract_facts/render_review_notes`
+  - transcribes audio inputs via existing `transcribe_audio_blob` when `storage_key` is available
+  - emits canonical `EvidenceObject` + deterministic fallback metadata content when transcription is unavailable
+- Added `backend/app/agents/adapters/document.py`:
+  - minimal `DocumentAdapter` with deterministic manifests/review notes
+  - supports text-preview loading for text-like docs (`.txt/.md/.csv/.log/.json`) and metadata-only fallback for binary docs (pdf/doc/ppt)
+- Updated `backend/app/agents/adapters/registry.py`:
+  - registered `audio` and `document` adapters
+  - expanded ordered precedence list to include new source types
+- Updated `backend/app/agents/extraction.py`:
+  - generalized adapter normalization to handle `video/transcript/audio/document`
+  - primary source selection now supports dedicated audio/document content paths
+  - source-type normalization now preserves `audio` as `source_type: "audio"` and keeps transcript fallback for unsupported/mixed document evidence
+- Updated `backend/app/workers/runner.py`:
+  - drops `_audio_transcript_inline` as an ephemeral extracting-phase field before persistence
+- Updated adapter exports in `backend/app/agents/adapters/__init__.py`
+
+### Test Coverage
+
+- Extended `tests/unit/test_adapters.py` with:
+  - AudioAdapter detect/normalize coverage
+  - DocumentAdapter detect/normalize coverage
+  - registry coverage for audio/document registration and ordering
+  - extraction `_normalize_input` coverage for audio-only and document-only jobs
+- Updated existing registry unknown-type expectation for new supported types
+
+### Validation
+
+- `cd backend && .venv/bin/pytest ../tests/unit/test_adapters.py -q --tb=short` → `48 passed`
+- `cd backend && .venv/bin/pytest ../tests/unit ../tests/integration -q --tb=short` → `328 passed, 2 skipped`
+
+### Decisions
+
+- Kept `document` evidence conservative: deterministic manifests + contextual metadata (text preview where feasible), with no schema/API contract expansion.
+- Reused existing transcription utility for audio adapter to avoid duplicating audio ingestion logic and keep behavior aligned with video-transcription paths.

--- a/backend/app/agents/adapters/__init__.py
+++ b/backend/app/agents/adapters/__init__.py
@@ -1,4 +1,4 @@
-"""Adapter layer for IProcessEvidenceAdapter — video and transcript sources."""
+"""Adapter layer for IProcessEvidenceAdapter sources."""
 
 from app.agents.adapters.base import (
     DetectionResult,
@@ -7,6 +7,8 @@ from app.agents.adapters.base import (
     FactItem,
     IProcessEvidenceAdapter,
 )
+from app.agents.adapters.audio import AudioAdapter
+from app.agents.adapters.document import DocumentAdapter
 from app.agents.adapters.registry import AdapterRegistry
 from app.agents.adapters.transcript import TranscriptAdapter
 from app.agents.adapters.video import VideoAdapter
@@ -18,6 +20,8 @@ __all__ = [
     "FactItem",
     "DocumentTypeManifest",
     "AdapterRegistry",
+    "AudioAdapter",
+    "DocumentAdapter",
     "TranscriptAdapter",
     "VideoAdapter",
 ]

--- a/backend/app/agents/adapters/audio.py
+++ b/backend/app/agents/adapters/audio.py
@@ -1,0 +1,135 @@
+"""AudioAdapter — normalizes audio source metadata into canonical evidence."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from app.agents.adapters.base import (
+    DetectionResult,
+    EvidenceObject,
+    FactItem,
+    IProcessEvidenceAdapter,
+)
+from app.agents.alignment import parse_vtt_cues
+from app.agents.transcription import transcribe_audio_blob
+
+_AUDIO_MIME_PREFIXES = ("audio/",)
+
+
+def _format_seconds(total_seconds: float) -> str:
+    total = max(int(total_seconds), 0)
+    hours = total // 3600
+    minutes = (total % 3600) // 60
+    seconds = total % 60
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+
+class AudioAdapter(IProcessEvidenceAdapter):
+    """Adapter for audio-only source inputs."""
+
+    def detect(self, manifest_entry: Dict[str, Any]) -> DetectionResult:
+        source_type = manifest_entry.get("source_type", "")
+        mime = (manifest_entry.get("mime_type") or "").lower()
+        if source_type != "audio":
+            return DetectionResult(
+                source_type=source_type,
+                document_type="unknown",
+                valid=False,
+                confidence=0.0,
+                notes=["source_type is not 'audio'"],
+            )
+
+        notes: List[str] = []
+        if mime and any(mime.startswith(prefix) for prefix in _AUDIO_MIME_PREFIXES):
+            notes.append(f"Audio MIME type confirmed: {mime}")
+        else:
+            notes.append("Audio source accepted; MIME type not strictly validated.")
+        return DetectionResult(
+            source_type="audio",
+            document_type="audio",
+            valid=True,
+            confidence=0.70,
+            notes=notes,
+        )
+
+    def normalize(self, job: Dict[str, Any]) -> EvidenceObject:
+        manifest = job.get("input_manifest") or {}
+        source_inputs = manifest.get("inputs") or []
+        audio_input = next((inp for inp in source_inputs if inp.get("source_type") == "audio"), {})
+        storage_key = audio_input.get("storage_key")
+
+        transcript_text = ""
+        if storage_key:
+            raw = transcribe_audio_blob(storage_key)
+            if raw and not raw.startswith("[transcription"):
+                transcript_text = raw
+                job["_audio_transcript_inline"] = raw
+
+        if transcript_text:
+            anchors = [
+                f"{_format_seconds(start)}-{_format_seconds(end)}"
+                for start, end in parse_vtt_cues(transcript_text)
+            ]
+            return EvidenceObject(
+                source_type="audio",
+                document_type="audio",
+                content_text=transcript_text,
+                anchors=anchors,
+                confidence=0.70,
+                metadata={
+                    "storage_key": storage_key,
+                    "transcribed": True,
+                    "duration_hint_sec": manifest.get("duration_hint_sec"),
+                },
+            )
+
+        size_bytes = audio_input.get("size_bytes") or 0
+        file_name = audio_input.get("file_name") or "audio-input"
+        content = (
+            f"Source type: audio\n"
+            f"File name: {file_name}\n"
+            f"Approx size bytes: {size_bytes}\n"
+            "Audio transcription is unavailable; extraction uses metadata-only context."
+        )
+        return EvidenceObject(
+            source_type="audio",
+            document_type="audio",
+            content_text=content,
+            anchors=[],
+            confidence=0.55,
+            metadata={
+                "storage_key": storage_key,
+                "transcribed": False,
+                "duration_hint_sec": manifest.get("duration_hint_sec"),
+            },
+        )
+
+    def extract_facts(self, job: Dict[str, Any]) -> List[FactItem]:
+        raw = str(job.get("_audio_transcript_inline") or "").strip()
+        if not raw:
+            return []
+        cues = parse_vtt_cues(raw)
+        facts: List[FactItem] = []
+        for index, (start, end) in enumerate(cues):
+            facts.append(
+                FactItem(
+                    anchor=f"{_format_seconds(start)}-{_format_seconds(end)}",
+                    content=f"Audio segment {index + 1}",
+                    speaker=None,
+                    confidence=0.55,
+                )
+            )
+        return facts
+
+    def render_review_notes(self, evidence_obj: EvidenceObject) -> List[str]:
+        if evidence_obj.metadata.get("transcribed"):
+            return [
+                "Audio source detected.",
+                "Audio transcription complete.",
+                "Audio-derived sequence is used for extraction.",
+            ]
+        return [
+            "Audio source detected.",
+            "Audio transcription unavailable; metadata-only fallback was used.",
+            "Review extracted steps carefully before finalize.",
+        ]

--- a/backend/app/agents/adapters/document.py
+++ b/backend/app/agents/adapters/document.py
@@ -1,0 +1,130 @@
+"""DocumentAdapter — minimal deterministic adapter for document inputs."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from app.agents.adapters.base import (
+    DetectionResult,
+    EvidenceObject,
+    FactItem,
+    IProcessEvidenceAdapter,
+)
+
+_TEXT_LIKE_EXTENSIONS = (".txt", ".md", ".csv", ".log", ".json")
+
+
+class DocumentAdapter(IProcessEvidenceAdapter):
+    """Adapter for uploaded supporting documents."""
+
+    def detect(self, manifest_entry: Dict[str, Any]) -> DetectionResult:
+        source_type = manifest_entry.get("source_type", "")
+        if source_type != "document":
+            return DetectionResult(
+                source_type=source_type,
+                document_type="unknown",
+                valid=False,
+                confidence=0.0,
+                notes=["source_type is not 'document'"],
+            )
+        file_name = (manifest_entry.get("file_name") or "").lower()
+        mime = (manifest_entry.get("mime_type") or "").lower()
+        notes = [
+            f"Document input detected (mime={mime or 'unknown'}, file={file_name or 'unknown'})."
+        ]
+        return DetectionResult(
+            source_type="document",
+            document_type="document",
+            valid=True,
+            confidence=0.50,
+            notes=notes,
+        )
+
+    def normalize(self, job: Dict[str, Any]) -> EvidenceObject:
+        source_inputs = (job.get("input_manifest") or {}).get("inputs") or []
+        document_input = next(
+            (inp for inp in source_inputs if inp.get("source_type") == "document"),
+            {},
+        )
+        file_name = (document_input.get("file_name") or "document").strip()
+        mime = (document_input.get("mime_type") or "").strip()
+        storage_key = document_input.get("storage_key")
+        size_bytes = document_input.get("size_bytes") or 0
+
+        preview_text = self._load_preview_text(file_name, storage_key)
+        if preview_text:
+            content_text = (
+                f"Document context from {file_name}:\n"
+                f"{preview_text}"
+            )
+            confidence = 0.50
+        else:
+            content_text = (
+                f"Source type: document\n"
+                f"File name: {file_name}\n"
+                f"MIME type: {mime or 'unknown'}\n"
+                f"Approx size bytes: {size_bytes}\n"
+                "Document text extraction is unavailable; this input is used as contextual metadata."
+            )
+            confidence = 0.40
+
+        return EvidenceObject(
+            source_type="document",
+            document_type="document",
+            content_text=content_text,
+            anchors=[],
+            confidence=confidence,
+            metadata={
+                "file_name": file_name,
+                "mime_type": mime,
+                "storage_key": storage_key,
+                "preview_loaded": bool(preview_text),
+            },
+        )
+
+    def extract_facts(self, job: Dict[str, Any]) -> List[FactItem]:
+        source_inputs = (job.get("input_manifest") or {}).get("inputs") or []
+        document_input = next(
+            (inp for inp in source_inputs if inp.get("source_type") == "document"),
+            {},
+        )
+        file_name = (document_input.get("file_name") or "document").strip()
+        if not file_name:
+            return []
+        return [
+            FactItem(
+                anchor=f"document:{file_name}",
+                content=f"Document provided: {file_name}",
+                speaker=None,
+                confidence=0.40,
+            )
+        ]
+
+    def render_review_notes(self, evidence_obj: EvidenceObject) -> List[str]:
+        preview_loaded = evidence_obj.metadata.get("preview_loaded", False)
+        if preview_loaded:
+            return [
+                "Document source detected.",
+                "Text preview loaded for contextual extraction support.",
+                "Document evidence remains secondary to media sequence evidence.",
+            ]
+        return [
+            "Document source detected.",
+            "Document parsed as metadata-only context (no text preview).",
+            "Review document-linked assumptions before finalize.",
+        ]
+
+    def _load_preview_text(self, file_name: str, storage_key: Any) -> str:
+        if not storage_key or not isinstance(storage_key, str):
+            return ""
+        if not file_name.lower().endswith(_TEXT_LIKE_EXTENSIONS):
+            return ""
+        try:
+            with open(storage_key, "rb") as handle:
+                raw = handle.read().decode("utf-8", errors="ignore")
+        except OSError:
+            return ""
+        lines = [line.strip() for line in raw.splitlines() if line.strip()]
+        if not lines:
+            return ""
+        return "\n".join(lines[:20])[:2000]

--- a/backend/app/agents/adapters/registry.py
+++ b/backend/app/agents/adapters/registry.py
@@ -5,16 +5,20 @@ from __future__ import annotations
 from typing import Dict, List, Optional
 
 from app.agents.adapters.base import IProcessEvidenceAdapter
+from app.agents.adapters.audio import AudioAdapter
+from app.agents.adapters.document import DocumentAdapter
 from app.agents.adapters.transcript import TranscriptAdapter
 from app.agents.adapters.video import VideoAdapter
 
 # Ordered list of source types for deterministic adapter resolution.
 # Video takes extraction precedence over transcript for video-first behavior.
-_SOURCE_TYPE_ORDER = ["video", "transcript"]
+_SOURCE_TYPE_ORDER = ["video", "transcript", "audio", "document"]
 
 _REGISTRY: Dict[str, IProcessEvidenceAdapter] = {
     "transcript": TranscriptAdapter(),
     "video": VideoAdapter(),
+    "audio": AudioAdapter(),
+    "document": DocumentAdapter(),
 }
 
 

--- a/backend/app/agents/extraction.py
+++ b/backend/app/agents/extraction.py
@@ -259,7 +259,14 @@ def _apply_source_type_defaults(extracted: Dict[str, Any], primary_source_type: 
     items = extracted.get("evidence_items")
     if not isinstance(items, list):
         return
-    resolved = "video" if primary_source_type == "video" else "transcript"
+    if primary_source_type == "video":
+        resolved = "video"
+    elif primary_source_type == "audio":
+        resolved = "audio"
+    else:
+        # Keep transcript as the conservative fallback for unsupported/mixed
+        # sources such as generic documents.
+        resolved = "transcript"
     for item in items:
         if isinstance(item, dict):
             item["source_type"] = resolved
@@ -282,10 +289,8 @@ def _normalize_input(job: Dict[str, Any]) -> Tuple[str, List[Dict[str, Any]], Di
     adapters = _adapter_registry.get_adapters(source_types)
 
     content_text = ""
-    transcript_content = ""
-    video_content = ""
-    video_fact_hints: List[Dict[str, Any]] = []
-    transcript_fact_hints: List[Dict[str, Any]] = []
+    source_content: Dict[str, str] = {}
+    source_fact_hints: Dict[str, List[Dict[str, Any]]] = {}
     manifests: List[Dict[str, Any]] = []
 
     for adapter in adapters:
@@ -298,40 +303,43 @@ def _normalize_input(job: Dict[str, Any]) -> Tuple[str, List[Dict[str, Any]], Di
             "anchor_count": len(ev.anchors),
             "provenance_notes": notes,
         })
-        if ev.source_type == "transcript" and ev.content_text:
-            transcript_content = ev.content_text
-            transcript_fact_hints = _fact_items_to_evidence_items(
-                adapter.extract_facts(job), source_type="transcript"
-            )
-        elif ev.source_type == "video" and ev.content_text and not ev.content_text.startswith("["):
-            video_content = ev.content_text
-            video_fact_hints = _fact_items_to_evidence_items(
-                adapter.extract_facts(job), source_type="video"
-            )
+        if ev.content_text:
+            source_content[ev.source_type] = ev.content_text
+        source_fact_hints[ev.source_type] = _fact_items_to_evidence_items(
+            adapter.extract_facts(job), source_type=ev.source_type
+        )
 
     primary_source_type = "transcript"
-    fact_hints = transcript_fact_hints
+    fact_hints: List[Dict[str, Any]] = []
+    for source_type in ("video", "transcript", "audio", "document"):
+        if source_content.get(source_type):
+            content_text = source_content[source_type]
+            primary_source_type = source_type
+            fact_hints = source_fact_hints.get(source_type, [])
+            break
 
     # Video-first precedence: when both are available, transcript stays as
     # alignment context and video drives extraction content.
-    if video_content:
-        content_text = video_content
-        primary_source_type = "video"
-        fact_hints = video_fact_hints
-        if transcript_content:
-            job["_transcript_text_inline"] = transcript_content
-    elif transcript_content:
-        content_text = transcript_content
+    if primary_source_type == "video" and source_content.get("transcript"):
+        job["_transcript_text_inline"] = source_content["transcript"]
 
     # Final fallback: raw inline text (used when source_types is empty or unknown).
     # NOTE: _transcript_text_inline is intentionally ephemeral (set by the worker
     # during extracting and removed before persistence).
     if not content_text:
-        content_text = job.get("_transcript_text_inline") or ""
+        content_text = (
+            job.get("_transcript_text_inline")
+            or job.get("_audio_transcript_inline")
+            or ""
+        )
 
-    if not content_text and video_fact_hints:
-        primary_source_type = "video"
-        fact_hints = video_fact_hints
+    if not content_text:
+        for source_type in ("video", "transcript", "audio", "document"):
+            hints = source_fact_hints.get(source_type) or []
+            if hints:
+                primary_source_type = source_type
+                fact_hints = hints
+                break
 
     return content_text, manifests, {
         "primary_source_type": primary_source_type,

--- a/backend/app/workers/runner.py
+++ b/backend/app/workers/runner.py
@@ -189,6 +189,7 @@ class Worker:
         if self.phase == "extracting":
             # Keep the persisted payload deterministic: drop ephemeral working data.
             job.pop("_transcript_text_inline", None)
+            job.pop("_audio_transcript_inline", None)
             job.pop("_video_transcript_inline", None)
             job.pop("_frame_descriptions_inline", None)
         self.repo.upsert_job(job_id, job)

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -527,6 +527,81 @@ def test_video_adapter_render_review_notes_with_transcription_complete_note():
 
 
 # ---------------------------------------------------------------------------
+# AudioAdapter
+# ---------------------------------------------------------------------------
+
+def test_audio_adapter_detect_audio_source():
+    from app.agents.adapters.audio import AudioAdapter
+
+    adapter = AudioAdapter()
+    result = adapter.detect({"source_type": "audio", "mime_type": "audio/mpeg"})
+
+    assert result.valid is True
+    assert result.source_type == "audio"
+    assert result.document_type == "audio"
+
+
+def test_audio_adapter_normalize_with_transcription():
+    from app.agents.adapters.audio import AudioAdapter
+
+    adapter = AudioAdapter()
+    job = _make_job(has_video=False, has_audio=True, has_transcript=False)
+    job["input_manifest"]["inputs"] = [
+        {"source_type": "audio", "storage_key": "/tmp/demo.mp3", "size_bytes": 1024}
+    ]
+    job["input_manifest"]["source_types"] = ["audio"]
+
+    with patch(
+        "app.agents.adapters.audio.transcribe_audio_blob",
+        return_value="WEBVTT\n\n00:00:00.000 --> 00:00:03.000\nOpen SAP.\n",
+    ):
+        ev = adapter.normalize(job)
+
+    assert ev.source_type == "audio"
+    assert ev.document_type == "audio"
+    assert ev.content_text.startswith("WEBVTT")
+    assert ev.anchors == ["00:00:00-00:00:03"]
+
+
+# ---------------------------------------------------------------------------
+# DocumentAdapter
+# ---------------------------------------------------------------------------
+
+def test_document_adapter_detect_document_source():
+    from app.agents.adapters.document import DocumentAdapter
+
+    adapter = DocumentAdapter()
+    result = adapter.detect({"source_type": "document", "file_name": "notes.pdf"})
+
+    assert result.valid is True
+    assert result.source_type == "document"
+    assert result.document_type == "document"
+
+
+def test_document_adapter_normalize_metadata_fallback():
+    from app.agents.adapters.document import DocumentAdapter
+
+    adapter = DocumentAdapter()
+    job = _make_job(has_video=False, has_audio=False, has_transcript=False)
+    job["input_manifest"]["inputs"] = [
+        {
+            "source_type": "document",
+            "file_name": "notes.pdf",
+            "mime_type": "application/pdf",
+            "size_bytes": 2048,
+        }
+    ]
+    job["input_manifest"]["source_types"] = ["document"]
+
+    ev = adapter.normalize(job)
+
+    assert ev.source_type == "document"
+    assert ev.document_type == "document"
+    assert "Source type: document" in ev.content_text
+    assert ev.confidence == 0.40
+
+
+# ---------------------------------------------------------------------------
 # AdapterRegistry
 # ---------------------------------------------------------------------------
 
@@ -570,7 +645,7 @@ def test_registry_skips_unknown_source_types():
     from app.agents.adapters.registry import AdapterRegistry
 
     registry = AdapterRegistry()
-    adapters = registry.get_adapters(["audio", "doc", "unknown"])
+    adapters = registry.get_adapters(["doc", "unknown"])
 
     assert adapters == []
 
@@ -579,7 +654,7 @@ def test_registry_get_adapter_returns_none_for_unknown():
     from app.agents.adapters.registry import AdapterRegistry
 
     registry = AdapterRegistry()
-    assert registry.get_adapter("audio") is None
+    assert registry.get_adapter("unknown") is None
 
 
 def test_registry_supported_types_contains_video_and_transcript():
@@ -590,6 +665,21 @@ def test_registry_supported_types_contains_video_and_transcript():
 
     assert "video" in supported
     assert "transcript" in supported
+    assert "audio" in supported
+    assert "document" in supported
+
+
+def test_registry_returns_audio_and_document_adapters():
+    from app.agents.adapters.registry import AdapterRegistry
+    from app.agents.adapters.audio import AudioAdapter
+    from app.agents.adapters.document import DocumentAdapter
+
+    registry = AdapterRegistry()
+    adapters = registry.get_adapters(["document", "audio"])
+
+    assert len(adapters) == 2
+    assert isinstance(adapters[0], AudioAdapter)
+    assert isinstance(adapters[1], DocumentAdapter)
 
 
 # ---------------------------------------------------------------------------
@@ -662,3 +752,39 @@ def test_extraction_document_manifests_populated_on_graceful_degradation():
 
     assert "document_type_manifests" in job
     assert isinstance(job["document_type_manifests"], list)
+
+
+def test_normalize_input_audio_only():
+    from app.agents.extraction import _normalize_input
+
+    job = _make_job(has_video=False, has_audio=True, has_transcript=False)
+    job["input_manifest"]["inputs"] = [
+        {"source_type": "audio", "storage_key": "/tmp/demo.mp3", "size_bytes": 2048}
+    ]
+    job["input_manifest"]["source_types"] = ["audio"]
+
+    with patch(
+        "app.agents.adapters.audio.transcribe_audio_blob",
+        return_value="WEBVTT\n\n00:00:00.000 --> 00:00:03.000\nOpen SAP.\n",
+    ):
+        content_text, manifests, input_context = _normalize_input(job)
+
+    assert content_text.startswith("WEBVTT")
+    assert any(m["source_type"] == "audio" for m in manifests)
+    assert input_context["primary_source_type"] == "audio"
+
+
+def test_normalize_input_document_only():
+    from app.agents.extraction import _normalize_input
+
+    job = _make_job(has_video=False, has_audio=False, has_transcript=False)
+    job["input_manifest"]["inputs"] = [
+        {"source_type": "document", "file_name": "notes.pdf", "mime_type": "application/pdf"}
+    ]
+    job["input_manifest"]["source_types"] = ["document"]
+
+    content_text, manifests, input_context = _normalize_input(job)
+
+    assert "Source type: document" in content_text
+    assert any(m["source_type"] == "document" for m in manifests)
+    assert input_context["primary_source_type"] == "document"


### PR DESCRIPTION
## Summary
- add dedicated `AudioAdapter` and `DocumentAdapter` implementations under `backend/app/agents/adapters/`
- register new `audio` and `document` adapters in `AdapterRegistry`
- generalize extraction adapter normalization to support `video/transcript/audio/document` source content paths
- preserve deterministic source-type normalization for extracted evidence (`audio` preserved, unsupported/mixed falls back conservatively)
- clean up `_audio_transcript_inline` as an extracting-phase ephemeral field in worker runner
- extend unit tests for adapter registration/ordering and audio/document normalization behavior

## Validation
- `cd backend && .venv/bin/pytest ../tests/unit/test_adapters.py -q --tb=short` (`48 passed`)
- `cd backend && .venv/bin/pytest ../tests/unit ../tests/integration -q --tb=short` (`328 passed, 2 skipped`)

## Issue
Closes #14