### PR TITLE
fix: harden transcript-only extraction prompts for gpt-5.4 (Issue #62)

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2843,6 +2843,62 @@ Implemented a preflight cost confirmation flow for selected profiles (default: `
 
 - None for this issue scope.
 
+## Section 21: Issue #62 — Extraction Prompt Hardening for GPT-5.4* (2026-04-20)
+
+Updated transcript-only extraction instructions and token budgeting to address under-extraction on discovery-session transcripts with stricter model behavior (`gpt-5.4-mini` / `gpt-5.4`).
+
+### What changed
+
+- `backend/app/agents/extraction.py`
+  - Updated `_SYSTEM_PROMPT` to make source hierarchy conditional:
+    - video/audio primary when present
+    - transcript primary when it is the only source
+  - Replaced user rules block to:
+    - preserve discovery-session Q&A that contains real process content
+    - explicitly reject meeting meta-steps
+    - forbid invented timestamps
+    - target richer extraction density (`15–30 evidence items` for 60-minute sessions)
+  - Added `_max_extraction_tokens()`:
+    - uses `PFCD_MAX_EXTRACTION_TOKENS`
+    - falls back to `PFCD_MAX_COMPLETION_TOKENS`
+    - defaults to `4096`
+    - applies floor `max(512, value)`
+  - Wired extraction call settings to use `_max_extraction_tokens()` (without changing processing agent token behavior).
+
+### Tests updated
+
+- `tests/unit/test_agents.py`
+  - Updated extraction prompt-contract assertions for the new conditional hierarchy and discovery-session rules.
+  - Added extraction token-cap tests:
+    - default `4096`
+    - extraction env override precedence over completion env
+    - floor and invalid-value fallback behavior
+
+### Validation
+
+- `pytest tests/unit/test_agents.py -k "extraction_prompt_contract_is_media_first or extraction_tokens" -q`
+  - Result: `4 passed`
+- `pytest tests/unit tests/integration -q`
+  - Result: `359 passed, 2 skipped`
+
+### Live transcript re-run status
+
+- Attempted required re-run on:
+  - `/Users/karthicks/kAgents/Projects/PFCD/samples/process-discovery-session-transcript-copy-vtt-as-txt.txt`
+  - with `PFCD_PROVIDER=openai` and `OPENAI_CHAT_MODEL_BALANCED=gpt-5.4-mini`
+- Runtime blocked by provider quota:
+  - `openai.RateLimitError: insufficient_quota (429)`
+- Because of the upstream quota block, the explicit `>=15 evidence items with real timestamps` live acceptance check is pending external quota restoration.
+
+### Decisions
+
+- Kept change strictly scoped to extraction prompt + extraction-only token cap as requested.
+- Avoided touching processing prompt/token settings to prevent cross-agent behavioral drift.
+
+### Open questions
+
+- Once OpenAI quota is restored, rerun the live extraction command to close the final acceptance gate (`>=15` items with real transcript timestamps).
+
 ## Section 20: Issue #15 — Frame Evidence Embeds for PDF/DOCX (2026-04-20)
 
 Fixed export embedding for frame captures stored as blob-relative `storage_key` values.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -137,7 +137,8 @@ uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
 | `PFCD_CLEANUP_INTERVAL_SECONDS` | Cleanup worker poll interval | `300` |
 | `PFCD_JOB_TTL_DAYS` | Job retention window before expiry/cleanup | `7` |
 | `PFCD_LLM_TIMEOUT_SECONDS` | Max seconds allowed for a single extraction/processing LLM call | `120` |
-| `PFCD_MAX_COMPLETION_TOKENS` | Max completion tokens for extraction/processing/vision LLM calls | `2048` |
+| `PFCD_MAX_COMPLETION_TOKENS` | Max completion tokens for processing/vision LLM calls (fallback for extraction) | `2048` |
+| `PFCD_MAX_EXTRACTION_TOKENS` | Max completion tokens for extraction LLM calls (overrides `PFCD_MAX_COMPLETION_TOKENS`; higher budget for dense transcripts) | `4096` |
 | `PFCD_API_KEY` | Static API key for `X-API-Key` header | `""` (auth disabled if unset) |
 | `PFCD_CORS_ORIGINS` | Comma-separated allowed CORS origins | `http://localhost:5173` |
 | `PFCD_PROVIDER` | Chat/transcription provider (`azure_openai` or `openai`) | `azure_openai` |

--- a/backend/app/agents/extraction.py
+++ b/backend/app/agents/extraction.py
@@ -16,8 +16,10 @@ logger = logging.getLogger(__name__)
 
 _SYSTEM_PROMPT = (
     "You are a process documentation specialist. Extract structured process evidence from "
-    "business process recordings. Video and audio are the primary sources; transcript is "
-    "a supporting signal. Return only valid JSON."
+    "business process recordings and discovery sessions. When video or audio is available, "
+    "they are the primary evidence source and transcript is a supporting signal. When "
+    "transcript is the only source, treat it as primary evidence and extract all described "
+    "process steps in full detail. Return only valid JSON."
 )
 
 _USER_PROMPT_TEMPLATE = """\
@@ -46,14 +48,18 @@ Extract all distinct process steps from this transcript. Return a JSON object wi
 
 Rules:
 - id must be sequential: ev-01, ev-02, …
-- each evidence item must represent a distinct process action, not a transcript fragment
-- remove transcript artifacts: VTT cue numbers, timestamps-only lines, facilitator questions,
-  filler phrases, and non-process chitchat
+- each evidence item must represent one distinct step in the process being described or performed
+- if the transcript is a PROCESS DISCOVERY SESSION (facilitators asking questions, participants describing how
+  they work), extract the steps of the DESCRIBED process from participants' answers — NOT the meta-steps of
+  the meeting itself (do NOT produce steps like "discuss the process" or "capture process details")
+- remove only genuine non-process content: greetings, audio-check talk, scheduling coordination, and filler
+  phrases; keep all Q&A that reveals process steps, decision points, handoffs, systems, actors, or SLAs
 - collapse adjacent steps with the same actor and substantially the same action into one item
-- anchor must reference a timestamp range or section label from the transcript
+- anchor must reference a timestamp range or section label FROM THE TRANSCRIPT — do NOT invent timestamps
 - source_type must be one of video|audio|transcript|frame based on the evidence source
-- confidence is a float between 0.0 and 1.0
+- confidence is a float between 0.0 and 1.0; use 0.7–0.9 for clearly described steps, 0.4–0.6 for inferred
 - speakers_detected must list all unique speakers; use "Unknown Speaker" if unidentifiable
+- aim for complete extraction: a 60-minute discovery session should yield 15–30 evidence items
 """
 
 
@@ -85,13 +91,16 @@ def _extract_usage_tokens(metadata: Dict[str, Any]) -> Tuple[int, int]:
     )
 
 
-def _max_completion_tokens() -> int:
-    raw = os.environ.get("PFCD_MAX_COMPLETION_TOKENS", "2048").strip()
+def _max_extraction_tokens() -> int:
+    raw = os.environ.get(
+        "PFCD_MAX_EXTRACTION_TOKENS",
+        os.environ.get("PFCD_MAX_COMPLETION_TOKENS", "4096"),
+    ).strip()
     try:
         value = int(raw)
     except ValueError:
-        return 2048
-    return max(1, value)
+        return 4096
+    return max(512, value)
 
 
 def _extract_balanced_json_object(text: str) -> str | None:
@@ -207,7 +216,7 @@ async def _call_extraction(deployment: str, system_prompt: str, user_content: st
     chat.add_user_message(user_content)
     settings = OpenAIChatPromptExecutionSettings(
         response_format={"type": "json_object"},
-        max_completion_tokens=_max_completion_tokens(),
+        max_completion_tokens=_max_extraction_tokens(),
     )
     svc = get_chat_service(deployment)
     result = await svc.get_chat_message_content(chat, settings, kernel=kernel)

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -300,13 +300,41 @@ def test_extraction_prompt_contract_is_media_first():
     system_prompt = extraction._SYSTEM_PROMPT
     user_prompt = extraction._USER_PROMPT_TEMPLATE
 
-    assert "Video and audio are the primary sources" in system_prompt
-    assert "supporting signal" in system_prompt
+    assert "When video or audio is available" in system_prompt
+    assert "When transcript is the only source, treat it as primary evidence" in system_prompt
     assert "source_type" in user_prompt
     assert "video|audio|transcript|frame" in user_prompt
     assert "Unknown Speaker" in user_prompt
-    assert "Remove transcript artifacts".lower() in user_prompt.lower()
+    assert "remove only genuine non-process content" in user_prompt.lower()
+    assert "do not invent timestamps" in user_prompt.lower()
+    assert "15–30 evidence items" in user_prompt
     assert "collapse adjacent steps" in user_prompt.lower()
+
+
+def test_extraction_tokens_default_to_4096(monkeypatch):
+    from app.agents.extraction import _max_extraction_tokens
+
+    monkeypatch.delenv("PFCD_MAX_EXTRACTION_TOKENS", raising=False)
+    monkeypatch.delenv("PFCD_MAX_COMPLETION_TOKENS", raising=False)
+    assert _max_extraction_tokens() == 4096
+
+
+def test_extraction_tokens_prefers_extraction_env(monkeypatch):
+    from app.agents.extraction import _max_extraction_tokens
+
+    monkeypatch.setenv("PFCD_MAX_COMPLETION_TOKENS", "2048")
+    monkeypatch.setenv("PFCD_MAX_EXTRACTION_TOKENS", "8192")
+    assert _max_extraction_tokens() == 8192
+
+
+def test_extraction_tokens_floor_and_invalid(monkeypatch):
+    from app.agents.extraction import _max_extraction_tokens
+
+    monkeypatch.setenv("PFCD_MAX_EXTRACTION_TOKENS", "120")
+    assert _max_extraction_tokens() == 512
+
+    monkeypatch.setenv("PFCD_MAX_EXTRACTION_TOKENS", "abc")
+    assert _max_extraction_tokens() == 4096
 
 
 def test_processing_usage_tokens_supports_dict_usage():


### PR DESCRIPTION
## Summary
- update extraction system prompt to make source hierarchy conditional
  - video/audio primary only when present
  - transcript primary when it is the only source
- replace extraction rules block to preserve discovery-session process content, reject meeting meta-steps, and explicitly forbid invented timestamps
- add extraction-only token cap function `_max_extraction_tokens()`
  - `PFCD_MAX_EXTRACTION_TOKENS` -> fallback `PFCD_MAX_COMPLETION_TOKENS` -> default `4096`
  - floor `>=512`
- wire extraction call settings to use `_max_extraction_tokens()`
- update unit tests for prompt contract + token cap behavior
- append implementation notes to `IMPLEMENTATION_SUMMARY.md`

## Validation
1. `pytest tests/unit/test_agents.py -k "extraction_prompt_contract_is_media_first or extraction_tokens" -q`
   - `4 passed`
2. `pytest tests/unit tests/integration -q`
   - `359 passed, 2 skipped`

## Live acceptance check status
Attempted required re-run with:
- transcript: `/Users/karthicks/kAgents/Projects/PFCD/samples/process-discovery-session-transcript-copy-vtt-as-txt.txt`
- model: `OPENAI_CHAT_MODEL_BALANCED=gpt-5.4-mini`

Blocked by provider quota at runtime:
- `openai.RateLimitError: insufficient_quota (429)`

Code is ready; final `>=15 evidence items with real timestamps` gate is pending quota restoration.

## Issue
- Closes #62