### PR TITLE
feat: issue #9 sas/blob-first upload-url ingestion flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,19 +5,26 @@
 At the start of every session, before writing any code:
 
 1. Read `AGENTS.md` (this file)
-2. Read `HANDOVER.md` — work assignment board; pick up items from "Assigned to Codex"
-3. Read `IMPLEMENTATION_SUMMARY.md` — rolling log of what has been built and what remains
-4. Read `prd.md` — authoritative requirements; never modify requirements, only the progress table
-5. Read `REFERENCE.md` on demand — file layout, env vars, API/data model, Azure infra, CI/CD
+2. Read `IMPLEMENTATION_SUMMARY.md` — rolling log of what has been built and what remains
+3. Read `prd.md` — authoritative requirements; never modify requirements, only the progress table
+4. Read `REFERENCE.md` on demand — file layout, env vars, API/data model, Azure infra, CI/CD
+
+## Issue Workflow (MANDATORY)
+
+For every GitHub issue, always follow this exact order:
+
+1. `git checkout main`
+2. `git pull origin main`
+3. Create a new branch for the issue (example: `codex/issue-9-upload-url`)
+4. Implement only the issue scope on that branch
+5. Run relevant tests and record exact commands/results
+6. Update the GitHub issue with progress/completion notes
+7. Open a pull request from the issue branch to `main`
 
 After completing work:
-- `HANDOVER.md` → move item from "Assigned to Codex" / "In Progress" to "Ready for Claude Review"
 - `IMPLEMENTATION_SUMMARY.md` → append what was built, decisions made, open questions
 
-When picking up an assignment:
-- `HANDOVER.md` → move item from "Assigned to Codex" to "In Progress"
-
-Shared logs are append-only to avoid overwrite conflicts between agents.
+`HANDOVER.md` is deprecated. Do not use it for issue tracking or status transitions.
 
 ## Implementation Status
 - Active implementation details and progress history are maintained in `IMPLEMENTATION_SUMMARY.md`.
@@ -94,3 +101,71 @@ PR expectations:
 - Keep secrets (Azure keys, storage SAS, DB creds) in environment variables or Key Vault, never in repo files.
 - Track environment differences (`local`, `staging`, `production`) with explicit profiles.
 - Redact transcript/video identifiers in logs by default.
+
+
+<claude-mem-context>
+# Memory Context
+
+# [PFCD-V2] recent context, 2026-04-20 3:02pm GMT+5:30
+
+Legend: 🎯session 🔴bugfix 🟣feature 🔄refactor ✅change 🔵discovery ⚖️decision
+Format: ID TIME TYPE TITLE
+Fetch details: get_observations([IDs]) | Search: mem-search skill
+
+Stats: 50 obs (18,078t read) | 335,221t work | 95% savings
+
+### Apr 19, 2026
+283 11:04p 🔴 Critical GHCO Bundle — 5 Security/Concurrency Bugs Fixed on codex/fix-critical-ghco-issues
+284 " 🔵 gh CLI Token Still Invalid — PR Creation Blocked Again
+285 " ⚖️ Optimistic Locking — Single Job-Level Lock, Separate Draft Version
+288 11:05p ✅ Critical GHCO Bug Bundle — 20 Files Staged for Commit
+289 " ✅ Critical GHCO Issues #36-#40 Committed to Branch
+### Apr 20, 2026
+294 9:24a 🔵 PFCD-V2 docker-compose.local.yml — Full Service + Env Var Map Confirmed
+295 " 🔵 PFCD-V2 Required Env Vars for Local Docker — Minimum Set to Unblock Stuck Queue Item
+297 9:25a 🔵 PFCD-V2 Docker Stack Missing Worker Services — Root Cause of Stuck Queue Item
+298 " 🔵 PFCD-V2 /dev/simulate Endpoint — Local Dev Escape Hatch for Queue-Stuck Jobs
+300 9:27a 🔵 PFCD-V2 Live /health Probe — 6 Missing Env Vars Confirmed on Running Docker Stack
+301 " 🔵 PFCD-V2 Stuck Job e97bbf65 — Full State Confirmed via Live API
+302 " 🔵 backend/docker-compose.smoke.yml — Worker Service Pattern for Local Docker with Real Workers
+304 9:50a 🔵 PFCD-V2 Local Docker API — SQLite Missing jobs.version Column
+305 9:51a 🔵 PFCD-V2 Local SQLite DB — Alembic Migration History Absent, Table Pre-exists Without version Column
+308 " 🔵 PFCD-V2 Local SQLite Schema — Confirmed Missing version Column, Full Migration Chain Mapped
+309 " 🔴 PFCD-V2 Local SQLite Schema Repaired — jobs.version Column Added Without Data Loss
+312 9:53a 🔵 PFCD-V2 Local Docker Stack — Post-Migration State and Remaining Gaps
+315 9:55a 🟣 docker-compose.local.yml — Three Worker Services Added for Full Local Pipeline
+317 9:59a 🟣 PFCD-V2 Local Docker Stack — All 5 Containers Running Including 3 Workers
+318 " 🔵 PFCD-V2 Workers — All Three Connected to Azure Service Bus and Listening
+319 " 🟣 Job e97bbf65 Manually Re-enqueued to Extracting Queue
+322 10:00a 🔵 PFCD-V2 Pipeline — Extracting Succeeds, Processing Permanently Fails on OpenAI 429 Quota Exceeded
+324 " 🔵 PFCD-V2 Local Stack — PFCD_PROVIDER=openai Set in .env.docker.local, OpenAI Account Has No Quota
+326 10:13a 🔵 PFCD-V2 Local Docker Stack — All 5 Containers Running, Workers Connected to Service Bus
+327 " 🔵 PFCD-V2 Worker-Processing Env — Provider Mismatch Confirmed: openai + Azure Endpoint
+329 " 🔵 Two Different OPENAI_API_KEY Values — Shell Env vs .env.docker.local
+331 10:14a ✅ PFCD-V2 Stack Restarted with Shell OPENAI_API_KEY Unset — Containers Pick Key from .env.docker.local Only
+333 " 🔵 Worker-Processing Now Receives .env.docker.local Key — But PFCD_PROVIDER Still "openai"
+335 10:15a 🔵 Job e97bbf65 Full Failure Trace — SK Uses OpenAIChatCompletion Despite provider_effective=azure_openai
+337 " 🔵 sk-proj- API Key Works for gpt-4o-mini — gpt-5.4-mini Fails with max_tokens Incompatibility
+341 10:16a 🔴 .env.docker.local Model Names Downgraded — gpt-5.4-mini → gpt-4o-mini, gpt-5.4 → gpt-4o
+344 " ✅ PFCD-V2 Stack Restarted — Workers Now Use gpt-4o-mini/gpt-4o, Correct API Key Confirmed
+346 10:20a 🔵 extraction.py and processing.py — SK Connector Uses OpenAIChatPromptExecutionSettings, No max_tokens Passed
+347 " 🔵 Installed SK OpenAIChatPromptExecutionSettings Supports Both max_tokens and max_completion_tokens
+350 " 🟣 extraction.py and processing.py — max_completion_tokens Added via PFCD_MAX_COMPLETION_TOKENS Env Var
+354 10:22a 🔵 PFCD-V2 API Container Storage Path — /app/storage/uploads/manual/ Confirmed Writable
+356 1:34p 🟣 Issue #16 — Readiness Probe + App Insights + Alerting Baseline Implemented
+357 2:01p ✅ Issue #16 Readiness + Monitoring Committed on codex/issue-16-readiness-appinsights-alerts
+358 2:29p ✅ Issue #16 Draft PR #56 Created — Readiness Probe + Monitoring Baseline
+359 " 🔵 GET /health/readiness — Full Contract and Response Schema
+361 2:47p 🔵 Issue #9 — Retry/Back-off Work Assignment Picked Up
+362 " 🔵 GitHub Issue #9 — SAS/Blob-First Ingestion, Not Retry Logic
+363 " ✅ HANDOVER.md — Issue #9 Moved to In Progress
+366 2:48p 🔵 Current Upload Architecture — Full Code Map Before SAS Migration
+368 2:51p 🟣 SAS/Blob-First Upload Infrastructure Added to main.py
+369 2:53p 🟣 SAS/Blob-First Upload Endpoints + Frontend Migration Complete
+370 " 🔴 _resolve_input_files Missing append Before continue
+372 " ✅ Issue #9 Marked Complete — HANDOVER.md + IMPLEMENTATION_SUMMARY.md Updated
+375 3:00p ✅ Issue #9 Committed on codex/fix-issue-9 Branch
+376 3:01p ✅ AGENTS.md — Issue Workflow Updated, HANDOVER.md Deprecated
+
+Access 335k tokens of past work via get_observations([IDs]) or mem-search skill.
+</claude-mem-context>

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2648,3 +2648,38 @@ Implemented the operational baseline requested in issue #16 across backend, infr
 
 - Kept readiness checks deterministic and local-process safe (config + local capability checks) to avoid introducing network-dependent flakiness in health endpoints.
 - Implemented alert baseline creation as idempotent/best-effort with graceful fallback when monitor extensions or notification channels are unavailable.
+
+## Section 75: Issue #9 — SAS/Blob-First Ingestion + `upload-url` Contract (2026-04-20)
+
+Implemented the upload-contract migration requested by issue #9 while preserving existing `/api/jobs*` lifecycle behavior.
+
+### Completed
+
+- Backend API updates in `backend/app/main.py`:
+  - added `POST /api/jobs/{job_id}/upload-url` returning a time-limited upload contract:
+    - `upload_id`, file metadata, storage key, expiry
+    - upload transport contract (`method`, `url`, `headers`, `requires_api_auth`)
+  - added `PUT /api/uploads/{upload_id}/content` for local/dev relay uploads
+  - added upload-manifest persistence (`UPLOAD_META_DIR`) to track upload metadata and storage mapping by `upload_id`
+  - added blob-mode contract generation (SAS URL) when storage connection string includes account key
+  - added blob/local existence checks during `create_job` upload-id resolution
+  - preserved legacy `POST /api/upload` and made it write the same upload manifest format for backward compatibility
+- Frontend updates:
+  - `frontend/src/api.js`: `uploadFile()` now uses two-step flow:
+    - request upload contract from `POST /api/jobs/{job_id}/upload-url`
+    - upload bytes with `PUT` to returned URL
+  - `frontend/src/components/CreateJob.jsx`: passes `sourceType` into `uploadFile()` while keeping existing `createJob()` payload contract unchanged
+- Integration tests:
+  - `tests/integration/test_lifecycle.py`:
+    - added happy-path test for upload-url flow (`upload-url` -> `PUT` -> `create_job`)
+    - added rejection test when `upload_id` exists but content is not uploaded
+
+### Validation
+
+- `pytest tests/integration/test_lifecycle.py tests/integration/test_error_cases.py -q` → `31 passed`
+
+### Decisions
+
+- Kept `/api/upload` active to avoid breaking existing callers while migrating frontend to `upload-url`.
+- Implemented a local relay upload path (`/api/uploads/{upload_id}/content`) as fallback when direct blob SAS generation is unavailable (for example local/integration environments).
+- Scoped blob verification to existence checks during `create_job` so upload lifecycle remains deterministic without introducing new async callbacks/webhooks.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,14 +8,16 @@ import logging
 import os
 import tempfile
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 from uuid import uuid4
 
 import anyio
-from fastapi import APIRouter, Depends, FastAPI, File, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, FastAPI, File, HTTPException, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, PlainTextResponse, Response
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +43,9 @@ from app.storage import ExportStorage
 MAX_UPLOAD_BYTES = 500 * 1024 * 1024
 ALLOWED_FORMATS = {"json", "markdown", "pdf", "docx"}
 UPLOADS_DIR = os.environ.get("UPLOADS_DIR", "./storage/uploads")
+UPLOAD_META_DIR = os.environ.get("UPLOAD_META_DIR", os.path.join(UPLOADS_DIR, "_manifest"))
+UPLOAD_SAS_EXPIRY_MINUTES = max(1, int(os.environ.get("PFCD_UPLOAD_SAS_EXPIRY_MINUTES", "30")))
+UPLOAD_CONTAINER = os.environ.get("AZURE_STORAGE_CONTAINER_UPLOADS", "uploads")
 
 JOB_REPO = JobRepository.from_env()
 EXPORT_STORAGE = ExportStorage.from_env()
@@ -86,22 +91,180 @@ def _resolve_upload_path(upload_id: str, file_name: str | None) -> str:
     return os.path.join(UPLOADS_DIR, upload_id, file_part)
 
 
+def _upload_manifest_path(upload_id: str) -> str:
+    safe_id = os.path.basename(upload_id.replace("\\", "/")).strip()
+    if not safe_id or safe_id != upload_id:
+        raise ValueError(f"Invalid upload id: {upload_id!r}")
+    return os.path.join(UPLOAD_META_DIR, f"{safe_id}.json")
+
+
+def _parse_iso8601(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _save_upload_manifest(upload_id: str, payload: Dict[str, Any]) -> None:
+    os.makedirs(UPLOAD_META_DIR, exist_ok=True)
+    with open(_upload_manifest_path(upload_id), "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=True, separators=(",", ":"))
+
+
+def _load_upload_manifest(upload_id: str) -> Dict[str, Any] | None:
+    manifest_path = _upload_manifest_path(upload_id)
+    if not os.path.isfile(manifest_path):
+        return None
+    with open(manifest_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _update_upload_manifest(upload_id: str, updates: Dict[str, Any]) -> Dict[str, Any]:
+    manifest = _load_upload_manifest(upload_id)
+    if not manifest:
+        raise HTTPException(status_code=404, detail=f"Upload id {upload_id!r} was not found.")
+    manifest.update(updates)
+    _save_upload_manifest(upload_id, manifest)
+    return manifest
+
+
+def _parse_storage_connection_string() -> Dict[str, str]:
+    raw = os.environ.get("AZURE_STORAGE_CONNECTION_STRING", "")
+    parts: Dict[str, str] = {}
+    for chunk in raw.split(";"):
+        if "=" not in chunk:
+            continue
+        key, value = chunk.split("=", 1)
+        parts[key] = value
+    return parts
+
+
+def _build_blob_upload_contract(job_id: str, upload_id: str, safe_name: str, mime_type: str) -> Dict[str, Any] | None:
+    try:
+        from azure.storage.blob import BlobSasPermissions, BlobServiceClient, generate_blob_sas
+    except Exception:
+        return None
+
+    conn = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
+    conn_parts = _parse_storage_connection_string()
+    account_name = conn_parts.get("AccountName") or os.environ.get("AZURE_STORAGE_ACCOUNT_NAME")
+    account_key = conn_parts.get("AccountKey")
+    if not conn or not account_name or not account_key:
+        return None
+
+    blob_name = f"{job_id}/{upload_id}/{safe_name}"
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=UPLOAD_SAS_EXPIRY_MINUTES)
+    blob_service = BlobServiceClient.from_connection_string(conn)
+    container_client = blob_service.get_container_client(UPLOAD_CONTAINER)
+    try:
+        container_client.create_container()
+    except Exception:
+        pass
+
+    sas_token = generate_blob_sas(
+        account_name=account_name,
+        container_name=UPLOAD_CONTAINER,
+        blob_name=blob_name,
+        account_key=account_key,
+        permission=BlobSasPermissions(create=True, write=True),
+        expiry=expires_at,
+    )
+    blob_client = blob_service.get_blob_client(UPLOAD_CONTAINER, blob_name)
+    return {
+        "mode": "blob",
+        "storage_key": blob_name,
+        "upload": {
+            "method": "PUT",
+            "url": f"{blob_client.url}?{sas_token}",
+            "headers": {
+                "x-ms-blob-type": "BlockBlob",
+                "Content-Type": mime_type,
+            },
+            "requires_api_auth": False,
+        },
+        "expires_at": expires_at.isoformat(),
+    }
+
+
+def _blob_upload_exists(blob_name: str) -> bool:
+    try:
+        from azure.storage.blob import BlobServiceClient
+    except Exception:
+        return False
+    conn = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
+    if not conn:
+        return False
+    try:
+        blob_service = BlobServiceClient.from_connection_string(conn)
+        blob_client = blob_service.get_blob_client(UPLOAD_CONTAINER, blob_name)
+        blob_client.get_blob_properties()
+        return True
+    except Exception:
+        return False
+
+
+def _build_local_upload_contract(upload_id: str, safe_name: str, mime_type: str) -> Dict[str, Any]:
+    storage_key = _resolve_upload_path(upload_id, safe_name)
+    return {
+        "mode": "local_api",
+        "storage_key": storage_key,
+        "upload": {
+            "method": "PUT",
+            "url": f"/api/uploads/{upload_id}/content",
+            "headers": {
+                "Content-Type": mime_type,
+            },
+            "requires_api_auth": True,
+        },
+        "expires_at": (datetime.now(timezone.utc) + timedelta(minutes=UPLOAD_SAS_EXPIRY_MINUTES)).isoformat(),
+    }
+
+
 def _resolve_input_files(payload: JobCreateRequest) -> JobCreateRequest:
     resolved_inputs = []
     for item in payload.input_files:
         resolved = item.model_copy(deep=True)
         if resolved.upload_id:
-            storage_key = _resolve_upload_path(resolved.upload_id, resolved.file_name)
-            if not os.path.isfile(storage_key):
+            manifest = _load_upload_manifest(resolved.upload_id)
+            if manifest:
+                if manifest.get("mode") == "blob":
+                    storage_key = manifest.get("storage_key")
+                    if not storage_key or not _blob_upload_exists(storage_key):
+                        raise HTTPException(
+                            status_code=400,
+                            detail=f"input_files upload_id {resolved.upload_id!r} has no uploaded blob content.",
+                        )
+                else:
+                    storage_key = manifest.get("storage_key")
+                    if not storage_key or not os.path.isfile(storage_key):
+                        raise HTTPException(
+                            status_code=400,
+                            detail=f"input_files upload_id {resolved.upload_id!r} has no uploaded local content.",
+                        )
+                resolved.storage_key = storage_key
+                if not resolved.file_name:
+                    resolved.file_name = manifest.get("file_name")
+                if not resolved.size_bytes:
+                    resolved.size_bytes = int(manifest.get("size_bytes") or 0)
+                if not resolved.mime_type:
+                    resolved.mime_type = manifest.get("mime_type")
+                resolved_inputs.append(resolved)
+                continue
+
+            # Backward-compatible fallback for legacy /api/upload path.
+            legacy_storage_key = _resolve_upload_path(resolved.upload_id, resolved.file_name)
+            if not os.path.isfile(legacy_storage_key):
                 raise HTTPException(
                     status_code=400,
                     detail=f"input_files upload_id {resolved.upload_id!r} does not reference an existing upload.",
                 )
-            resolved.storage_key = storage_key
+            resolved.storage_key = legacy_storage_key
             if not resolved.file_name:
-                resolved.file_name = os.path.basename(storage_key)
+                resolved.file_name = os.path.basename(legacy_storage_key)
             if not resolved.size_bytes:
-                resolved.size_bytes = os.path.getsize(storage_key)
+                resolved.size_bytes = os.path.getsize(legacy_storage_key)
         resolved_inputs.append(resolved)
     return payload.model_copy(update={"input_files": resolved_inputs})
 
@@ -285,6 +448,94 @@ MIME_TO_SOURCE_TYPE: Dict[str, str] = {
 }
 
 
+class UploadUrlRequest(BaseModel):
+    file_name: str = Field(min_length=1, max_length=512)
+    size_bytes: int = Field(gt=0, le=MAX_UPLOAD_BYTES)
+    mime_type: Optional[str] = None
+    source_type: Optional[str] = None
+    document_type: Optional[str] = "video"
+
+
+@api_router.post("/jobs/{job_id}/upload-url", status_code=201)
+async def create_upload_url(job_id: str, payload: UploadUrlRequest) -> Dict[str, Any]:
+    upload_id = str(uuid4())
+    safe_name = _safe_upload_name(payload.file_name)
+    mime_type = payload.mime_type or "application/octet-stream"
+    source_type = payload.source_type or MIME_TO_SOURCE_TYPE.get(mime_type, "document")
+
+    contract = _build_blob_upload_contract(job_id, upload_id, safe_name, mime_type)
+    if not contract:
+        contract = _build_local_upload_contract(upload_id, safe_name, mime_type)
+
+    manifest = {
+        "upload_id": upload_id,
+        "job_id": job_id,
+        "file_name": safe_name,
+        "size_bytes": payload.size_bytes,
+        "mime_type": mime_type,
+        "source_type": source_type,
+        "document_type": payload.document_type or "video",
+        "storage_key": contract["storage_key"],
+        "mode": contract["mode"],
+        "uploaded_at": None,
+        "expires_at": contract["expires_at"],
+        "created_at": _utc_now(),
+    }
+    _save_upload_manifest(upload_id, manifest)
+    return {
+        "upload_id": upload_id,
+        "job_id": job_id,
+        "file_name": safe_name,
+        "size_bytes": payload.size_bytes,
+        "mime_type": mime_type,
+        "source_type": source_type,
+        "storage_key": contract["storage_key"],
+        "expires_at": contract["expires_at"],
+        "upload": contract["upload"],
+    }
+
+
+@api_router.put("/uploads/{upload_id}/content", status_code=201)
+async def upload_content_via_api(upload_id: str, request: Request) -> Dict[str, Any]:
+    manifest = _load_upload_manifest(upload_id)
+    if not manifest:
+        raise HTTPException(status_code=404, detail=f"Upload id {upload_id!r} was not found.")
+    if manifest.get("mode") != "local_api":
+        raise HTTPException(status_code=409, detail="Upload content must be written to blob URL for this upload id.")
+    expires_at = _parse_iso8601(manifest.get("expires_at"))
+    if expires_at and expires_at < datetime.now(timezone.utc):
+        raise HTTPException(status_code=410, detail="Upload URL has expired.")
+
+    body = await request.body()
+    size_bytes = len(body)
+    if size_bytes > MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="File exceeds 500MB limit.")
+    expected_size = int(manifest.get("size_bytes") or 0)
+    if expected_size and expected_size != size_bytes:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Upload size mismatch for {upload_id}: expected {expected_size}, got {size_bytes}",
+        )
+
+    storage_key = manifest["storage_key"]
+    await anyio.to_thread.run_sync(lambda: os.makedirs(os.path.dirname(storage_key), exist_ok=True))
+
+    def _write() -> None:
+        with open(storage_key, "wb") as fh:
+            fh.write(body)
+
+    await anyio.to_thread.run_sync(_write)
+    updated = _update_upload_manifest(upload_id, {"uploaded_at": _utc_now()})
+    return {
+        "upload_id": upload_id,
+        "file_name": updated["file_name"],
+        "size_bytes": size_bytes,
+        "mime_type": updated["mime_type"],
+        "source_type": updated.get("source_type", "document"),
+        "location": storage_key,
+    }
+
+
 @api_router.post("/upload", status_code=201)
 async def upload_file(file: UploadFile = File(...)) -> Dict[str, Any]:
     upload_id = str(uuid4())
@@ -303,6 +554,23 @@ async def upload_file(file: UploadFile = File(...)) -> Dict[str, Any]:
     await anyio.to_thread.run_sync(_write)
 
     source_type = MIME_TO_SOURCE_TYPE.get(file.content_type or "", "document")
+    _save_upload_manifest(
+        upload_id,
+        {
+            "upload_id": upload_id,
+            "job_id": None,
+            "file_name": safe_name,
+            "size_bytes": size_bytes,
+            "mime_type": file.content_type,
+            "source_type": source_type,
+            "document_type": "video",
+            "storage_key": dest_path,
+            "mode": "local_api",
+            "uploaded_at": _utc_now(),
+            "expires_at": None,
+            "created_at": _utc_now(),
+        },
+    )
     return {
         "upload_id": upload_id,
         "file_name": safe_name,

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -68,19 +68,52 @@ export function exportUrl(jobId, fmt) {
   return `${BASE}/jobs/${jobId}/exports/${fmt}`
 }
 
-export async function uploadFile(file) {
-  const form = new FormData()
-  form.append('file', file)
-  const res = await fetch(`${BASE}/upload`, {
+function _resolveUploadUrl(url) {
+  if (/^https?:\/\//i.test(url)) return url
+  if (url.startsWith('/')) return `${DEV_BASE}${url}`
+  return url
+}
+
+function _makeClientUploadJobId() {
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID()
+  return `upload-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+export async function uploadFile(file, sourceType = 'document') {
+  const uploadJobId = _makeClientUploadJobId()
+  const requestRes = await _fetch(`/jobs/${uploadJobId}/upload-url`, {
     method: 'POST',
-    body: form,
-    headers: authHeaders(),
+    body: JSON.stringify({
+      file_name: file.name,
+      size_bytes: file.size,
+      mime_type: file.type || 'application/octet-stream',
+      source_type: sourceType,
+      document_type: sourceType === 'document' ? 'document' : 'video',
+    }),
   })
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({}))
-    throw new Error(err.detail ?? `Upload failed: ${res.statusText}`)
+  const uploadMeta = await requestRes.json()
+  const uploadUrl = _resolveUploadUrl(uploadMeta.upload.url)
+  const uploadHeaders = {
+    ...(uploadMeta.upload.headers ?? {}),
+    ...(uploadMeta.upload.requires_api_auth ? authHeaders() : {}),
   }
-  return res.json()
+  const uploadRes = await fetch(uploadUrl, {
+    method: uploadMeta.upload.method ?? 'PUT',
+    body: file,
+    headers: uploadHeaders,
+  })
+  if (!uploadRes.ok) {
+    const err = await uploadRes.json().catch(() => ({}))
+    throw new Error(err.detail ?? `Upload failed: ${uploadRes.statusText}`)
+  }
+  return {
+    upload_id: uploadMeta.upload_id,
+    file_name: uploadMeta.file_name,
+    size_bytes: uploadMeta.size_bytes,
+    mime_type: uploadMeta.mime_type,
+    source_type: uploadMeta.source_type,
+    storage_key: uploadMeta.storage_key,
+  }
 }
 
 function inferDownloadName(jobId, fmt, res) {

--- a/frontend/src/components/CreateJob.jsx
+++ b/frontend/src/components/CreateJob.jsx
@@ -63,7 +63,7 @@ export default function CreateJob({ onCreated }) {
           if (row.result) return row.result
           setRows(prev => prev.map((r, i) => i === idx ? { ...r, uploading: true, error: null } : r))
           try {
-            const result = await uploadFile(row.file)
+            const result = await uploadFile(row.file, row.sourceType)
             setRows(prev => prev.map((r, i) => i === idx ? { ...r, uploading: false, result, sourceType: result.source_type } : r))
             return { ...result, source_type: row.sourceType }
           } catch (err) {

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -103,6 +103,74 @@ def test_create_job_accepts_existing_upload_id(app_client):
     assert body["input_manifest"]["inputs"][0]["upload_id"] == upload["upload_id"]
 
 
+def test_upload_url_flow_accepts_uploaded_content(app_client):
+    upload_url_resp = app_client.client.post(
+        "/api/jobs/client-upload-1/upload-url",
+        json={
+            "file_name": "t.vtt",
+            "size_bytes": 50,
+            "mime_type": "text/vtt",
+            "source_type": "transcript",
+        },
+    )
+    assert upload_url_resp.status_code == 201
+    contract = upload_url_resp.json()
+    assert contract["upload"]["method"] == "PUT"
+    assert contract["upload_id"]
+
+    put_resp = app_client.client.put(
+        contract["upload"]["url"],
+        content=b"WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhello world\n",
+        headers=contract["upload"]["headers"],
+    )
+    assert put_resp.status_code == 201
+
+    payload = {
+        "input_files": [
+            {
+                "source_type": "transcript",
+                "file_name": contract["file_name"],
+                "size_bytes": contract["size_bytes"],
+                "mime_type": contract["mime_type"],
+                "upload_id": contract["upload_id"],
+            }
+        ]
+    }
+    create_resp = app_client.client.post("/api/jobs", json=payload)
+    assert create_resp.status_code == 201
+    body = create_resp.json()
+    assert body["input_manifest"]["inputs"][0]["upload_id"] == contract["upload_id"]
+
+
+def test_create_job_rejects_upload_url_without_uploaded_content(app_client):
+    upload_url_resp = app_client.client.post(
+        "/api/jobs/client-upload-2/upload-url",
+        json={
+            "file_name": "t.vtt",
+            "size_bytes": 32,
+            "mime_type": "text/vtt",
+            "source_type": "transcript",
+        },
+    )
+    assert upload_url_resp.status_code == 201
+    contract = upload_url_resp.json()
+
+    payload = {
+        "input_files": [
+            {
+                "source_type": "transcript",
+                "file_name": contract["file_name"],
+                "size_bytes": contract["size_bytes"],
+                "mime_type": contract["mime_type"],
+                "upload_id": contract["upload_id"],
+            }
+        ]
+    }
+    create_resp = app_client.client.post("/api/jobs", json=payload)
+    assert create_resp.status_code == 400
+    assert "upload_id" in create_resp.text
+
+
 def test_get_missing_job_returns_404(app_client):
     resp = app_client.client.get(f"/api/jobs/{uuid4()}")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add `POST /api/jobs/{job_id}/upload-url` contract for SAS/blob-first ingestion
- add local relay fallback `PUT /api/uploads/{upload_id}/content` for non-blob environments
- resolve `upload_id` in `create_job` via upload manifest and blob/local existence checks
- migrate frontend upload flow to request upload contract then PUT bytes
- add integration tests for upload-url happy path and missing-content rejection
- update `AGENTS.md` workflow: mandatory per-issue branch/PR flow; mark `HANDOVER.md` deprecated

## Validation
- `pytest tests/integration/test_lifecycle.py tests/integration/test_error_cases.py -q`
- Result: `31 passed, 1 warning`

Closes #9.