### PR TITLE
feat: embed referenced frame evidence in PDF/DOCX exports (Issue #15)

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2806,3 +2806,57 @@ Implemented a preflight cost confirmation flow for selected profiles (default: `
 ### Open questions
 
 - None for this issue scope.
+
+## Section 20: Issue #15 — Frame Evidence Embeds for PDF/DOCX (2026-04-20)
+
+Fixed export embedding for frame captures stored as blob-relative `storage_key` values.
+
+### What was added
+
+- `backend/app/storage.py`
+  - Added `read_frame_bytes(storage_key: str) -> bytes | None`.
+  - Supports local absolute path reads and Azure Blob reads from evidence container.
+  - Uses account URL + `DefaultAzureCredential` when available, falls back to connection string.
+  - Returns `None` on missing/unavailable frames and logs a warning instead of raising.
+
+- `backend/app/export_builder.py`
+  - Extended `build_export_pdf(...)` with optional `frame_bytes_map: Optional[Dict[str, bytes]]`.
+  - Extended `build_export_docx(...)` with optional `frame_bytes_map: Optional[Dict[str, bytes]]`.
+  - Frame embedding now prefers pre-resolved bytes (`io.BytesIO(...)`) and only falls back to local-path file reads.
+  - Missing/unreadable frames now emit explicit deterministic text notes (`not available` / `image unreadable`) instead of crashing.
+
+- `backend/app/main.py`
+  - Added `_resolve_frame_bytes_map(evidence_bundle)` helper to pre-fetch frame bytes by `storage_key` using `read_frame_bytes`.
+  - Wired both export-generation paths to pass `frame_bytes_map`:
+    - `POST /api/jobs/{job_id}/finalize`
+    - `GET /api/jobs/{job_id}/exports/{fmt}` (live fallback path)
+
+### Tests added/updated
+
+- `tests/unit/test_export_builder.py`
+  - Added `test_pdf_embeds_frame_from_bytes_map`
+  - Added `test_pdf_skips_missing_frame_gracefully`
+  - Added `test_docx_embeds_frame_from_bytes_map`
+  - Added `test_docx_skips_missing_frame_gracefully`
+
+- `tests/unit/test_storage.py`
+  - Added `test_read_frame_bytes_local_path`
+  - Added `test_read_frame_bytes_missing_returns_none`
+
+### Verification
+
+- `pytest -q tests/unit/test_export_builder.py tests/unit/test_storage.py`
+  - Result: `52 passed`
+- `pytest -q tests/integration/test_exports.py`
+  - Result: `8 passed`
+- `pytest -q tests/unit tests/integration`
+  - Result: `355 passed, 2 skipped`
+
+### Decisions
+
+- Kept `export_builder` storage-agnostic by passing pre-resolved frame bytes from `main.py`, preserving module boundaries.
+- Preserved backward compatibility for local absolute paths while enabling blob-relative keys.
+
+### Open questions
+
+- None for this issue scope.

--- a/backend/app/export_builder.py
+++ b/backend/app/export_builder.py
@@ -233,7 +233,11 @@ def build_export_markdown(draft: Dict[str, Any], evidence_bundle: Dict[str, Any]
     return "\n".join(parts)
 
 
-def build_export_pdf(draft: Dict[str, Any], evidence_bundle: Dict[str, Any]) -> bytes:
+def build_export_pdf(
+    draft: Dict[str, Any],
+    evidence_bundle: Dict[str, Any],
+    frame_bytes_map: Optional[Dict[str, bytes]] = None,
+) -> bytes:
     """Build evidence-linked PDF export."""
     from fpdf import FPDF
     from fpdf.enums import XPos, YPos
@@ -318,26 +322,40 @@ def build_export_pdf(draft: Dict[str, Any], evidence_bundle: Dict[str, Any]) -> 
         for capture in frame_captures:
             key = capture.get("storage_key", "")
             timestamp_sec = capture.get("timestamp_sec", 0.0)
-            if key.startswith("/") or (key.startswith(".") and os.path.exists(key)):
+            image_bytes = (frame_bytes_map or {}).get(key)
+            if not image_bytes and (os.path.isabs(key) or (key.startswith(".") and os.path.exists(key))):
                 try:
-                    pdf.image(key, w=120)
+                    with open(key, "rb") as handle:
+                        image_bytes = handle.read()
+                except OSError:
+                    pass
+            if image_bytes:
+                try:
+                    pdf.image(io.BytesIO(image_bytes), w=120)
                     pdf.set_font("Helvetica", size=8)
                     pdf.cell(0, 5, f"Frame @ {timestamp_sec:.1f}s — {key}", new_x=XPos.LMARGIN, new_y=YPos.NEXT)
                     pdf.set_font("Helvetica", size=11)
                 except Exception:
-                    pdf.set_font("Helvetica", size=8)
-                    pdf.cell(0, 5, f"Frame @ {timestamp_sec:.1f}s (image unreadable)", new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-                    pdf.set_font("Helvetica", size=11)
+                    _row(f"Frame @ {timestamp_sec:.1f}s (image unreadable): {key}")
             else:
                 pdf.set_font("Helvetica", size=8)
-                pdf.cell(0, 5, f"Frame @ {timestamp_sec:.1f}s: {key}", new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+                pdf.cell(
+                    0,
+                    5,
+                    f"Frame @ {timestamp_sec:.1f}s: {key} (not available)",
+                    new_x=XPos.LMARGIN,
+                    new_y=YPos.NEXT,
+                )
                 pdf.set_font("Helvetica", size=11)
 
     return bytes(pdf.output())
 
 
 def build_export_docx(
-    draft: Dict[str, Any], evidence_bundle: Dict[str, Any], job_id: str
+    draft: Dict[str, Any],
+    evidence_bundle: Dict[str, Any],
+    job_id: str,
+    frame_bytes_map: Optional[Dict[str, bytes]] = None,
 ) -> bytes:
     """Build evidence-linked DOCX export using python-docx."""
     from docx import Document  # type: ignore[import-untyped]
@@ -412,14 +430,21 @@ def build_export_docx(
         for capture in frame_captures:
             key = capture.get("storage_key", "")
             timestamp_sec = capture.get("timestamp_sec", 0.0)
-            if os.path.isabs(key) or (key.startswith(".") and os.path.exists(key)):
+            image_bytes = (frame_bytes_map or {}).get(key)
+            if not image_bytes and (os.path.isabs(key) or (key.startswith(".") and os.path.exists(key))):
                 try:
-                    doc.add_picture(key)
+                    with open(key, "rb") as handle:
+                        image_bytes = handle.read()
+                except OSError:
+                    pass
+            if image_bytes:
+                try:
+                    doc.add_picture(io.BytesIO(image_bytes))
                     doc.add_paragraph(f"Frame @ {timestamp_sec:.1f}s — {key}")
                 except Exception:
-                    doc.add_paragraph(f"Frame @ {timestamp_sec:.1f}s (image unreadable)")
+                    doc.add_paragraph(f"Frame @ {timestamp_sec:.1f}s (image unreadable): {key}")
             else:
-                doc.add_paragraph(f"Frame capture: {key} @ {timestamp_sec:.1f}s")
+                doc.add_paragraph(f"Frame @ {timestamp_sec:.1f}s: {key} (not available)")
 
     buf = io.BytesIO()
     doc.save(buf)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -39,7 +39,7 @@ from app.job_logic import (
 )
 from app.repository import ConcurrentModificationError, JobRepository
 from app.servicebus import ServiceBusOrchestrator, build_message
-from app.storage import ExportStorage
+from app.storage import ExportStorage, read_frame_bytes
 
 MAX_UPLOAD_BYTES = 500 * 1024 * 1024
 ALLOWED_FORMATS = {"json", "markdown", "pdf", "docx"}
@@ -292,6 +292,18 @@ async def _repo_upsert_job(job_id: str, payload: Dict[str, Any]) -> None:
         await anyio.to_thread.run_sync(JOB_REPO.upsert_job, job_id, payload)
     except ConcurrentModificationError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+def _resolve_frame_bytes_map(evidence_bundle: Dict[str, Any]) -> Dict[str, bytes]:
+    frame_bytes_map: Dict[str, bytes] = {}
+    for capture in evidence_bundle.get("frame_captures") or []:
+        key = capture.get("storage_key", "")
+        if not key:
+            continue
+        frame_bytes = read_frame_bytes(key)
+        if frame_bytes:
+            frame_bytes_map[key] = frame_bytes
+    return frame_bytes_map
 
 
 def _safe_upload_name(filename: str | None) -> str:
@@ -798,6 +810,7 @@ async def finalize_job(job_id: str) -> Dict[str, Any]:
         finalized_draft = copy.deepcopy(job["draft"])
         finalized_draft["finalized_at"] = _utc_now()
         evidence_bundle = build_evidence_bundle(finalized_draft, job)
+        frame_bytes_map = _resolve_frame_bytes_map(evidence_bundle)
         exports_payload = {
             "job_id": job_id,
             "status": JobStatus.COMPLETED.value,
@@ -811,10 +824,15 @@ async def finalize_job(job_id: str) -> Dict[str, Any]:
             lambda: build_export_markdown(finalized_draft, evidence_bundle).encode("utf-8")
         )
         pdf_bytes = await anyio.to_thread.run_sync(
-            lambda: build_export_pdf(finalized_draft, evidence_bundle)
+            lambda: build_export_pdf(finalized_draft, evidence_bundle, frame_bytes_map=frame_bytes_map)
         )
         docx_bytes = await anyio.to_thread.run_sync(
-            lambda: build_export_docx(finalized_draft, evidence_bundle, job_id)
+            lambda: build_export_docx(
+                finalized_draft,
+                evidence_bundle,
+                job_id,
+                frame_bytes_map=frame_bytes_map,
+            )
         )
 
         json_meta = await anyio.to_thread.run_sync(
@@ -916,16 +934,17 @@ async def get_export(job_id: str, fmt: str):
             }
         )
     bundle = build_evidence_bundle(draft, job)
+    frame_bytes_map = _resolve_frame_bytes_map(bundle)
     if fmt == "markdown":
         return PlainTextResponse(build_export_markdown(draft, bundle))
     if fmt == "pdf":
         return Response(
-            content=build_export_pdf(draft, bundle),
+            content=build_export_pdf(draft, bundle, frame_bytes_map=frame_bytes_map),
             media_type="application/pdf",
             headers={"Content-Disposition": f'attachment; filename="pdd-{job_id}.pdf"'},
         )
     return Response(
-        content=build_export_docx(draft, bundle, job_id),
+        content=build_export_docx(draft, bundle, job_id, frame_bytes_map=frame_bytes_map),
         media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         headers={"Content-Disposition": f'attachment; filename="pdd-{job_id}.docx"'},
     )

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -216,3 +216,41 @@ def upload_frame(job_id: str, frame_index: int, jpg_bytes: bytes) -> str | None:
     except Exception as exc:
         logger.warning("Frame upload failed for job %s frame %d: %s", job_id, frame_index, exc)
         return None
+
+
+def read_frame_bytes(storage_key: str) -> bytes | None:
+    """Read frame bytes from evidence storage.
+
+    Supports:
+    - local absolute paths
+    - blob paths in the configured evidence container
+    Returns None on any failure.
+    """
+    try:
+        if os.path.isabs(storage_key) and os.path.exists(storage_key):
+            with open(storage_key, "rb") as handle:
+                return handle.read()
+
+        account_url = os.environ.get("AZURE_STORAGE_ACCOUNT_URL")
+        if not account_url:
+            account_name = os.environ.get("AZURE_STORAGE_ACCOUNT_NAME")
+            if account_name:
+                account_url = f"https://{account_name}.blob.core.windows.net"
+        connection_string = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
+
+        if account_url:
+            from azure.identity import DefaultAzureCredential
+
+            client = BlobServiceClient(account_url=account_url, credential=DefaultAzureCredential())
+            blob = client.get_blob_client(_EVIDENCE_CONTAINER, storage_key)
+            return blob.download_blob().readall()
+
+        if connection_string:
+            client = BlobServiceClient.from_connection_string(connection_string)
+            blob = client.get_blob_client(_EVIDENCE_CONTAINER, storage_key)
+            return blob.download_blob().readall()
+
+        return None
+    except Exception as exc:
+        logger.warning("read_frame_bytes failed for key %s: %s", storage_key, exc)
+        return None

--- a/tests/unit/test_export_builder.py
+++ b/tests/unit/test_export_builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import sys
 import os
 
@@ -14,6 +15,10 @@ from app.export_builder import (
     build_export_docx,
     build_export_markdown,
     build_export_pdf,
+)
+
+TINY_PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7+6wAAAABJRU5ErkJggg=="
 )
 
 
@@ -302,6 +307,32 @@ class TestBuildExportPdf:
         result = build_export_pdf(DRAFT_WITH_ANCHORS, bundle)
         assert isinstance(result, bytes)
 
+    def test_pdf_embeds_frame_from_bytes_map(self):
+        bundle = {
+            "linked_anchors": [],
+            "evidence_strength": "high",
+            "frame_captures_note": "",
+            "frame_captures": [{"storage_key": "job-123/frames/frame_0001.jpg", "timestamp_sec": 12.0}],
+        }
+        result = build_export_pdf(
+            DRAFT_WITH_ANCHORS,
+            bundle,
+            frame_bytes_map={"job-123/frames/frame_0001.jpg": TINY_PNG_BYTES},
+        )
+        assert isinstance(result, bytes)
+        assert result[:4] == b"%PDF"
+
+    def test_pdf_skips_missing_frame_gracefully(self):
+        bundle = {
+            "linked_anchors": [],
+            "evidence_strength": "high",
+            "frame_captures_note": "",
+            "frame_captures": [{"storage_key": "job-123/frames/missing.jpg", "timestamp_sec": 12.0}],
+        }
+        result = build_export_pdf(DRAFT_WITH_ANCHORS, bundle, frame_bytes_map={})
+        assert isinstance(result, bytes)
+        assert result[:4] == b"%PDF"
+
 
 # ---------------------------------------------------------------------------
 # build_export_docx
@@ -369,3 +400,30 @@ class TestBuildExportDocx:
         doc = Document(io.BytesIO(result))
         full_text = " ".join(p.text for p in doc.paragraphs)
         assert "No SIPOC rows available" in full_text
+
+    def test_docx_embeds_frame_from_bytes_map(self):
+        bundle = {
+            "linked_anchors": [],
+            "evidence_strength": "high",
+            "frame_captures_note": "",
+            "frame_captures": [{"storage_key": "job-123/frames/frame_0001.jpg", "timestamp_sec": 12.0}],
+        }
+        result = build_export_docx(
+            DRAFT_WITH_ANCHORS,
+            bundle,
+            "job-123",
+            frame_bytes_map={"job-123/frames/frame_0001.jpg": TINY_PNG_BYTES},
+        )
+        assert isinstance(result, bytes)
+        assert result[:2] == b"PK"
+
+    def test_docx_skips_missing_frame_gracefully(self):
+        bundle = {
+            "linked_anchors": [],
+            "evidence_strength": "high",
+            "frame_captures_note": "",
+            "frame_captures": [{"storage_key": "job-123/frames/missing.jpg", "timestamp_sec": 12.0}],
+        }
+        result = build_export_docx(DRAFT_WITH_ANCHORS, bundle, "job-123", frame_bytes_map={})
+        assert isinstance(result, bytes)
+        assert result[:2] == b"PK"

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -39,3 +39,20 @@ def test_load_local_meta_in_blob_mode_raises(tmp_path):
 
     with pytest.raises(FileNotFoundError, match="blob storage mode"):
         store.load_bytes({"storage": "local", "location": str(tmp_path / "job-1" / "pdd.json")})
+
+
+def test_read_frame_bytes_local_path(tmp_path):
+    from app.storage import read_frame_bytes
+
+    frame_path = tmp_path / "frame_0001.jpg"
+    payload = b"\xff\xd8\xff\xd9"
+    frame_path.write_bytes(payload)
+
+    assert read_frame_bytes(str(frame_path)) == payload
+
+
+def test_read_frame_bytes_missing_returns_none(tmp_path):
+    from app.storage import read_frame_bytes
+
+    missing = tmp_path / "does_not_exist.jpg"
+    assert read_frame_bytes(str(missing)) is None


### PR DESCRIPTION
## Summary
- add `read_frame_bytes(storage_key)` in storage layer to resolve frame media from local paths or Azure Blob evidence container
- extend export builders to accept `frame_bytes_map` and embed images from in-memory bytes for both PDF and DOCX
- keep local-path fallback for backward compatibility
- ensure deterministic graceful fallback notes when frame bytes are missing/unreadable
- wire both finalize and live export paths to pre-resolve frame bytes and pass them to builders
- append implementation notes to `IMPLEMENTATION_SUMMARY.md`

## Tests
- added 4 unit tests in `tests/unit/test_export_builder.py` for PDF/DOCX embed + graceful skip
- added 2 unit tests in `tests/unit/test_storage.py` for `read_frame_bytes` local-hit + missing

## Validation
1. `pytest -q tests/unit/test_export_builder.py tests/unit/test_storage.py`
   - `52 passed`
2. `pytest -q tests/integration/test_exports.py`
   - `8 passed`
3. `pytest -q tests/unit tests/integration`
   - `355 passed, 2 skipped`

## Issue
- Closes #15