### PR TITLE
feat: filter future-state leakage + improve quantification (Issue #70)

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3081,3 +3081,58 @@ Aligned V2 markdown/docx exports to the custom SOP template and extended process
 ### Open questions
 
 - Stakeholder/version-history population remains placeholder-only in v2 (no dedicated persistence model yet); future work can populate from explicit metadata fields when available.
+
+## Section 24: Issue #70 — Future-State Filtering + Quantification Prompt Tightening (2026-04-22)
+
+Implemented prompt-level controls to reduce future-state leakage into as-is process steps and improve automation-opportunity quantification specificity.
+
+### What was added
+
+- `backend/app/agents/extraction.py`
+  - Extended extraction schema contract in prompt with `evidence_items[].evidence_type` (`as_is|future_state`).
+  - Added explicit extraction rules:
+    - tag current executable process actions/pain points as `as_is`
+    - tag recommendations/target-state/proposed improvements as `future_state`
+    - keep future-state content separated from as-is evidence items.
+
+- `backend/app/agents/processing.py`
+  - Added strict placement rule:
+    - `pdd.steps[]` must contain current as-is executable actions only.
+    - future-state recommendations/target-state workflow content must be moved to `automation_opportunities[]` or `assumptions[]`.
+  - Added stronger quantification guidance for `automation_opportunities[].quantification`:
+    - prefer concrete numbers (percentages, counts, durations, frequencies, error rates)
+    - include specific values verbatim when present in evidence (for example `20% reassignment`, `200/day`, `1-2 day delay`).
+
+- `tests/unit/test_agents.py`
+  - Updated extraction prompt contract assertions for:
+    - `evidence_type`
+    - explicit future-state tagging guidance.
+  - Updated processing prompt contract assertions for:
+    - as-is-only steps rule
+    - future-state relocation rule
+    - concrete-figures quantification guidance.
+
+### Validation
+
+- `pytest -q tests/unit/test_agents.py -k "extraction_prompt_contract_is_media_first or processing_prompt_contract_includes_alignment_and_priority_rules"`
+  - Result: `2 passed`
+- `pytest -q tests/unit tests/integration`
+  - Result: `359 passed, 2 skipped`
+
+### Live transcript re-run status
+
+- Attempted rerun with:
+  - transcript: `/Users/karthicks/kAgents/Projects/PFCD/samples/process-discovery-session-transcript-copy-vtt-as-txt.txt`
+  - profile/model path: `PFCD_PROVIDER=openai`, `OPENAI_CHAT_MODEL_BALANCED=gpt-5.4-mini`, `OPENAI_CHAT_MODEL_QUALITY=gpt-5.4`
+- Blocked by upstream provider quota:
+  - `openai.RateLimitError: insufficient_quota (429)`
+- Because of quota block, live acceptance checks (`<=18` as-is steps, no future-state leakage in steps, concrete quantification carry-through) remain pending quota restoration.
+
+### Decisions
+
+- Kept this change prompt-only and backward-compatible; no schema persistence migrations or runtime parsing changes required.
+- Left downstream placement/validation behavior to existing extraction->processing flow while tightening model instructions.
+
+### Open questions
+
+- After quota restoration, rerun the sample transcript to validate step-count and leakage acceptance gates against real model output.

--- a/backend/app/agents/extraction.py
+++ b/backend/app/agents/extraction.py
@@ -39,6 +39,7 @@ Return a JSON object with this exact shape:
       "system": "string",
       "input_artifact": "string",
       "output_artifact": "string",
+      "evidence_type": "as_is|future_state",
       "source_type": "video|audio|transcript|frame",
       "anchor": "HH:MM:SS-HH:MM:SS or section label",
       "confidence": 0.0
@@ -64,6 +65,9 @@ Rules:
 - subject_process is the operational process being documented, NOT the discovery meeting itself
 - each evidence item is one step of subject_process — not a meeting action and not a summary of the session
 - if the transcript is a discovery session, extract process steps from participants' answers (Q&A content)
+- set evidence_type to "as_is" for currently executed process actions and current pain points
+- set evidence_type to "future_state" for proposed improvements, recommendations, target-state design,
+  or consultant suggestions; do not mix these into as_is evidence items
 - remove only genuine non-process content: greetings, audio-check talk, scheduling coordination, and filler
   phrases
 - collapse adjacent steps with the same actor and substantially the same action into one item

--- a/backend/app/agents/processing.py
+++ b/backend/app/agents/processing.py
@@ -128,10 +128,16 @@ Rules:
 - Use conservative language: do not invent roles, systems, or business rules not supported by evidence.
 - If evidence is sparse or transcript-only, still produce best-effort structure and list explicit
   assumptions in assumptions[] instead of fabricating detail.
+- PDD steps[] must include only current as-is executable actions.
+- Future-state proposals, recommendations, target-state workflows, and consultant suggestions must NOT
+  appear in pdd.steps[]; place them in automation_opportunities[] or assumptions[] instead.
 - Populate steps[].tools_systems from evidence; use "Needs Review" when the system/tool cannot
   be determined from evidence.
 - Populate automation_opportunities[] from repetitive/rule-based/manual effort patterns in evidence.
   Include quantification where possible (volume, time, rework, touchpoints); otherwise "Needs Review".
+- Prefer concrete figures (percentages, counts, durations, frequencies, and error rates) from evidence
+  over generic descriptions. If evidence includes a specific number (e.g. "20% reassignment rate",
+  "200 complaints/day", "1-2 day delay"), include it verbatim in quantification.
 - Every evidence item must map to at least one PDD step
 - Every PDD step must appear in at least one SIPOC row
 - step_anchor MUST be a non-empty JSON array with at least one PDD step ID from the steps list above (e.g. ["step-01"]). Never leave step_anchor as [] or null.

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -307,12 +307,14 @@ def test_extraction_prompt_contract_is_media_first():
     assert "When video or audio is available" in system_prompt
     assert "When transcript is the only source, treat it as primary evidence" in system_prompt
     assert "source_type" in user_prompt
+    assert "evidence_type" in user_prompt
     assert '"subject_process":' in user_prompt
     assert "video|audio|transcript|frame" in user_prompt
     assert "Unknown Speaker" in user_prompt
     assert "extraction method:" in user_prompt.lower()
     assert "[00:10:50-00:11:40] Priya Nair (Customer)" in user_prompt
     assert "remove only genuine non-process content" in user_prompt.lower()
+    assert 'set evidence_type to "future_state"' in user_prompt
     assert "do not invent timestamps" in user_prompt.lower()
     assert "15–30 evidence items" in user_prompt
     assert "collapse adjacent steps" in user_prompt.lower()
@@ -484,6 +486,9 @@ def test_processing_prompt_contract_includes_alignment_and_priority_rules():
     assert '"confidence_delta": 0.0' in user_prompt
     assert '"automation_opportunities": [' in user_prompt
     assert "Populate steps[].tools_systems from evidence" in user_prompt
+    assert "PDD steps[] must include only current as-is executable actions." in user_prompt
+    assert "Future-state proposals, recommendations, target-state workflows" in user_prompt
+    assert "Prefer concrete figures (percentages, counts, durations, frequencies, and error rates)" in user_prompt
 
 
 def test_processing_profile_guidance_balanced_and_quality():


### PR DESCRIPTION
## Summary
- add extraction prompt guidance to separate as-is evidence from future-state recommendations via `evidence_type`
- add processing prompt rule to keep `pdd.steps[]` as as-is executable actions only
- add processing prompt guidance to relocate future-state content to `automation_opportunities[]` / `assumptions[]`
- strengthen automation quantification guidance to prefer concrete figures from evidence (percentages, counts, durations, frequencies, error rates)
- update prompt-contract unit tests for extraction and processing

## Validation
- `pytest -q tests/unit/test_agents.py -k "extraction_prompt_contract_is_media_first or processing_prompt_contract_includes_alignment_and_priority_rules"` -> `2 passed`
- `pytest -q tests/unit tests/integration` -> `359 passed, 2 skipped`

## Live acceptance rerun
- attempted sample transcript rerun (`process-discovery-session-transcript-copy-vtt-as-txt.txt`)
- config: `PFCD_PROVIDER=openai`, `OPENAI_CHAT_MODEL_BALANCED=gpt-5.4-mini`, `OPENAI_CHAT_MODEL_QUALITY=gpt-5.4`
- blocked by provider quota: `openai.RateLimitError: insufficient_quota (429)`

Closes #70
