### PR TITLE
feat: implement issue #12 preflight cost confirmation flow

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2748,3 +2748,61 @@ Implemented profile-aware non-chat routing and expanded effective-provider track
 ### Open questions
 
 - None for issue scope. Optional future improvement: persist richer per-run service metadata in a dedicated `agent_runs.metadata` column if migration budget is available.
+
+## Section 19: Issue #12 — Preflight Cost Confirmation Gate (2026-04-20)
+
+Implemented a preflight cost confirmation flow for selected profiles (default: `quality`) so high-cost runs are held before orchestration enqueue.
+
+### What was added
+
+- `backend/app/job_logic.py`
+  - Added `JobStatus.AWAITING_CONFIRMATION = "awaiting_confirmation"`.
+  - Added `cost_confirmation_profiles()` parsing `PFCD_COST_CONFIRM_PROFILES` (default `quality`).
+  - Added `requires_cost_confirmation(profile)` helper.
+
+- `backend/app/main.py`
+  - Updated `POST /api/jobs`:
+    - If profile requires confirmation: creates job with `status=awaiting_confirmation`, persists it, and returns without Service Bus enqueue.
+    - If confirmation is not required: existing immediate enqueue flow remains unchanged.
+    - Response now includes `cost_estimate` with `{profile, cost_cap_usd, requires_confirmation}`.
+  - Added new endpoint `POST /api/jobs/{job_id}/confirm-cost`:
+    - `awaiting_confirmation` -> `queued`, persists transition, enqueues `extracting` phase.
+    - Returns `409` if job is not awaiting confirmation.
+    - Returns `404` for missing/deleted jobs.
+
+- `frontend/src/api.js`
+  - Added `confirmCost(jobId)` client helper.
+
+- `frontend/src/components/CreateJob.jsx`
+  - Added in-place confirmation panel when create-job returns `awaiting_confirmation`.
+  - Added `Confirm & Start` button to call `confirmCost(jobId)`.
+  - Keeps existing behavior for non-confirmation jobs (navigates immediately).
+
+### Tests added/updated
+
+- `tests/unit/test_job_logic.py`
+  - Added coverage for default/override behavior of `PFCD_COST_CONFIRM_PROFILES` and `requires_cost_confirmation(...)`.
+
+- `tests/integration/test_lifecycle.py`
+  - Added quality profile create test: `awaiting_confirmation` + no enqueue.
+  - Added confirm-cost happy path test: transitions to `queued` + enqueues.
+  - Tightened balanced create regression assertion: still enqueues immediately.
+
+- `tests/integration/test_error_cases.py`
+  - Added confirm-cost wrong-state test (`409`).
+
+### Verification
+
+- `pytest -q tests/unit/test_job_logic.py tests/integration/test_lifecycle.py tests/integration/test_error_cases.py`
+  - Result: `52 passed`
+- `pytest -q tests/unit tests/integration`
+  - Result: `349 passed, 2 skipped`
+
+### Decisions
+
+- Implemented confirmation control via env var profile list (`PFCD_COST_CONFIRM_PROFILES`) for runtime configurability without code changes.
+- Kept worker terminal-skip logic unchanged; `awaiting_confirmation` remains non-terminal and is never auto-processed because enqueue only happens after explicit confirmation.
+
+### Open questions
+
+- None for this issue scope.

--- a/backend/app/job_logic.py
+++ b/backend/app/job_logic.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 class JobStatus(str, Enum):
     QUEUED = "queued"
+    AWAITING_CONFIRMATION = "awaiting_confirmation"
     PROCESSING = "processing"
     NEEDS_REVIEW = "needs_review"
     FINALIZING = "finalizing"
@@ -94,6 +95,16 @@ def _safe_dict(value: Optional[Dict[str, Any]]) -> Dict[str, Any]:
 
 def _provider_name() -> str:
     return os.environ.get("PFCD_PROVIDER", "azure_openai").strip().lower() or "azure_openai"
+
+
+def cost_confirmation_profiles() -> set[str]:
+    raw = os.environ.get("PFCD_COST_CONFIRM_PROFILES", "quality")
+    return {token.strip().lower() for token in raw.split(",") if token.strip()}
+
+
+def requires_cost_confirmation(profile: Profile | str | None) -> bool:
+    resolved = _coerce_profile(profile)
+    return resolved.value in cost_confirmation_profiles()
 
 
 def _coerce_profile(profile: Profile | str | None) -> Profile:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,6 +33,7 @@ from app.job_logic import (
     JobCreateRequest,
     JobStatus,
     ReviewSeverity,
+    requires_cost_confirmation,
     _utc_now,
     default_job_payload,
 )
@@ -604,6 +605,9 @@ async def create_job(payload: JobCreateRequest) -> Dict[str, Any]:
     job_id = str(uuid4())
     job = default_job_payload(payload)
     job["job_id"] = job_id
+    needs_confirmation = requires_cost_confirmation(job.get("profile_requested"))
+    if needs_confirmation:
+        job["status"] = JobStatus.AWAITING_CONFIRMATION.value
     await _repo_upsert_job(job_id, job)
     await anyio.to_thread.run_sync(
         JOB_REPO.append_job_event,
@@ -612,16 +616,59 @@ async def create_job(payload: JobCreateRequest) -> Dict[str, Any]:
         {"job_id": job_id, "profile": job["profile_requested"], "at": _utc_now()},
     )
 
+    if not needs_confirmation:
+        trace_id = str(uuid4())
+        message = build_message(
+            job_id=job_id,
+            phase="extracting",
+            attempt=0,
+            requested_by="api",
+            trace_id=trace_id,
+        )
+        await anyio.to_thread.run_sync(ORCHESTRATOR.enqueue, "extracting", message)
+
+    logger.info(
+        "Job created: job_id=%s profile=%s status=%s",
+        job_id,
+        job["profile_requested"],
+        job["status"],
+    )
+    response = {"job_id": job_id, **job}
+    response["cost_estimate"] = {
+        "profile": job["provider_effective"].get("profile"),
+        "cost_cap_usd": job["provider_effective"].get("cost_cap_usd"),
+        "requires_confirmation": needs_confirmation,
+    }
+    return response
+
+
+@api_router.post("/jobs/{job_id}/confirm-cost")
+async def confirm_cost(job_id: str) -> Dict[str, Any]:
+    job = await _job_or_404(job_id)
+    if job["status"] == JobStatus.DELETED.value:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job["status"] != JobStatus.AWAITING_CONFIRMATION.value:
+        raise HTTPException(status_code=409, detail="Job is not awaiting cost confirmation.")
+
+    job["status"] = JobStatus.QUEUED.value
+    job["updated_at"] = _utc_now()
+    await _repo_upsert_job(job_id, job)
+    await anyio.to_thread.run_sync(
+        JOB_REPO.append_job_event,
+        job_id,
+        "cost_confirmed",
+        {"job_id": job_id, "at": _utc_now()},
+    )
+
     trace_id = str(uuid4())
     message = build_message(
         job_id=job_id,
         phase="extracting",
         attempt=0,
-        requested_by="api",
+        requested_by="api:confirm-cost",
         trace_id=trace_id,
     )
     await anyio.to_thread.run_sync(ORCHESTRATOR.enqueue, "extracting", message)
-    logger.info("Job created: job_id=%s profile=%s", job_id, job["profile_requested"])
     return {"job_id": job_id, **job}
 
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -34,6 +34,11 @@ export async function createJob(payload) {
   return res.json()
 }
 
+export async function confirmCost(jobId) {
+  const res = await _fetch(`/jobs/${jobId}/confirm-cost`, { method: 'POST' })
+  return res.json()
+}
+
 export async function getJob(jobId) {
   const res = await _fetch(`/jobs/${jobId}`)
   return res.json()

--- a/frontend/src/components/CreateJob.jsx
+++ b/frontend/src/components/CreateJob.jsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react'
-import { createJob, uploadFile } from '../api'
+import { confirmCost, createJob, uploadFile } from '../api'
 
 const SOURCE_TYPES = ['video', 'audio', 'transcript', 'document']
 
@@ -25,6 +25,8 @@ export default function CreateJob({ onCreated }) {
   const [profile, setProfile] = useState('balanced')
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState(null)
+  const [pendingConfirmation, setPendingConfirmation] = useState(null)
+  const [confirming, setConfirming] = useState(false)
   const inputRef = useRef()
 
   function onFilesPicked(e) {
@@ -55,6 +57,7 @@ export default function CreateJob({ onCreated }) {
     if (rows.length === 0) return
     setSubmitError(null)
     setSubmitting(true)
+    setPendingConfirmation(null)
 
     try {
       // Upload all files that haven't been uploaded yet
@@ -83,7 +86,15 @@ export default function CreateJob({ onCreated }) {
           upload_id: u.upload_id,
         })),
       })
-      onCreated(data.job_id)
+      if (data.status === 'awaiting_confirmation') {
+        setPendingConfirmation({
+          jobId: data.job_id,
+          profile: data.cost_estimate?.profile ?? profile,
+          cap: data.cost_estimate?.cost_cap_usd ?? null,
+        })
+      } else {
+        onCreated(data.job_id)
+      }
     } catch (err) {
       if (!rows.some(r => r.error)) {
         const detail = err.data?.detail
@@ -91,6 +102,21 @@ export default function CreateJob({ onCreated }) {
       }
     } finally {
       setSubmitting(false)
+    }
+  }
+
+  async function handleConfirmStart() {
+    if (!pendingConfirmation?.jobId) return
+    setSubmitError(null)
+    setConfirming(true)
+    try {
+      const data = await confirmCost(pendingConfirmation.jobId)
+      onCreated(data.job_id)
+    } catch (err) {
+      const detail = err.data?.detail
+      setSubmitError(typeof detail === 'string' ? detail : detail?.message ?? err.message)
+    } finally {
+      setConfirming(false)
     }
   }
 
@@ -191,9 +217,27 @@ export default function CreateJob({ onCreated }) {
           </div>
         )}
 
+        {pendingConfirmation && (
+          <div className="bg-amber-50 border border-amber-300 text-amber-800 text-sm rounded px-3 py-3 space-y-2">
+            <p className="font-medium">Cost confirmation required</p>
+            <p className="text-xs">
+              Profile: <span className="font-semibold capitalize">{pendingConfirmation.profile}</span>
+              {pendingConfirmation.cap !== null ? ` · Cap: $${pendingConfirmation.cap}` : ''}
+            </p>
+            <button
+              type="button"
+              onClick={handleConfirmStart}
+              disabled={confirming}
+              className="bg-amber-600 text-white px-3 py-1.5 rounded font-medium hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {confirming ? 'Starting…' : 'Confirm & Start'}
+            </button>
+          </div>
+        )}
+
         <button
           type="submit"
-          disabled={submitting || anyUploading || rows.length === 0}
+          disabled={submitting || confirming || anyUploading || rows.length === 0}
           className="w-full bg-indigo-600 text-white py-2 rounded-lg font-medium hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {anyUploading ? 'Uploading files…' : submitting ? 'Submitting…' : 'Submit Job'}

--- a/tests/integration/test_error_cases.py
+++ b/tests/integration/test_error_cases.py
@@ -182,3 +182,9 @@ def test_upload_sanitizes_path_traversal_filename(app_client, tmp_path):
     assert body["location"] == str(stored_path)
     assert stored_path.read_bytes() == b"owned"
     assert not (tmp_path / "evil.txt").exists()
+
+
+def test_confirm_cost_on_non_awaiting_job_returns_409(app_client):
+    job_id = _create_queued(app_client.client)
+    resp = app_client.client.post(f"/api/jobs/{job_id}/confirm-cost")
+    assert resp.status_code == 409

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -27,9 +27,45 @@ def test_create_job_returns_queued(app_client):
     assert resp.status_code == 201
     body = resp.json()
     assert body["status"] == "queued"
+    app_client.module.ORCHESTRATOR.enqueue.assert_called_once()
     # Must be a valid UUID.
     from uuid import UUID
     UUID(body["job_id"])
+
+
+def test_create_job_quality_awaits_cost_confirmation(app_client, monkeypatch):
+    monkeypatch.setenv("PFCD_COST_CONFIRM_PROFILES", "quality")
+    payload = {
+        "profile": "quality",
+        "input_files": [
+            {"source_type": "transcript", "file_name": "t.vtt", "size_bytes": 512}
+        ],
+    }
+    resp = app_client.client.post("/api/jobs", json=payload)
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["status"] == "awaiting_confirmation"
+    assert body["cost_estimate"]["requires_confirmation"] is True
+    app_client.module.ORCHESTRATOR.enqueue.assert_not_called()
+
+
+def test_confirm_cost_transitions_to_queued_and_enqueues(app_client, monkeypatch):
+    monkeypatch.setenv("PFCD_COST_CONFIRM_PROFILES", "quality")
+    payload = {
+        "profile": "quality",
+        "input_files": [
+            {"source_type": "transcript", "file_name": "t.vtt", "size_bytes": 512}
+        ],
+    }
+    create_resp = app_client.client.post("/api/jobs", json=payload)
+    assert create_resp.status_code == 201
+    job_id = create_resp.json()["job_id"]
+    app_client.module.ORCHESTRATOR.enqueue.reset_mock()
+
+    confirm_resp = app_client.client.post(f"/api/jobs/{job_id}/confirm-cost")
+    assert confirm_resp.status_code == 200
+    assert confirm_resp.json()["status"] == "queued"
+    app_client.module.ORCHESTRATOR.enqueue.assert_called_once()
 
 
 def test_create_job_requires_at_least_one_file(app_client):

--- a/tests/unit/test_job_logic.py
+++ b/tests/unit/test_job_logic.py
@@ -11,10 +11,12 @@ from app.job_logic import (
     JobCreateRequest,
     Profile,
     apply_cost_tracking_and_cap_warning,
+    cost_confirmation_profiles,
     default_job_payload,
     get_transcription_target,
     get_vision_model,
     profile_config,
+    requires_cost_confirmation,
 )
 
 
@@ -188,6 +190,19 @@ def test_get_transcription_target_provider_matrix(monkeypatch):
     azure_target = get_transcription_target(Profile.QUALITY)
     assert azure_target["service"] == "azure_openai_whisper"
     assert azure_target["model"] == "whisper-prod"
+
+
+def test_cost_confirmation_profiles_default(monkeypatch):
+    monkeypatch.delenv("PFCD_COST_CONFIRM_PROFILES", raising=False)
+    assert cost_confirmation_profiles() == {"quality"}
+    assert requires_cost_confirmation(Profile.QUALITY) is True
+    assert requires_cost_confirmation(Profile.BALANCED) is False
+
+
+def test_cost_confirmation_profiles_env_override(monkeypatch):
+    monkeypatch.setenv("PFCD_COST_CONFIRM_PROFILES", "quality,balanced")
+    assert requires_cost_confirmation(Profile.QUALITY) is True
+    assert requires_cost_confirmation(Profile.BALANCED) is True
 
 
 def test_cost_cap_warn_only_adds_warning_flag(monkeypatch):


### PR DESCRIPTION
## Summary
- add `awaiting_confirmation` state for preflight cost gating
- add configurable confirmation profiles via `PFCD_COST_CONFIRM_PROFILES` (default `quality`)
- update create-job flow to hold gated profiles without Service Bus enqueue
- add `POST /api/jobs/{job_id}/confirm-cost` to transition and enqueue
- add create-job response `cost_estimate` payload
- add frontend confirmation UI + API helper (`confirmCost`) before starting gated jobs

## Validation
- `pytest -q tests/unit/test_job_logic.py tests/integration/test_lifecycle.py tests/integration/test_error_cases.py` (52 passed)
- `pytest -q tests/unit tests/integration` (349 passed, 2 skipped)

## Issue
- Closes #12