### PR TITLE
feat: implement issue #11 provider routing matrix

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2683,3 +2683,68 @@ Implemented the upload-contract migration requested by issue #9 while preserving
 - Kept `/api/upload` active to avoid breaking existing callers while migrating frontend to `upload-url`.
 - Implemented a local relay upload path (`/api/uploads/{upload_id}/content`) as fallback when direct blob SAS generation is unavailable (for example local/integration environments).
 - Scoped blob verification to existence checks during `create_job` so upload lifecycle remains deterministic without introducing new async callbacks/webhooks.
+
+## Section 18: Issue #11 — Full Provider Routing Matrix (2026-04-20)
+
+Implemented profile-aware non-chat routing and expanded effective-provider tracking for both `PFCD_PROVIDER=azure_openai` and `PFCD_PROVIDER=openai`.
+
+### What was added
+
+- `job_logic.py`
+  - Added `get_vision_model(profile)` with profile-aware routing:
+    - OpenAI: `OPENAI_VISION_MODEL_BALANCED` / `OPENAI_VISION_MODEL_QUALITY` with fallback to `OPENAI_VISION_MODEL`
+    - Azure OpenAI: `AZURE_OPENAI_VISION_DEPLOYMENT_BALANCED` / `AZURE_OPENAI_VISION_DEPLOYMENT_QUALITY` with fallback to `AZURE_OPENAI_VISION_DEPLOYMENT`
+  - Added `get_transcription_target(profile)` to resolve the effective transcription service target per provider.
+  - Expanded `profile_config()` to include `chat_model`, `vision_model`, and `transcription` target metadata.
+  - Expanded `default_job_payload().provider_effective` to capture:
+    - `chat_model`
+    - `transcription` service target
+    - `vision_model`
+    - `phase_resolved` map for per-phase effective routing snapshots.
+
+- `agents/vision.py`
+  - Vision model/deployment resolution moved from module-level static env vars to call-time profile-aware routing via `get_vision_model(...)`.
+  - `analyze_frames(..., profile=...)` now routes by both provider and profile.
+
+- `agents/transcription.py`
+  - Transcription target resolution now uses `get_transcription_target(...)`.
+  - Added optional `profile` passthrough (`transcribe_audio_blob(..., profile=...)`) for profile-aware routing parity.
+
+- `agents/adapters/video.py` and `agents/adapters/audio.py`
+  - Pass job profile to transcription/vision calls.
+  - Added compatibility fallback for legacy call signatures used in existing test monkeypatches.
+
+- `workers/runner.py`
+  - On successful phase completion, records per-phase effective routing in `provider_effective.phase_resolved`.
+  - Extraction phase now records resolved transcription service and vision model alongside chat model/profile/provider.
+
+### Tests added/updated
+
+- `tests/unit/test_job_logic.py`
+  - Added provider/profile routing coverage for vision model matrix.
+  - Added fallback coverage to single-var vision model env.
+  - Added transcription target matrix coverage.
+  - Updated `provider_effective` assertions for expanded payload.
+
+- `tests/unit/test_vision.py`
+  - Added matrix test for balanced/quality × openai/azure vision routing (4 combinations).
+  - Updated existing tests for new call signatures.
+
+- `tests/unit/test_worker.py`
+  - Added assertions for `provider_effective.phase_resolved.extracting` metadata.
+
+### Verification
+
+- `pytest -q tests/unit/test_job_logic.py tests/unit/test_vision.py tests/unit/test_media_preprocessor.py tests/unit/test_worker.py`
+  - Result: `60 passed`
+- `pytest -q tests/unit tests/integration`
+  - Result: `344 passed, 2 skipped`
+
+### Decisions
+
+- Chose `provider_effective.phase_resolved` at the job level for per-phase service provenance, avoiding schema changes to `agent_runs`.
+- Kept backward compatibility for existing adapter test monkeypatch patterns while adding profile-aware runtime parameters.
+
+### Open questions
+
+- None for issue scope. Optional future improvement: persist richer per-run service metadata in a dedicated `agent_runs.metadata` column if migration budget is available.

--- a/backend/app/agents/adapters/audio.py
+++ b/backend/app/agents/adapters/audio.py
@@ -57,10 +57,14 @@ class AudioAdapter(IProcessEvidenceAdapter):
         source_inputs = manifest.get("inputs") or []
         audio_input = next((inp for inp in source_inputs if inp.get("source_type") == "audio"), {})
         storage_key = audio_input.get("storage_key")
+        profile = job.get("profile_requested") or "balanced"
 
         transcript_text = ""
         if storage_key:
-            raw = transcribe_audio_blob(storage_key)
+            try:
+                raw = transcribe_audio_blob(storage_key, profile=profile)
+            except TypeError:
+                raw = transcribe_audio_blob(storage_key)
             if raw and not raw.startswith("[transcription"):
                 transcript_text = raw
                 job["_audio_transcript_inline"] = raw

--- a/backend/app/agents/adapters/video.py
+++ b/backend/app/agents/adapters/video.py
@@ -109,10 +109,14 @@ class VideoAdapter(IProcessEvidenceAdapter):
 
         storage_key = video_meta.get("storage_key")
         interval = frame_policy.get("sample_interval_sec", 5)
+        profile = job.get("profile_requested") or "balanced"
         transcript_text = ""
 
         if has_audio and storage_key:
-            raw = transcribe_audio_blob(storage_key)
+            try:
+                raw = transcribe_audio_blob(storage_key, profile=profile)
+            except TypeError:
+                raw = transcribe_audio_blob(storage_key)
             if raw and not raw.startswith("[transcription"):
                 transcript_text = raw
                 job["_video_transcript_inline"] = raw
@@ -134,7 +138,10 @@ class VideoAdapter(IProcessEvidenceAdapter):
                         if persisted_key:
                             frame_storage_keys.append((persisted_key, timestamp_sec))
                     job.setdefault("agent_signals", {})["frame_storage_keys"] = frame_storage_keys
-                    frame_descriptions = analyze_frames(frames, frame_policy)
+                    try:
+                        frame_descriptions = analyze_frames(frames, frame_policy, profile=profile)
+                    except TypeError:
+                        frame_descriptions = analyze_frames(frames, frame_policy)
                     if frame_descriptions:
                         job["_frame_descriptions_inline"] = frame_descriptions
             finally:

--- a/backend/app/agents/transcription.py
+++ b/backend/app/agents/transcription.py
@@ -18,7 +18,7 @@ from app.agents.media_preprocessor import (
     merge_vtt_chunks,
     split_audio_chunks,
 )
-from app.job_logic import _provider_name
+from app.job_logic import Profile, _provider_name, get_transcription_target
 
 logger = logging.getLogger(__name__)
 
@@ -31,11 +31,10 @@ def _too_large_stub() -> str:
     return "[transcription_skipped:file_too_large — chunked transcription pending MediaPreprocessor]"
 
 
-def _transcribe_with_azure(storage_key: str) -> str:
+def _transcribe_with_azure(storage_key: str, *, deployment: str) -> str:
     from azure.identity import DefaultAzureCredential
 
     endpoint = os.environ["AZURE_OPENAI_ENDPOINT"].rstrip("/")
-    deployment = os.environ.get("AZURE_OPENAI_WHISPER_DEPLOYMENT", "whisper")
     api_version = os.environ.get("AZURE_OPENAI_API_VERSION", _DEFAULT_AZURE_OPENAI_API_VERSION)
     url = (
         f"{endpoint}/openai/deployments/{deployment}/audio/transcriptions"
@@ -54,9 +53,8 @@ def _transcribe_with_azure(storage_key: str) -> str:
         return response.text
 
 
-def _transcribe_with_openai(storage_key: str) -> str:
+def _transcribe_with_openai(storage_key: str, *, model: str) -> str:
     api_key = os.environ["OPENAI_API_KEY"]
-    model = os.environ.get("OPENAI_TRANSCRIPTION_MODEL", "whisper-1")
     headers = {"Authorization": f"Bearer {api_key}"}
 
     with open(storage_key, "rb") as fh:
@@ -73,13 +71,20 @@ def _transcribe_with_openai(storage_key: str) -> str:
         return response.text
 
 
-def _transcribe_single(path: str) -> str:
+def _resolve_profile(profile: str | None) -> Profile:
+    if (profile or "").strip().lower() == Profile.QUALITY.value:
+        return Profile.QUALITY
+    return Profile.BALANCED
+
+
+def _transcribe_single(path: str, profile: str | None = None) -> str:
+    target = get_transcription_target(_resolve_profile(profile))
     if _provider_name() == "openai":
-        return _transcribe_with_openai(path)
-    return _transcribe_with_azure(path)
+        return _transcribe_with_openai(path, model=target["model"])
+    return _transcribe_with_azure(path, deployment=target["model"])
 
 
-def transcribe_audio_blob(storage_key: str) -> str:
+def transcribe_audio_blob(storage_key: str, *, profile: str | None = None) -> str:
     """Transcribe audio/video file at storage_key using Whisper. Returns VTT text."""
     tmp_dir: str | None = None
     try:
@@ -115,7 +120,10 @@ def transcribe_audio_blob(storage_key: str) -> str:
 
         vtt_chunks: list[tuple[str, float]] = []
         for chunk_path, offset_sec in chunk_pairs:
-            vtt = _transcribe_single(chunk_path)
+            if profile is None:
+                vtt = _transcribe_single(chunk_path)
+            else:
+                vtt = _transcribe_single(chunk_path, profile)
             if vtt.startswith("[transcription"):
                 logger.warning("Chunk transcription failed at offset %.0fs: %s", offset_sec, vtt)
                 continue

--- a/backend/app/agents/vision.py
+++ b/backend/app/agents/vision.py
@@ -9,14 +9,12 @@ from typing import Any
 
 import httpx
 
-from app.job_logic import _provider_name
+from app.job_logic import Profile, _provider_name, get_vision_model
 
 logger = logging.getLogger(__name__)
 
 _MAX_FRAMES_PER_CALL = int(os.environ.get("PFCD_VISION_FRAMES_PER_CALL", "4"))
 _MAX_FRAMES_TOTAL = int(os.environ.get("PFCD_VISION_MAX_FRAMES", "40"))
-_OPENAI_VISION_MODEL = os.environ.get("OPENAI_VISION_MODEL", "gpt-4o-mini")
-_AZURE_VISION_DEPLOYMENT = os.environ.get("AZURE_OPENAI_VISION_DEPLOYMENT", "")
 
 _SYSTEM_PROMPT = """You are a process documentation assistant. For each video frame shown, describe:
 1. What the user is doing (actions, clicks, navigation)
@@ -68,14 +66,15 @@ def _build_messages(batch: list[tuple[str, float]], policy: dict[str, Any]) -> l
     ]
 
 
-def _call_vision_openai(messages: list[dict]) -> str:
+def _call_vision_openai(messages: list[dict], *, model: str | None = None) -> str:
     """POST to OpenAI chat completions with vision content."""
     api_key = os.environ["OPENAI_API_KEY"]
+    resolved_model = model or os.environ.get("OPENAI_VISION_MODEL", "gpt-4o-mini")
     response = httpx.post(
         "https://api.openai.com/v1/chat/completions",
         headers={"Authorization": f"Bearer {api_key}"},
         json={
-            "model": _OPENAI_VISION_MODEL,
+            "model": resolved_model,
             "messages": messages,
             "max_completion_tokens": _max_completion_tokens(),
         },
@@ -85,17 +84,18 @@ def _call_vision_openai(messages: list[dict]) -> str:
     return response.json()["choices"][0]["message"]["content"]
 
 
-def _call_vision_azure(messages: list[dict]) -> str:
+def _call_vision_azure(messages: list[dict], *, deployment: str | None = None) -> str:
     """POST to Azure OpenAI chat completions with vision content."""
     from azure.identity import DefaultAzureCredential
 
-    if not _AZURE_VISION_DEPLOYMENT:
+    resolved_deployment = deployment or os.environ.get("AZURE_OPENAI_VISION_DEPLOYMENT", "")
+    if not resolved_deployment:
         raise ValueError("AZURE_OPENAI_VISION_DEPLOYMENT is not set")
 
     endpoint = os.environ["AZURE_OPENAI_ENDPOINT"].rstrip("/")
     api_version = os.environ.get("AZURE_OPENAI_API_VERSION", "2024-10-21")
     url = (
-        f"{endpoint}/openai/deployments/{_AZURE_VISION_DEPLOYMENT}"
+        f"{endpoint}/openai/deployments/{resolved_deployment}"
         f"/chat/completions?api-version={api_version}"
     )
     credential = DefaultAzureCredential()
@@ -110,7 +110,13 @@ def _call_vision_azure(messages: list[dict]) -> str:
     return response.json()["choices"][0]["message"]["content"]
 
 
-def analyze_frames(frames: list[tuple[str, float]], policy: dict) -> str:
+def _resolve_profile(profile: str | None) -> Profile:
+    if (profile or "").strip().lower() == Profile.QUALITY.value:
+        return Profile.QUALITY
+    return Profile.BALANCED
+
+
+def analyze_frames(frames: list[tuple[str, float]], policy: dict, *, profile: str | None = None) -> str:
     if not frames:
         return ""
 
@@ -122,10 +128,11 @@ def analyze_frames(frames: list[tuple[str, float]], policy: dict) -> str:
         for index in range(0, len(capped_frames), batch_size):
             batch = capped_frames[index:index + batch_size]
             messages = _build_messages(batch, policy)
+            vision_model = get_vision_model(_resolve_profile(profile))
             if _provider_name() == "openai":
-                responses.append(_call_vision_openai(messages))
+                responses.append(_call_vision_openai(messages, model=vision_model))
             else:
-                responses.append(_call_vision_azure(messages))
+                responses.append(_call_vision_azure(messages, deployment=vision_model))
 
         return "\n\n".join(text for text in responses if text)
     except Exception as exc:  # pragma: no cover - exercised by unit tests

--- a/backend/app/job_logic.py
+++ b/backend/app/job_logic.py
@@ -96,6 +96,16 @@ def _provider_name() -> str:
     return os.environ.get("PFCD_PROVIDER", "azure_openai").strip().lower() or "azure_openai"
 
 
+def _coerce_profile(profile: Profile | str | None) -> Profile:
+    if isinstance(profile, Profile):
+        return profile
+    if isinstance(profile, str):
+        normalized = profile.strip().lower()
+        if normalized == Profile.QUALITY.value:
+            return Profile.QUALITY
+    return Profile.BALANCED
+
+
 def _default_chat_model() -> str:
     deployment = os.environ.get("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME")
     if deployment:
@@ -139,20 +149,76 @@ def _profile_chat_model(profile: Profile) -> str:
     )
 
 
+def get_vision_model(profile: Profile | str | None) -> str:
+    resolved_profile = _coerce_profile(profile)
+    provider = _provider_name()
+    if provider == "openai":
+        default_model = "gpt-4o-mini"
+        if resolved_profile == Profile.QUALITY:
+            return (
+                os.environ.get("OPENAI_VISION_MODEL_QUALITY")
+                or os.environ.get("OPENAI_VISION_MODEL")
+                or "gpt-4o"
+            )
+        return (
+            os.environ.get("OPENAI_VISION_MODEL_BALANCED")
+            or os.environ.get("OPENAI_VISION_MODEL")
+            or default_model
+        )
+
+    if resolved_profile == Profile.QUALITY:
+        return (
+            os.environ.get("AZURE_OPENAI_VISION_DEPLOYMENT_QUALITY")
+            or os.environ.get("AZURE_OPENAI_VISION_DEPLOYMENT")
+            or ""
+        )
+    return (
+        os.environ.get("AZURE_OPENAI_VISION_DEPLOYMENT_BALANCED")
+        or os.environ.get("AZURE_OPENAI_VISION_DEPLOYMENT")
+        or ""
+    )
+
+
+def get_transcription_target(profile: Profile | str | None) -> Dict[str, str]:
+    # Profile is accepted for parity with chat/vision routing and future
+    # per-profile transcription targets.
+    _ = _coerce_profile(profile)
+    provider = _provider_name()
+    if provider == "openai":
+        return {
+            "provider": "openai",
+            "service": "openai_whisper",
+            "model": os.environ.get("OPENAI_TRANSCRIPTION_MODEL", "whisper-1"),
+        }
+    return {
+        "provider": "azure_openai",
+        "service": "azure_openai_whisper",
+        "model": os.environ.get("AZURE_OPENAI_WHISPER_DEPLOYMENT", "whisper"),
+    }
+
+
 def profile_config(profile: Profile) -> Dict[str, Any]:
     provider = _provider_name()
-    deployment = _profile_chat_model(profile)
+    chat_model = _profile_chat_model(profile)
+    vision_model = get_vision_model(profile)
+    transcription = get_transcription_target(profile)
     if profile == Profile.QUALITY:
         return {
             "profile": profile.value,
             "provider": provider,
-            "model": deployment,
+            "model": chat_model,
+            "chat_model": chat_model,
+            "vision_model": vision_model,
+            "transcription": transcription,
             "cost_cap_usd": 8.0,
         }
     return {
         "profile": profile.value,
         "provider": provider,
-        "model": deployment,
+        "model": chat_model,
+        "chat_model": chat_model,
+        "vision_model": vision_model,
+        "transcription": transcription,
         "cost_cap_usd": 4.0,
     }
 
@@ -176,9 +242,13 @@ def default_job_payload(payload: JobCreateRequest) -> Dict[str, Any]:
         "profile_requested": payload.profile.value,
         "provider_effective": {
             "provider": profile_conf["provider"],
-            "deployment": profile_conf["model"],
+            "deployment": profile_conf["chat_model"],
+            "chat_model": profile_conf["chat_model"],
             "profile": profile_conf["profile"],
             "cost_cap_usd": profile_conf["cost_cap_usd"],
+            "transcription": profile_conf["transcription"],
+            "vision_model": profile_conf["vision_model"],
+            "phase_resolved": {},
         },
         "input_manifest": {
             "video": {

--- a/backend/app/workers/runner.py
+++ b/backend/app/workers/runner.py
@@ -25,6 +25,8 @@ from app.job_logic import (
     add_agent_run,
     apply_cost_tracking_and_cap_warning,
     build_draft,
+    get_transcription_target,
+    get_vision_model,
     load_transcript_text,
     profile_config,
     update_agent_run,
@@ -57,6 +59,23 @@ _TERMINAL_STATUSES = {
     JobStatus.EXPIRED.value,
     JobStatus.DELETED.value,
 }
+
+
+def _record_phase_provider_effective(job: Dict[str, Any], *, phase: str, profile_conf: Dict[str, Any]) -> None:
+    provider_effective = job.setdefault("provider_effective", {})
+    phase_resolved = provider_effective.setdefault("phase_resolved", {})
+    profile = profile_conf.get("profile", "balanced")
+    provider = profile_conf.get("provider")
+    chat_model = profile_conf.get("chat_model") or profile_conf.get("model")
+    phase_payload: Dict[str, Any] = {
+        "provider": provider,
+        "profile": profile,
+        "chat_model": chat_model,
+    }
+    if phase == "extracting":
+        phase_payload["transcription"] = get_transcription_target(profile)
+        phase_payload["vision_model"] = get_vision_model(profile)
+    phase_resolved[phase] = phase_payload
 def _load_message(raw_body: Any) -> Dict[str, Any]:
     if isinstance(raw_body, (bytes, bytearray)):
         return json.loads(raw_body.decode("utf-8"))
@@ -176,6 +195,7 @@ class Worker:
             duration_ms=duration_ms,
             cost=cost,
         )
+        _record_phase_provider_effective(job, phase=self.phase, profile_conf=profile_conf)
         apply_cost_tracking_and_cap_warning(
             job,
             phase=self.phase,

--- a/tests/unit/test_job_logic.py
+++ b/tests/unit/test_job_logic.py
@@ -12,6 +12,8 @@ from app.job_logic import (
     Profile,
     apply_cost_tracking_and_cap_warning,
     default_job_payload,
+    get_transcription_target,
+    get_vision_model,
     profile_config,
 )
 
@@ -107,6 +109,85 @@ def test_default_job_payload_uses_provider_effective_from_profile(monkeypatch):
 
     assert job["provider_effective"]["provider"] == "openai"
     assert job["provider_effective"]["deployment"] == "gpt-4o-mini"
+    assert job["provider_effective"]["chat_model"] == "gpt-4o-mini"
+    assert job["provider_effective"]["transcription"]["service"] == "openai_whisper"
+
+
+@pytest.mark.parametrize(
+    ("provider", "profile", "balanced_key", "quality_key", "fallback_key", "expected"),
+    [
+        (
+            "openai",
+            Profile.BALANCED,
+            "OPENAI_VISION_MODEL_BALANCED",
+            "OPENAI_VISION_MODEL_QUALITY",
+            "OPENAI_VISION_MODEL",
+            "gpt-4o-mini",
+        ),
+        (
+            "openai",
+            Profile.QUALITY,
+            "OPENAI_VISION_MODEL_BALANCED",
+            "OPENAI_VISION_MODEL_QUALITY",
+            "OPENAI_VISION_MODEL",
+            "gpt-4o",
+        ),
+        (
+            "azure_openai",
+            Profile.BALANCED,
+            "AZURE_OPENAI_VISION_DEPLOYMENT_BALANCED",
+            "AZURE_OPENAI_VISION_DEPLOYMENT_QUALITY",
+            "AZURE_OPENAI_VISION_DEPLOYMENT",
+            "azure-vision-balanced",
+        ),
+        (
+            "azure_openai",
+            Profile.QUALITY,
+            "AZURE_OPENAI_VISION_DEPLOYMENT_BALANCED",
+            "AZURE_OPENAI_VISION_DEPLOYMENT_QUALITY",
+            "AZURE_OPENAI_VISION_DEPLOYMENT",
+            "azure-vision-quality",
+        ),
+    ],
+)
+def test_get_vision_model_profile_matrix(
+    monkeypatch,
+    provider,
+    profile,
+    balanced_key,
+    quality_key,
+    fallback_key,
+    expected,
+):
+    monkeypatch.setenv("PFCD_PROVIDER", provider)
+    monkeypatch.setenv(balanced_key, "gpt-4o-mini" if provider == "openai" else "azure-vision-balanced")
+    monkeypatch.setenv(quality_key, "gpt-4o" if provider == "openai" else "azure-vision-quality")
+    monkeypatch.delenv(fallback_key, raising=False)
+
+    assert get_vision_model(profile) == expected
+
+
+def test_get_vision_model_falls_back_to_single_var(monkeypatch):
+    monkeypatch.setenv("PFCD_PROVIDER", "openai")
+    monkeypatch.delenv("OPENAI_VISION_MODEL_BALANCED", raising=False)
+    monkeypatch.delenv("OPENAI_VISION_MODEL_QUALITY", raising=False)
+    monkeypatch.setenv("OPENAI_VISION_MODEL", "gpt-4.1-mini")
+    assert get_vision_model(Profile.BALANCED) == "gpt-4.1-mini"
+    assert get_vision_model(Profile.QUALITY) == "gpt-4.1-mini"
+
+
+def test_get_transcription_target_provider_matrix(monkeypatch):
+    monkeypatch.setenv("PFCD_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_TRANSCRIPTION_MODEL", "whisper-1")
+    openai_target = get_transcription_target(Profile.BALANCED)
+    assert openai_target["service"] == "openai_whisper"
+    assert openai_target["model"] == "whisper-1"
+
+    monkeypatch.setenv("PFCD_PROVIDER", "azure_openai")
+    monkeypatch.setenv("AZURE_OPENAI_WHISPER_DEPLOYMENT", "whisper-prod")
+    azure_target = get_transcription_target(Profile.QUALITY)
+    assert azure_target["service"] == "azure_openai_whisper"
+    assert azure_target["model"] == "whisper-prod"
 
 
 def test_cost_cap_warn_only_adds_warning_flag(monkeypatch):

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import pathlib
 import sys
+from typing import Any
 from unittest.mock import patch
 
 import httpx
+import pytest
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 BACKEND = ROOT / "backend"
@@ -28,7 +30,7 @@ def test_analyze_frames_calls_openai_provider(monkeypatch):
     monkeypatch.setattr("app.agents.vision._build_messages", lambda _frames, _policy: [{"role": "user"}])
     monkeypatch.setattr(
         "app.agents.vision._call_vision_openai",
-        lambda _messages: "Frame 1: User opens SAP.",
+        lambda _messages, *, model=None: "Frame 1: User opens SAP.",
     )
 
     result = analyze_frames(frames, {})
@@ -110,8 +112,7 @@ def test_call_vision_azure_uses_max_completion_tokens(monkeypatch):
     monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com")
     monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-10-21")
     monkeypatch.setenv("PFCD_MAX_COMPLETION_TOKENS", "444")
-    monkeypatch.setattr("app.agents.vision._AZURE_VISION_DEPLOYMENT", "vision-deployment")
-
+    monkeypatch.setenv("AZURE_OPENAI_VISION_DEPLOYMENT", "vision-deployment")
     captured: dict = {}
 
     class _Resp:
@@ -142,3 +143,48 @@ def test_call_vision_azure_uses_max_completion_tokens(monkeypatch):
     assert result == "ok"
     assert captured["json"]["max_completion_tokens"] == 444
     assert "max_tokens" not in captured["json"]
+
+
+@pytest.mark.parametrize(
+    ("provider", "profile", "expected_target"),
+    [
+        ("openai", "balanced", "openai-balanced-vision"),
+        ("openai", "quality", "openai-quality-vision"),
+        ("azure_openai", "balanced", "azure-balanced-vision"),
+        ("azure_openai", "quality", "azure-quality-vision"),
+    ],
+)
+def test_analyze_frames_routes_by_profile_and_provider(
+    monkeypatch, provider: str, profile: str, expected_target: str
+):
+    from app.agents.vision import analyze_frames
+
+    frames = [("/tmp/f1.jpg", 0.0)]
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr("app.agents.vision._provider_name", lambda: provider)
+    monkeypatch.setattr("app.agents.vision._build_messages", lambda _frames, _policy: [{"role": "user"}])
+
+    def _fake_get_vision_model(_profile):
+        return expected_target
+
+    monkeypatch.setattr("app.agents.vision.get_vision_model", _fake_get_vision_model)
+
+    def _openai_call(_messages, *, model=None):
+        captured["target"] = model
+        return "openai-ok"
+
+    def _azure_call(_messages, *, deployment=None):
+        captured["target"] = deployment
+        return "azure-ok"
+
+    monkeypatch.setattr("app.agents.vision._call_vision_openai", _openai_call)
+    monkeypatch.setattr("app.agents.vision._call_vision_azure", _azure_call)
+
+    result = analyze_frames(frames, {}, profile=profile)
+
+    assert expected_target == captured["target"]
+    if provider == "openai":
+        assert result == "openai-ok"
+    else:
+        assert result == "azure-ok"

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -84,6 +84,10 @@ def test_worker_extracting_phase(tmp_path, monkeypatch):
 
     updated = repository.get_job(job_id)
     assert updated["last_completed_phase"] == "extracting"
+    phase_resolved = updated["provider_effective"].get("phase_resolved", {}).get("extracting", {})
+    assert phase_resolved.get("chat_model") == updated["provider_effective"]["chat_model"]
+    assert isinstance(phase_resolved.get("transcription"), dict)
+    assert "vision_model" in phase_resolved
     # After extracting, next phase (processing) is enqueued
     assert len(enqueued) == 1
     assert enqueued[0][0] == "processing"


### PR DESCRIPTION
## Summary
- implement profile-aware vision routing for both `PFCD_PROVIDER=openai` and `PFCD_PROVIDER=azure_openai`
- add routing helpers in `job_logic.py`: `get_vision_model(profile)` and `get_transcription_target(profile)`
- expand `provider_effective` with `chat_model`, `transcription`, `vision_model`, and `phase_resolved` snapshots
- record per-phase effective service routing in worker phase completion (`provider_effective.phase_resolved`)
- wire adapters and agent calls to pass profile through to transcription/vision resolution
- add unit coverage for balanced/quality × openai/azure matrix and provider-effective recording

## Validation
- `pytest -q tests/unit/test_job_logic.py tests/unit/test_vision.py tests/unit/test_media_preprocessor.py tests/unit/test_worker.py` (60 passed)
- `pytest -q tests/unit tests/integration` (344 passed, 2 skipped)

## Issue
- Closes #11