### PR TITLE
Fix extraction prompt anchoring for reasoning models (Issue #64)

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2952,3 +2952,60 @@ Fixed export embedding for frame captures stored as blob-relative `storage_key` 
 ### Open questions
 
 - None for this issue scope.
+
+## Section 22: Issue #64 — Reasoning-Model Extraction Prompt Anchoring (2026-04-20)
+
+Implemented follow-up hardening for `gpt-5.4-mini` transcript extraction by adding explicit subject-process anchoring, decomposition instructions, and discovery-session few-shot guidance.
+
+### What was added
+
+- `backend/app/agents/extraction.py`
+  - Updated `_USER_PROMPT_TEMPLATE` JSON contract to include:
+    - `subject_process`
+  - Reworked transcript instructions from rule-only filtering to explicit extraction decomposition:
+    - identify the underlying business process first
+    - map each process-relevant cue to one evidence item
+    - anchor each item to transcript cue timestamps
+  - Added discovery-session few-shot example using real cue structure:
+    - `[00:10:50-00:11:40] Priya Nair (Customer) ...`
+  - Preserved and clarified anti-meta-step behavior while keeping existing dedup guidance (`collapse adjacent steps...`).
+  - Added `subject_process` defaulting/propagation in extraction output:
+    - no-content path defaults to `"unknown"`
+    - fallback extraction payload includes `"subject_process": "unknown"`
+    - parsed LLM output is normalized with `setdefault("subject_process", process_domain or "unknown")` before persisting `job["extracted_evidence"]`.
+
+- `tests/unit/test_agents.py`
+  - Updated extraction prompt-contract assertions to require:
+    - `"subject_process":` in prompt schema
+    - `Extraction method:` section
+    - discovery-session few-shot cue presence
+  - Updated extraction JSON fixture stubs used in tests to include `subject_process` where appropriate.
+  - Added pass-through assertion ensuring parsed extraction JSON preserves `subject_process` in `job["extracted_evidence"]`.
+
+### Verification
+
+- `pytest tests/unit/test_agents.py -k "extraction_prompt_contract_is_media_first or extraction_parses_json_inside_code_fence or extraction_agent_scenario_a or extraction_cost_calculation" -q`
+  - Result: `4 passed`
+- `pytest tests/unit tests/integration -q`
+  - Result: `359 passed, 2 skipped`
+
+### Live transcript re-run status
+
+- Attempted required rerun on:
+  - `/Users/karthicks/kAgents/Projects/PFCD/samples/process-discovery-session-transcript-copy-vtt-as-txt.txt`
+  - with `PFCD_PROVIDER=openai` and `OPENAI_CHAT_MODEL_BALANCED=gpt-5.4-mini`
+- Runtime blocked by provider quota:
+  - `openai.RateLimitError: insufficient_quota (429)`
+- Because of the upstream quota block, the acceptance checks requiring live output (`subject_process` value, `>=15` evidence items with real timestamps, transcript_quality high/medium) remain pending quota restoration.
+
+### Decisions
+
+- Kept scope strictly to extraction prompt + extraction output shaping for `subject_process`; no model swap and no dependency changes.
+- Preserved prior #62 extraction token behavior and did not alter processing/reviewing contracts.
+
+### Open questions
+
+- After quota restoration, rerun the live transcript extraction to confirm:
+  - `subject_process` resolves to the operational process (for example, complaint handling)
+  - `evidence_items >= 15` with non-placeholder timestamp anchors
+  - `transcript_quality in {high, medium}`.

--- a/backend/app/agents/extraction.py
+++ b/backend/app/agents/extraction.py
@@ -26,12 +26,15 @@ _USER_PROMPT_TEMPLATE = """\
 Transcript:
 {transcript_text}
 
-Extract all distinct process steps from this transcript. Return a JSON object with this exact shape:
+Task: Extract all distinct steps of the business process described or performed in this transcript.
+
+Return a JSON object with this exact shape:
 {{
+  "subject_process": "name of the business process being documented (e.g. Customer Complaint Handling)",
   "evidence_items": [
     {{
       "id": "ev-01",
-      "summary": "Actor performs action on system",
+      "summary": "Actor performs action on/in system",
       "actor": "string",
       "system": "string",
       "input_artifact": "string",
@@ -46,20 +49,30 @@ Extract all distinct process steps from this transcript. Return a JSON object wi
   "transcript_quality": "high|medium|low"
 }}
 
+Extraction method:
+1. Read the transcript and identify the subject business process (what operation participants are describing, such as complaint intake, order processing, or invoice approval). Set subject_process to this.
+2. Scan every cue where a participant describes a specific action, system, decision point, handoff, or SLA in that business process. Each such description is one evidence item.
+3. Use the timestamp of the cue where the step was described as the anchor.
+
+Discovery session example — given this exchange:
+  [00:10:50-00:11:40] Priya Nair (Customer): Every morning, two analysts review the shared mailbox and the phone log spreadsheet. They create complaint records in CRM for items not already there.
+→ Create:
+  {{ "id": "ev-01", "summary": "Analyst reviews shared mailbox and phone log spreadsheet, creates CRM records for new complaints", "actor": "Analyst", "system": "Shared Mailbox / CRM", "input_artifact": "Email complaints, phone log spreadsheet", "output_artifact": "CRM complaint record", "source_type": "transcript", "anchor": "00:10:50-00:11:40", "confidence": 0.85 }}
+
 Rules:
 - id must be sequential: ev-01, ev-02, …
-- each evidence item must represent one distinct step in the process being described or performed
-- if the transcript is a PROCESS DISCOVERY SESSION (facilitators asking questions, participants describing how
-  they work), extract the steps of the DESCRIBED process from participants' answers — NOT the meta-steps of
-  the meeting itself (do NOT produce steps like "discuss the process" or "capture process details")
+- subject_process is the operational process being documented, NOT the discovery meeting itself
+- each evidence item is one step of subject_process — not a meeting action and not a summary of the session
+- if the transcript is a discovery session, extract process steps from participants' answers (Q&A content)
 - remove only genuine non-process content: greetings, audio-check talk, scheduling coordination, and filler
-  phrases; keep all Q&A that reveals process steps, decision points, handoffs, systems, actors, or SLAs
+  phrases
 - collapse adjacent steps with the same actor and substantially the same action into one item
 - anchor must reference a timestamp range or section label FROM THE TRANSCRIPT — do NOT invent timestamps
 - source_type must be one of video|audio|transcript|frame based on the evidence source
-- confidence is a float between 0.0 and 1.0; use 0.7–0.9 for clearly described steps, 0.4–0.6 for inferred
+- confidence: 0.7–0.9 for explicitly stated steps; 0.4–0.6 for inferred; 0.2–0.4 for ambiguous
 - speakers_detected must list all unique speakers; use "Unknown Speaker" if unidentifiable
 - aim for complete extraction: a 60-minute discovery session should yield 15–30 evidence items
+- transcript_quality: high if cues clearly describe process steps; medium if some steps are implicit; low if content is mostly chitchat
 """
 
 
@@ -195,6 +208,7 @@ def _fallback_extraction_from_text(content_text: str, parse_error: str) -> Dict[
             )
 
     return {
+        "subject_process": "unknown",
         "evidence_items": items,
         "speakers_detected": ["Unknown"] if items else [],
         "process_domain": "unknown",
@@ -367,6 +381,7 @@ def run_extraction(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
     if not content_text:
         # Graceful degradation: no transcript available yet
         job["extracted_evidence"] = {
+            "subject_process": "unknown",
             "evidence_items": [],
             "speakers_detected": [],
             "process_domain": "unknown",
@@ -416,6 +431,7 @@ def run_extraction(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
             extracted.setdefault("fallback_reason", "adapter_fact_hints")
 
     _apply_source_type_defaults(extracted, primary_source_type)
+    extracted.setdefault("subject_process", extracted.get("process_domain") or "unknown")
 
     job["extracted_evidence"] = extracted
     job["agent_signals"]["transcript_parsed"] = True

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -93,7 +93,8 @@ def test_extraction_agent_scenario_a(monkeypatch):
 
     transcript = _load_fixture("scenario_a", "transcript.vtt")
     expected = _load_expected("scenario_a")
-    mock_result = {"evidence_items": expected["extracted_evidence"]["evidence_items"],
+    mock_result = {"subject_process": "Invoice Approval",
+                   "evidence_items": expected["extracted_evidence"]["evidence_items"],
                    "speakers_detected": ["Finance Analyst", "AP Manager"],
                    "process_domain": "Accounts Payable — Invoice Approval",
                    "transcript_quality": "high"}
@@ -131,7 +132,7 @@ def test_extraction_cost_calculation(monkeypatch):
     """Cost should equal (prompt * 0.15 + completion * 0.60) / 1_000_000."""
     from app.agents.extraction import run_extraction
 
-    mock_result = {"evidence_items": [], "speakers_detected": [], "process_domain": "test", "transcript_quality": "low"}
+    mock_result = {"subject_process": "test", "evidence_items": [], "speakers_detected": [], "process_domain": "test", "transcript_quality": "low"}
 
     job = _make_job()
     job["_transcript_text_inline"] = "some transcript text"
@@ -188,6 +189,7 @@ def test_extraction_sets_source_type_to_video_when_video_is_primary():
             }
         ],
         "speakers_detected": ["Finance Analyst"],
+        "subject_process": "Invoice Processing",
         "process_domain": "Accounts Payable",
         "transcript_quality": "high",
     }
@@ -231,6 +233,7 @@ def test_extraction_uses_video_fact_hints_when_llm_returns_no_items():
                 json.dumps(
                     {
                         "evidence_items": [],
+                        "subject_process": "test",
                         "speakers_detected": [],
                         "process_domain": "test",
                         "transcript_quality": "high",
@@ -254,7 +257,7 @@ def test_extraction_parses_json_inside_code_fence():
 
     job = _make_job()
     job["_transcript_text_inline"] = "[00:00:01-00:00:05] test"
-    wrapped = """```json\n{"evidence_items":[],"speakers_detected":[],"process_domain":"x","transcript_quality":"high"}\n```"""
+    wrapped = """```json\n{"subject_process":"Order Intake","evidence_items":[],"speakers_detected":[],"process_domain":"x","transcript_quality":"high"}\n```"""
 
     with patch(
         "app.agents.extraction._call_extraction",
@@ -263,6 +266,7 @@ def test_extraction_parses_json_inside_code_fence():
         run_extraction(job, _balanced_profile())
 
     assert job["extracted_evidence"]["process_domain"] == "x"
+    assert job["extracted_evidence"]["subject_process"] == "Order Intake"
 
 
 def test_extraction_usage_tokens_supports_object_usage():
@@ -303,8 +307,11 @@ def test_extraction_prompt_contract_is_media_first():
     assert "When video or audio is available" in system_prompt
     assert "When transcript is the only source, treat it as primary evidence" in system_prompt
     assert "source_type" in user_prompt
+    assert '"subject_process":' in user_prompt
     assert "video|audio|transcript|frame" in user_prompt
     assert "Unknown Speaker" in user_prompt
+    assert "extraction method:" in user_prompt.lower()
+    assert "[00:10:50-00:11:40] Priya Nair (Customer)" in user_prompt
     assert "remove only genuine non-process content" in user_prompt.lower()
     assert "do not invent timestamps" in user_prompt.lower()
     assert "15–30 evidence items" in user_prompt


### PR DESCRIPTION
## Summary
- add `subject_process` to extraction prompt schema and extraction output defaults
- replace rule-only discovery extraction guidance with explicit extraction-method decomposition
- add discovery-session few-shot cue example to improve reasoning-model step mapping
- update extraction unit tests to assert subject-process schema/example/method contract
- append Issue #64 implementation notes and validation results in `IMPLEMENTATION_SUMMARY.md`

## Validation
- `pytest tests/unit/test_agents.py -k "extraction_prompt_contract_is_media_first or extraction_parses_json_inside_code_fence or extraction_agent_scenario_a or extraction_cost_calculation" -q` -> `4 passed`
- `pytest tests/unit tests/integration -q` -> `359 passed, 2 skipped`

## Live acceptance rerun
- attempted with transcript `/Users/karthicks/kAgents/Projects/PFCD/samples/process-discovery-session-transcript-copy-vtt-as-txt.txt`
- config: `PFCD_PROVIDER=openai`, `OPENAI_CHAT_MODEL_BALANCED=gpt-5.4-mini`
- blocked by upstream provider quota: `openai.RateLimitError: insufficient_quota (429)`

Closes #64
