### PR TITLE
fix: add extracted_evidence column — extraction results silently dropped on every upsert_job

### DIFF
--- a/backend/alembic/versions/20260420_0006_add_extracted_evidence.py
+++ b/backend/alembic/versions/20260420_0006_add_extracted_evidence.py
@@ -1,0 +1,29 @@
+"""add extracted_evidence column to jobs
+
+Revision ID: 20260420_0006
+Revises: 20260420_0005
+Create Date: 2026-04-20
+
+The extracted_evidence JSON column was missing from the jobs table, causing
+extraction results to be silently discarded on every upsert_job call. Processing
+workers always received empty evidence, producing 1-step stub drafts.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260420_0006"
+down_revision = "20260420_0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column("extracted_evidence", sa.Text(), nullable=False, server_default="{}"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("jobs", "extracted_evidence")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -24,6 +24,7 @@ class Job(Base):
     has_transcript = Column(Boolean, nullable=False, default=False)
     teams_metadata = Column(Text, nullable=False, default="{}")
     transcript_media_consistency = Column(Text, nullable=False, default="{}")
+    extracted_evidence = Column(Text, nullable=False, default="{}")
     agent_signals = Column(Text, nullable=False, default="{}")
     agent_review = Column(Text, nullable=False, default="{}")
     speaker_resolutions = Column(Text, nullable=False, default="{}")

--- a/backend/app/repository.py
+++ b/backend/app/repository.py
@@ -123,6 +123,7 @@ class JobRepository:
             "teams_metadata": self._deserialize(job.teams_metadata),
             "agent_runs": [self._agent_run_to_dict(run) for run in agent_runs],
             "transcript_media_consistency": self._deserialize(job.transcript_media_consistency),
+            "extracted_evidence": self._deserialize(job.extracted_evidence),
             "review_notes": self._deserialize(review_notes.payload) if review_notes else {"flags": [], "assumptions": []},
             "agent_signals": self._deserialize(job.agent_signals),
             "agent_review": self._deserialize(job.agent_review),
@@ -225,6 +226,7 @@ class JobRepository:
                 job.has_transcript = bool(payload.get("has_transcript"))
                 job.teams_metadata = self._serialize(payload.get("teams_metadata", {}))
                 job.transcript_media_consistency = self._serialize(payload.get("transcript_media_consistency", {}))
+                job.extracted_evidence = self._serialize(payload.get("extracted_evidence", {}))
                 job.agent_signals = self._serialize(payload.get("agent_signals", {}))
                 job.agent_review = self._serialize(payload.get("agent_review", {}))
                 job.speaker_resolutions = self._serialize(payload.get("speaker_resolutions", {}))


### PR DESCRIPTION
## Root cause

The `Job` model had no `extracted_evidence` column. `upsert_job()` did not write it and `_job_to_payload()` did not read it back. This meant every extraction result was silently discarded after being stored in the in-memory `job` dict — processing workers always received empty evidence (`{}`) and produced 1-step stub drafts.

The speakers_detected were being saved (via `agent_signals`) which is why the live jobs showed correct speaker names but 0 evidence items — they came from two different code paths.

## Fix
- `backend/app/models.py`: Add `extracted_evidence = Column(Text, nullable=False, default="{}")` to `Job`
- `backend/app/repository.py`: Write in `upsert_job()`, read in `_job_to_payload()`
- `backend/alembic/versions/20260420_0006_add_extracted_evidence.py`: Migration

## Validation
- 359 tests passing, 2 skipped
- Migration applied to local SQLite: column confirmed present
- Docker containers rebuilt — extraction worker now has the column

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>