### PR TITLE
Issue #16: add readiness probe and monitoring baseline

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2611,3 +2611,40 @@ Implemented dedicated adapter paths for `audio` and `document` source inputs wit
 
 - Kept `document` evidence conservative: deterministic manifests + contextual metadata (text preview where feasible), with no schema/API contract expansion.
 - Reused existing transcription utility for audio adapter to avoid duplicating audio ingestion logic and keep behavior aligned with video-transcription paths.
+## Section 74: Issue #16 — Readiness Probe + App Insights + Alerting Baseline (2026-04-20)
+
+Implemented the operational baseline requested in issue #16 across backend, infra bootstrap, and docs.
+
+### Completed
+
+- Added `GET /health/readiness` in `backend/app/main.py`:
+  - public endpoint (same auth posture as `/health`)
+  - returns `200` with `status: ready` only when dependency checks pass
+  - returns `503` with `status: not_ready` and per-check diagnostics otherwise
+  - includes explicit checks for database, storage writeability, service bus config, OpenAI config, and speech config
+  - includes `missing_environment` list for required readiness env vars
+- Infra bootstrap updates in `infra/dev-bootstrap.sh`:
+  - added workspace-based Application Insights provisioning (`APP_INSIGHTS_NAME`)
+  - stores App Insights connection string in Key Vault (`application-insights-connection-string`)
+  - applies `APPLICATIONINSIGHTS_CONNECTION_STRING` + profiler/snapshot disable settings to API and worker apps
+  - added Azure Monitor baseline alert setup:
+    - API `Http5xx` metric alert
+    - DLQ metric alerts for extracting/processing/reviewing queues
+    - scheduled query alert for failing `/health/readiness` requests
+  - added optional action group notification flow via `ALERT_EMAIL` / `ALERT_ACTION_GROUP_NAME`
+- Documentation updates:
+  - `REFERENCE.md`: readiness endpoint contract + new ops/bootstrap env vars
+  - `infra/README.md`: App Insights + alert baseline in “What it creates”, verification commands, and override notes
+- Tests:
+  - new `tests/unit/test_health_readiness.py`
+  - updated `tests/integration/test_auth_enforcement.py` to cover public `/health/readiness`
+
+### Validation
+
+- `cd backend && .venv/bin/pytest ../tests/unit/test_health_readiness.py ../tests/integration/test_auth_enforcement.py -q --tb=short` → `17 passed`
+- `cd backend && .venv/bin/pytest ../tests/unit ../tests/integration -q --tb=short` → `325 passed, 2 skipped`
+
+### Decisions
+
+- Kept readiness checks deterministic and local-process safe (config + local capability checks) to avoid introducing network-dependent flakiness in health endpoints.
+- Implemented alert baseline creation as idempotent/best-effort with graceful fallback when monitor extensions or notification channels are unavailable.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -158,6 +158,9 @@ uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
 | `PFCD_CONSISTENCY_MATCH_THRESHOLD` | Transcript/media consistency threshold for `match` | `0.80` |
 | `PFCD_CONSISTENCY_INCONCLUSIVE_THRESHOLD` | Anchor-fallback consistency threshold for `inconclusive` | `0.50` |
 | `PFCD_CONSISTENCY_MISMATCH_THRESHOLD` | Transcript/media consistency threshold for `suspected_mismatch` | `0.30` |
+| `APP_INSIGHTS_NAME` | Azure Application Insights component name (bootstrap/ops baseline) | `${PROJECT}-${ENVIRONMENT}-appi` |
+| `ALERT_ACTION_GROUP_NAME` | Azure Monitor action group name (bootstrap/ops baseline) | `${PROJECT}-${ENVIRONMENT}-ops-ag` |
+| `ALERT_EMAIL` | Alert notification recipient used by bootstrap action group setup | `""` (alerts created without notifications) |
 
 ### Frontend Dev Environment Variables
 
@@ -214,6 +217,7 @@ Base path: `/api`
 | GET | `/api/jobs/{job_id}/exports/{format}` | Export draft (`json`, `markdown`, `pdf`, `docx`) |
 | DELETE | `/api/jobs/{job_id}` | Soft-delete / mark job expired |
 | GET | `/health` | Health check — returns `{"status": "ok"}` (200) or `{"status": "degraded", ...}` (503) with env diagnostics when Azure connections are unavailable |
+| GET | `/health/readiness` | Deep readiness check — returns `{"status":"ready"}` (200) only when dependency checks pass, else `{"status":"not_ready", ...}` (503) with per-check diagnostics |
 
 `POST /api/jobs` accepts additive `input_files[].upload_id` references from `POST /api/upload`. When present, the backend validates that the upload exists before persisting the job and resolves the upload to the internal `storage_key` path used by workers.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ import copy
 import json
 import logging
 import os
+import tempfile
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
@@ -168,6 +169,108 @@ def health() -> Dict[str, Any]:
             "missing_environment": degraded,
         },
         status_code=status_code,
+    )
+
+
+def _required_readiness_env() -> List[str]:
+    return [
+        "DATABASE_URL",
+        "AZURE_STORAGE_CONNECTION_STRING",
+        "AZURE_SERVICE_BUS_CONNECTION_STRING",
+        "AZURE_SERVICE_BUS_QUEUE_EXTRACTING",
+        "AZURE_SERVICE_BUS_QUEUE_PROCESSING",
+        "AZURE_SERVICE_BUS_QUEUE_REVIEWING",
+    ]
+
+
+def _check_database_readiness() -> Dict[str, Any]:
+    try:
+        JOB_REPO.get_recent_jobs(limit=1)
+        return {"status": "ok"}
+    except Exception as exc:  # pragma: no cover - covered by endpoint tests
+        return {"status": "error", "error": str(exc)}
+
+
+def _check_storage_readiness() -> Dict[str, Any]:
+    try:
+        os.makedirs(UPLOADS_DIR, exist_ok=True)
+        fd, test_path = tempfile.mkstemp(prefix="ready_", dir=UPLOADS_DIR)
+        os.close(fd)
+        os.unlink(test_path)
+        return {"status": "ok", "uploads_dir": UPLOADS_DIR}
+    except Exception as exc:  # pragma: no cover - covered by endpoint tests
+        return {"status": "error", "error": str(exc), "uploads_dir": UPLOADS_DIR}
+
+
+def _check_service_bus_readiness() -> Dict[str, Any]:
+    queues = {
+        "extracting": os.environ.get("AZURE_SERVICE_BUS_QUEUE_EXTRACTING"),
+        "processing": os.environ.get("AZURE_SERVICE_BUS_QUEUE_PROCESSING"),
+        "reviewing": os.environ.get("AZURE_SERVICE_BUS_QUEUE_REVIEWING"),
+    }
+    missing_queues = [name for name, value in queues.items() if not value]
+    if not os.environ.get("AZURE_SERVICE_BUS_CONNECTION_STRING"):
+        return {"status": "error", "error": "Missing AZURE_SERVICE_BUS_CONNECTION_STRING", "queues": queues}
+    if missing_queues:
+        return {
+            "status": "error",
+            "error": f"Missing queue config: {', '.join(missing_queues)}",
+            "queues": queues,
+        }
+    return {"status": "ok", "queues": queues}
+
+
+def _check_openai_readiness() -> Dict[str, Any]:
+    provider = (os.environ.get("PFCD_PROVIDER", "azure_openai") or "azure_openai").strip().lower()
+    if provider == "openai":
+        missing = [name for name in ("OPENAI_API_KEY",) if not os.environ.get(name)]
+        if missing:
+            return {"status": "error", "provider": provider, "error": f"Missing env: {', '.join(missing)}"}
+        return {"status": "ok", "provider": provider}
+
+    missing = [
+        name
+        for name in ("AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_CHAT_DEPLOYMENT_NAME")
+        if not os.environ.get(name)
+    ]
+    if missing:
+        return {"status": "error", "provider": provider, "error": f"Missing env: {', '.join(missing)}"}
+    return {
+        "status": "ok",
+        "provider": provider,
+        "endpoint": os.environ.get("AZURE_OPENAI_ENDPOINT"),
+        "deployment": os.environ.get("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"),
+    }
+
+
+def _check_speech_readiness() -> Dict[str, Any]:
+    account = os.environ.get("AZURE_SPEECH_ACCOUNT_NAME")
+    if not account:
+        return {"status": "error", "error": "Missing AZURE_SPEECH_ACCOUNT_NAME"}
+    return {"status": "ok", "account": account}
+
+
+@app.get("/health/readiness")
+def readiness_health() -> Dict[str, Any]:
+    required_env = _required_readiness_env()
+    missing = [name for name in required_env if not os.environ.get(name)]
+    checks = {
+        "database": _check_database_readiness(),
+        "storage": _check_storage_readiness(),
+        "service_bus": _check_service_bus_readiness(),
+        "openai": _check_openai_readiness(),
+        "speech": _check_speech_readiness(),
+    }
+    all_checks_ok = all(check.get("status") == "ok" for check in checks.values())
+    ready = not missing and all_checks_ok
+    return JSONResponse(
+        content={
+            "status": "ready" if ready else "not_ready",
+            "timestamp": _utc_now(),
+            "checks": checks,
+            "missing_environment": missing,
+        },
+        status_code=200 if ready else 503,
     )
 
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -10,6 +10,8 @@ This folder contains an executable script to create a **development** Azure envi
 - Azure Database for PostgreSQL Flexible Server + database
 - App Service Plan + Linux Web App (`PYTHON:3.11`)
 - Azure OpenAI + Speech accounts
+- Application Insights (workspace-based) + Key Vault-backed connection string wiring to API/workers
+- Azure Monitor alerting baseline (API 5xx, queue DLQ alerts, readiness failure query alert)
 - Cost budget hook (best effort; may require manual portal step depending on CLI/API)
 
 ## Run
@@ -35,6 +37,10 @@ SPEECH_ACCOUNT_LOCATION=eastus bash infra/dev-bootstrap.sh
 - `az webapp config appsettings list --name pfcd-dev-api --resource-group app-pfcd-v2 --query \"[?starts_with(name, 'AZURE') || starts_with(name, 'APP_') || starts_with(name, 'COST_')].[name, value]\" -o table`
 - `az keyvault secret list --vault-name pfcd-dev-kv`
 - `az servicebus queue show --resource-group app-pfcd-v2 --namespace-name pfcd-dev-bus --name extracting`
+- `az monitor app-insights component show --app pfcd-dev-appi --resource-group app-pfcd-v2`
+- `az monitor metrics alert list --resource-group app-pfcd-v2 -o table`
+- `az monitor scheduled-query list --resource-group app-pfcd-v2 -o table`
+- `curl -sS https://<api-host>/health/readiness`
 
 ## Deployment
 - App Service startup command is set to `uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}`.
@@ -61,5 +67,6 @@ az webapp restart --name pfcd-dev-api --resource-group app-pfcd-v2
 - `OPENAI_DEPLOYMENT_NAME`, `OPENAI_MODEL_NAME`, `OPENAI_MODEL_VERSION`
 - `OPENAI_SKU_NAME`, `SERVICE_BUS_SKU`
 - `SERVICE_BUS_QUEUE_EXTRACTING`, `SERVICE_BUS_QUEUE_PROCESSING`, `SERVICE_BUS_QUEUE_REVIEWING`
+- `APP_INSIGHTS_NAME`, `ALERT_ACTION_GROUP_NAME`, `ALERT_EMAIL` (optional; if `ALERT_EMAIL` is unset, alerts are created without notification actions)
 - `SP_CLIENT_ID` (optional; grants the CI service principal blob-write access on the storage account)
 - `MONTHLY_BUDGET`, `BUDGET_NAME`, `POSTGRES_ADMIN_USER`, `POSTGRES_ADMIN_PASSWORD`

--- a/infra/dev-bootstrap.sh
+++ b/infra/dev-bootstrap.sh
@@ -19,6 +19,9 @@ CONTAINER_REGISTRY_NAME="${CONTAINER_REGISTRY_NAME:-${PROJECT}${ENVIRONMENT}regi
 CONTAINER_REGISTRY_SKU="${CONTAINER_REGISTRY_SKU:-Basic}"
 CONTAINER_APPS_ENVIRONMENT_NAME="${CONTAINER_APPS_ENVIRONMENT_NAME:-${PROJECT}-${ENVIRONMENT}-env}"
 LOG_ANALYTICS_WORKSPACE_NAME="${LOG_ANALYTICS_WORKSPACE_NAME:-${PROJECT}-${ENVIRONMENT}-logs}"
+APP_INSIGHTS_NAME="${APP_INSIGHTS_NAME:-${PROJECT}-${ENVIRONMENT}-appi}"
+ALERT_ACTION_GROUP_NAME="${ALERT_ACTION_GROUP_NAME:-${PROJECT}-${ENVIRONMENT}-ops-ag}"
+ALERT_EMAIL="${ALERT_EMAIL:-}"
 STORAGE_ACCOUNT="${STORAGE_ACCOUNT:-${PROJECT}${ENVIRONMENT}storage}"
 SERVICE_BUS_NAMESPACE="${SERVICE_BUS_NAMESPACE:-${PROJECT}-${ENVIRONMENT}-bus}"
 SERVICE_BUS_QUEUE="${SERVICE_BUS_QUEUE:-jobs}"
@@ -295,6 +298,40 @@ ensure_log_analytics_workspace() {
   fi
 }
 
+ensure_app_insights() {
+  local workspace_id
+  workspace_id="$(az monitor log-analytics workspace show \
+    --resource-group "$RESOURCE_GROUP" \
+    --workspace-name "$LOG_ANALYTICS_WORKSPACE_NAME" \
+    --query id -o tsv)"
+
+  if ! az monitor app-insights component show \
+      --app "$APP_INSIGHTS_NAME" \
+      --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+    az monitor app-insights component create \
+      --app "$APP_INSIGHTS_NAME" \
+      --location "$LOCATION" \
+      --resource-group "$RESOURCE_GROUP" \
+      --workspace "$workspace_id" \
+      --application-type web \
+      --tags $COMMON_TAGS \
+      --output none
+  fi
+
+  local appi_conn
+  appi_conn="$(az monitor app-insights component show \
+    --app "$APP_INSIGHTS_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --query connectionString -o tsv)"
+  if [[ -n "$appi_conn" ]]; then
+    az keyvault secret set \
+      --vault-name "$KEY_VAULT_NAME" \
+      --name "application-insights-connection-string" \
+      --value "$appi_conn" \
+      --output none
+  fi
+}
+
 ensure_container_apps_environment() {
   local workspace_customer_id workspace_shared_key
   workspace_customer_id="$(az monitor log-analytics workspace show \
@@ -566,6 +603,187 @@ ensure_cognitive_services() {
   fi
 }
 
+ensure_monitor_alerting_baseline() {
+  local action_group_id api_id extracting_queue_id processing_queue_id reviewing_queue_id appi_id
+
+  if [[ -n "$ALERT_EMAIL" ]]; then
+    if ! az monitor action-group show \
+        --name "$ALERT_ACTION_GROUP_NAME" \
+        --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+      az monitor action-group create \
+        --name "$ALERT_ACTION_GROUP_NAME" \
+        --resource-group "$RESOURCE_GROUP" \
+        --short-name "pfcdops" \
+        --action email pfcdops "$ALERT_EMAIL" \
+        --output none
+    fi
+  else
+    info "ALERT_EMAIL not set; creating metric alerts without action-group notifications"
+  fi
+
+  action_group_id="$(az monitor action-group show \
+    --name "$ALERT_ACTION_GROUP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --query id -o tsv 2>/dev/null || true)"
+
+  api_id="$(az webapp show --name "$WEBAPP_NAME" --resource-group "$RESOURCE_GROUP" --query id -o tsv)"
+  extracting_queue_id="$(az servicebus queue show --resource-group "$RESOURCE_GROUP" --namespace-name "$SERVICE_BUS_NAMESPACE" --name "$SERVICE_BUS_QUEUE_EXTRACTING" --query id -o tsv)"
+  processing_queue_id="$(az servicebus queue show --resource-group "$RESOURCE_GROUP" --namespace-name "$SERVICE_BUS_NAMESPACE" --name "$SERVICE_BUS_QUEUE_PROCESSING" --query id -o tsv)"
+  reviewing_queue_id="$(az servicebus queue show --resource-group "$RESOURCE_GROUP" --namespace-name "$SERVICE_BUS_NAMESPACE" --name "$SERVICE_BUS_QUEUE_REVIEWING" --query id -o tsv)"
+  appi_id="$(az monitor app-insights component show --app "$APP_INSIGHTS_NAME" --resource-group "$RESOURCE_GROUP" --query id -o tsv)"
+
+  if ! az monitor metrics alert show --name "${PROJECT}-${ENVIRONMENT}-api-5xx" --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+    if [[ -n "$action_group_id" ]]; then
+      az monitor metrics alert create \
+        --name "${PROJECT}-${ENVIRONMENT}-api-5xx" \
+        --resource-group "$RESOURCE_GROUP" \
+        --scopes "$api_id" \
+        --condition "total Http5xx > 5" \
+        --window-size 5m \
+        --evaluation-frequency 1m \
+        --severity 2 \
+        --description "PFCD API 5xx spike" \
+        --action "$action_group_id" \
+        --output none
+    else
+      az monitor metrics alert create \
+        --name "${PROJECT}-${ENVIRONMENT}-api-5xx" \
+        --resource-group "$RESOURCE_GROUP" \
+        --scopes "$api_id" \
+        --condition "total Http5xx > 5" \
+        --window-size 5m \
+        --evaluation-frequency 1m \
+        --severity 2 \
+        --description "PFCD API 5xx spike" \
+        --output none
+    fi
+  fi
+
+  if ! az monitor metrics alert show --name "${PROJECT}-${ENVIRONMENT}-dlq-extracting" --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+    if [[ -n "$action_group_id" ]]; then
+      az monitor metrics alert create \
+        --name "${PROJECT}-${ENVIRONMENT}-dlq-extracting" \
+        --resource-group "$RESOURCE_GROUP" \
+        --scopes "$extracting_queue_id" \
+        --condition "total DeadletteredMessages > 0" \
+        --window-size 5m \
+        --evaluation-frequency 5m \
+        --severity 2 \
+        --description "PFCD extracting queue dead-lettered messages" \
+        --action "$action_group_id" \
+        --output none
+    else
+      az monitor metrics alert create \
+        --name "${PROJECT}-${ENVIRONMENT}-dlq-extracting" \
+        --resource-group "$RESOURCE_GROUP" \
+        --scopes "$extracting_queue_id" \
+        --condition "total DeadletteredMessages > 0" \
+        --window-size 5m \
+        --evaluation-frequency 5m \
+        --severity 2 \
+        --description "PFCD extracting queue dead-lettered messages" \
+        --output none
+    fi
+  fi
+
+  if ! az monitor metrics alert show --name "${PROJECT}-${ENVIRONMENT}-dlq-processing" --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+    if [[ -n "$action_group_id" ]]; then
+      az monitor metrics alert create \
+        --name "${PROJECT}-${ENVIRONMENT}-dlq-processing" \
+        --resource-group "$RESOURCE_GROUP" \
+        --scopes "$processing_queue_id" \
+        --condition "total DeadletteredMessages > 0" \
+        --window-size 5m \
+        --evaluation-frequency 5m \
+        --severity 2 \
+        --description "PFCD processing queue dead-lettered messages" \
+        --action "$action_group_id" \
+        --output none
+    else
+      az monitor metrics alert create \
+        --name "${PROJECT}-${ENVIRONMENT}-dlq-processing" \
+        --resource-group "$RESOURCE_GROUP" \
+        --scopes "$processing_queue_id" \
+        --condition "total DeadletteredMessages > 0" \
+        --window-size 5m \
+        --evaluation-frequency 5m \
+        --severity 2 \
+        --description "PFCD processing queue dead-lettered messages" \
+        --output none
+    fi
+  fi
+
+  if ! az monitor metrics alert show --name "${PROJECT}-${ENVIRONMENT}-dlq-reviewing" --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+    if [[ -n "$action_group_id" ]]; then
+      az monitor metrics alert create \
+        --name "${PROJECT}-${ENVIRONMENT}-dlq-reviewing" \
+        --resource-group "$RESOURCE_GROUP" \
+        --scopes "$reviewing_queue_id" \
+        --condition "total DeadletteredMessages > 0" \
+        --window-size 5m \
+        --evaluation-frequency 5m \
+        --severity 2 \
+        --description "PFCD reviewing queue dead-lettered messages" \
+        --action "$action_group_id" \
+        --output none
+    else
+      az monitor metrics alert create \
+        --name "${PROJECT}-${ENVIRONMENT}-dlq-reviewing" \
+        --resource-group "$RESOURCE_GROUP" \
+        --scopes "$reviewing_queue_id" \
+        --condition "total DeadletteredMessages > 0" \
+        --window-size 5m \
+        --evaluation-frequency 5m \
+        --severity 2 \
+        --description "PFCD reviewing queue dead-lettered messages" \
+        --output none
+    fi
+  fi
+
+  if ! az monitor scheduled-query show --name "${PROJECT}-${ENVIRONMENT}-readiness-failures" --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+    if [[ -n "$action_group_id" ]]; then
+      az monitor scheduled-query create \
+        --name "${PROJECT}-${ENVIRONMENT}-readiness-failures" \
+        --resource-group "$RESOURCE_GROUP" \
+        --scopes "$appi_id" \
+        --condition "count 'requests | where name == \"GET /health/readiness\" and success == false' > 0" \
+        --evaluation-frequency 5m \
+        --window-size 5m \
+        --severity 2 \
+        --description "PFCD readiness endpoint failing" \
+        --action "$action_group_id" \
+        --output none \
+        || info "Scheduled query alert creation requires updated monitor extension; create manually if needed."
+    else
+      az monitor scheduled-query create \
+        --name "${PROJECT}-${ENVIRONMENT}-readiness-failures" \
+        --resource-group "$RESOURCE_GROUP" \
+        --scopes "$appi_id" \
+        --condition "count 'requests | where name == \"GET /health/readiness\" and success == false' > 0" \
+        --evaluation-frequency 5m \
+        --window-size 5m \
+        --severity 2 \
+        --description "PFCD readiness endpoint failing" \
+        --output none \
+        || info "Scheduled query alert creation requires updated monitor extension; create manually if needed."
+    fi
+  fi
+}
+
+apply_app_insights_appsettings() {
+  local app_name
+  for app_name in "$WEBAPP_NAME" "$WORKER_EXTRACTING_NAME" "$WORKER_PROCESSING_NAME" "$WORKER_REVIEWING_NAME"; do
+    az webapp config appsettings set \
+      --name "$app_name" \
+      --resource-group "$RESOURCE_GROUP" \
+      --settings \
+        APPLICATIONINSIGHTS_CONNECTION_STRING="@Microsoft.KeyVault(SecretUri=https://${KEY_VAULT_NAME}.vault.azure.net/secrets/application-insights-connection-string)" \
+        APPINSIGHTS_PROFILERFEATURE_VERSION=disabled \
+        APPINSIGHTS_SNAPSHOTFEATURE_VERSION=disabled \
+      --output none
+  done
+}
+
 ensure_budget() {
   local start_date end_date
   start_date="$(date -u +"%Y-%m-01")"
@@ -592,10 +810,13 @@ ensure_key_vault
 ensure_postgres
 ensure_container_registry
 ensure_log_analytics_workspace
+ensure_app_insights
 ensure_container_apps_environment
 assign_container_app_runtime_roles
 ensure_app_service
+apply_app_insights_appsettings
 ensure_cognitive_services
+ensure_monitor_alerting_baseline
 ensure_budget
 
 info "Bootstrap complete for environment '$ENVIRONMENT' in $RESOURCE_GROUP"

--- a/tests/integration/test_auth_enforcement.py
+++ b/tests/integration/test_auth_enforcement.py
@@ -30,6 +30,13 @@ def test_health_is_always_public(app_client_with_auth):
     assert resp.status_code not in (401, 403)
 
 
+def test_health_readiness_is_always_public(app_client_with_auth):
+    ctx, _ = app_client_with_auth
+    # /health/readiness must also succeed with no key.
+    resp = ctx.client.get("/health/readiness")
+    assert resp.status_code not in (401, 403)
+
+
 def test_missing_key_returns_401(app_client_with_auth):
     ctx, _ = app_client_with_auth
     resp = ctx.client.get(f"/api/jobs/{uuid4()}")

--- a/tests/unit/test_health_readiness.py
+++ b/tests/unit/test_health_readiness.py
@@ -1,0 +1,75 @@
+"""Unit tests for /health/readiness dependency checks."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+BACKEND = ROOT / "backend"
+sys.path.insert(0, str(BACKEND))
+
+
+def _set_required_env(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./test.db")
+    monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", "UseDevelopmentStorage=true")
+    monkeypatch.setenv("AZURE_SERVICE_BUS_CONNECTION_STRING", "Endpoint=sb://test/;SharedAccessKeyName=x;SharedAccessKey=y")
+    monkeypatch.setenv("AZURE_SERVICE_BUS_QUEUE_EXTRACTING", "extracting")
+    monkeypatch.setenv("AZURE_SERVICE_BUS_QUEUE_PROCESSING", "processing")
+    monkeypatch.setenv("AZURE_SERVICE_BUS_QUEUE_REVIEWING", "reviewing")
+
+
+def test_readiness_returns_200_when_all_checks_ok(app_client, monkeypatch):
+    ctx = app_client
+    _set_required_env(monkeypatch)
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com/")
+    monkeypatch.setenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME", "gpt-4o-mini")
+    monkeypatch.setenv("AZURE_SPEECH_ACCOUNT_NAME", "pfcd-dev-speech")
+
+    monkeypatch.setattr(ctx.module, "_check_database_readiness", lambda: {"status": "ok"})
+    monkeypatch.setattr(ctx.module, "_check_storage_readiness", lambda: {"status": "ok"})
+    monkeypatch.setattr(ctx.module, "_check_service_bus_readiness", lambda: {"status": "ok"})
+    monkeypatch.setattr(ctx.module, "_check_openai_readiness", lambda: {"status": "ok"})
+    monkeypatch.setattr(ctx.module, "_check_speech_readiness", lambda: {"status": "ok"})
+
+    resp = ctx.client.get("/health/readiness")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["status"] == "ready"
+    assert payload["missing_environment"] == []
+
+
+def test_readiness_returns_503_when_database_check_fails(app_client, monkeypatch):
+    ctx = app_client
+    _set_required_env(monkeypatch)
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com/")
+    monkeypatch.setenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME", "gpt-4o-mini")
+    monkeypatch.setenv("AZURE_SPEECH_ACCOUNT_NAME", "pfcd-dev-speech")
+
+    monkeypatch.setattr(ctx.module, "_check_database_readiness", lambda: {"status": "error", "error": "db down"})
+    monkeypatch.setattr(ctx.module, "_check_storage_readiness", lambda: {"status": "ok"})
+    monkeypatch.setattr(ctx.module, "_check_service_bus_readiness", lambda: {"status": "ok"})
+    monkeypatch.setattr(ctx.module, "_check_openai_readiness", lambda: {"status": "ok"})
+    monkeypatch.setattr(ctx.module, "_check_speech_readiness", lambda: {"status": "ok"})
+
+    resp = ctx.client.get("/health/readiness")
+    assert resp.status_code == 503
+    payload = resp.json()
+    assert payload["status"] == "not_ready"
+    assert payload["checks"]["database"]["status"] == "error"
+
+
+def test_readiness_returns_503_when_required_env_missing(app_client, monkeypatch):
+    ctx = app_client
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("AZURE_STORAGE_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("AZURE_SERVICE_BUS_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("AZURE_SERVICE_BUS_QUEUE_EXTRACTING", raising=False)
+    monkeypatch.delenv("AZURE_SERVICE_BUS_QUEUE_PROCESSING", raising=False)
+    monkeypatch.delenv("AZURE_SERVICE_BUS_QUEUE_REVIEWING", raising=False)
+
+    resp = ctx.client.get("/health/readiness")
+    assert resp.status_code == 503
+    payload = resp.json()
+    assert payload["status"] == "not_ready"
+    assert "DATABASE_URL" in payload["missing_environment"]


### PR DESCRIPTION
## Summary
- add public `GET /health/readiness` endpoint with explicit dependency checks and `200/503` readiness contract
- include per-check diagnostics for database, storage, service bus config, OpenAI config, and speech config
- add unit coverage for readiness success/failure/missing-env paths and auth-enforcement integration coverage for readiness public access
- extend infra bootstrap to provision Application Insights and wire `APPLICATIONINSIGHTS_CONNECTION_STRING` via Key Vault to API/workers
- add Azure Monitor alerting baseline creation (API 5xx, queue DLQ alerts, readiness failure scheduled query)
- document readiness endpoint and new ops/bootstrap variables in `REFERENCE.md` and `infra/README.md`

## Validation
- `cd backend && .venv/bin/pytest ../tests/unit/test_health_readiness.py ../tests/integration/test_auth_enforcement.py -q --tb=short` (`17 passed`)
- `cd backend && .venv/bin/pytest ../tests/unit ../tests/integration -q --tb=short` (`325 passed, 2 skipped`)

## Issue
Closes #16