### PR TITLE
fix: processing truncation + MessageLockLostError crash loop (Issue #71)

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3136,3 +3136,51 @@ Implemented prompt-level controls to reduce future-state leakage into as-is proc
 ### Open questions
 
 - After quota restoration, rerun the sample transcript to validate step-count and leakage acceptance gates against real model output.
+
+## Section 25: Issue #71 — Processing Token Ceiling + MessageLockLostError Guard (2026-04-22)
+
+Implemented two surgical stability fixes for the processing worker repeat-fail loop observed on quality-profile jobs.
+
+### What was added
+
+- `backend/app/agents/processing.py`
+  - Raised processing default completion-token ceiling in `_max_completion_tokens()`:
+    - default fallback changed from `8192` to `16384`
+    - invalid-value fallback changed from `8192` to `16384`
+  - This prevents default quality-profile truncation on large SOP payloads when `PFCD_MAX_PROCESSING_TOKENS` is unset.
+
+- `backend/app/workers/runner.py`
+  - Imported `MessageLockLostError` from `azure.servicebus.exceptions`.
+  - Wrapped all settlement calls in lock-loss guards inside `run()` message loop:
+    - `receiver.complete_message(...)`
+    - `receiver.dead_letter_message(...)`
+    - `receiver.abandon_message(...)`
+  - On lock-loss, worker now logs warnings and continues instead of propagating exceptions and crashing the process.
+
+### Tests added/updated
+
+- `tests/unit/test_agents.py`
+  - Added `test_processing_tokens_default_to_16384` to pin the new default behavior.
+
+- `tests/unit/test_worker.py`
+  - Added `test_run_continues_when_complete_loses_message_lock`:
+    - simulates `MessageLockLostError` during `complete_message`
+    - verifies the loop continues (no crash) and processes the message path.
+
+### Validation
+
+- `pytest -q tests/unit/test_agents.py -k "processing_tokens_default_to_16384 or processing_times_out_long_llm_call"`
+  - Result: `2 passed`
+- `pytest -q tests/unit/test_worker.py -k "message_lock or complete_loses_message_lock or run_recreates_receiver_after_servicebus_error"`
+  - Result: `2 passed`
+- `pytest -q tests/unit tests/integration`
+  - Result: `361 passed, 2 skipped`
+
+### Decisions
+
+- Kept lock-loss handling narrowly scoped to settlement operations rather than broader exception suppression.
+- Kept `16384` as code default so operators are protected even when env overrides are missing.
+
+### Open questions
+
+- Optional future hardening: add `AutoLockRenewer` for long-running processing calls to further reduce lock-loss frequency under high-latency model runs.

--- a/backend/app/agents/processing.py
+++ b/backend/app/agents/processing.py
@@ -183,16 +183,16 @@ def _extract_usage_tokens(metadata: Dict[str, Any]) -> tuple[int, int]:
 def _max_completion_tokens() -> int:
     # PFCD_MAX_PROCESSING_TOKENS takes precedence; falls back to PFCD_MAX_COMPLETION_TOKENS.
     # Processing generates PDD+SIPOC JSON from all evidence items, so it needs a higher
-    # ceiling than extraction (default 8192 vs extraction's 4096).
+    # ceiling than extraction (default 16384 vs extraction's 4096).
     raw = (
         os.environ.get("PFCD_MAX_PROCESSING_TOKENS")
         or os.environ.get("PFCD_MAX_COMPLETION_TOKENS")
-        or "8192"
+        or "16384"
     ).strip()
     try:
         value = int(raw)
     except ValueError:
-        return 8192
+        return 16384
     return max(512, value)
 
 

--- a/backend/app/workers/runner.py
+++ b/backend/app/workers/runner.py
@@ -13,7 +13,10 @@ from typing import Any, Dict
 from uuid import uuid4
 
 from azure.servicebus import ServiceBusMessage
-from azure.servicebus.exceptions import ServiceBusConnectionError as SBConnectionError
+from azure.servicebus.exceptions import (
+    MessageLockLostError,
+    ServiceBusConnectionError as SBConnectionError,
+)
 
 from app.agents.alignment import run_anchor_alignment
 from app.agents.extraction import run_extraction
@@ -419,13 +422,26 @@ def run() -> None:
                         try:
                             body = _read_message_body(message.body)
                             worker.handle_message(message, body)
-                            receiver.complete_message(message)
+                            try:
+                                receiver.complete_message(message)
+                            except MessageLockLostError:
+                                logger.warning(
+                                    "Message lock expired before complete; message will be retried by Service Bus"
+                                )
                         except json.JSONDecodeError as exc:
                             logger.error("Unparseable message body; dead-lettering: %s", exc)
-                            receiver.dead_letter_message(message, reason="UnparseableBody")
+                            try:
+                                receiver.dead_letter_message(message, reason="UnparseableBody")
+                            except MessageLockLostError:
+                                logger.warning("Message lock expired before dead-letter")
                         except Exception as exc:
                             logger.error("Unhandled error processing message; abandoning: %s", exc, exc_info=True)
-                            receiver.abandon_message(message)
+                            try:
+                                receiver.abandon_message(message)
+                            except MessageLockLostError:
+                                logger.warning(
+                                    "Message lock expired before abandon; Service Bus will retry"
+                                )
         except SBConnectionError as exc:
             consecutive_connection_errors += 1
             delay = _connection_backoff_seconds(consecutive_connection_errors)

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -366,6 +366,14 @@ def test_processing_usage_tokens_defaults_to_zero_when_missing():
     assert completion_tokens == 0
 
 
+def test_processing_tokens_default_to_16384(monkeypatch):
+    from app.agents.processing import _max_completion_tokens
+
+    monkeypatch.delenv("PFCD_MAX_PROCESSING_TOKENS", raising=False)
+    monkeypatch.delenv("PFCD_MAX_COMPLETION_TOKENS", raising=False)
+    assert _max_completion_tokens() == 16384
+
+
 def test_processing_times_out_long_llm_call(monkeypatch):
     import asyncio
 

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from azure.servicebus.exceptions import MessageLockLostError
 from azure.servicebus.exceptions import ServiceBusConnectionError as SBConnectionError
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -476,6 +477,67 @@ def test_run_uses_configured_receive_wait_and_idle_backoff(monkeypatch):
 
     assert fake_orchestrator.waits == [9]
     assert sleeps == [0.25]
+
+
+def test_run_continues_when_complete_loses_message_lock(monkeypatch):
+    from app.workers import runner as runner_mod
+
+    monkeypatch.setenv("PFCD_WORKER_ROLE", "processing")
+    monkeypatch.setattr(runner_mod.logging, "basicConfig", lambda **_: None)
+    monkeypatch.setattr(runner_mod, "_maybe_start_health_server", lambda: None)
+
+    class _FakeMessage:
+        body = [b"{}"]
+
+    class _FakeReceiver:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.completed = 0
+
+        def receive_messages(self, **_: Any):
+            self.calls += 1
+            if self.calls == 1:
+                return [_FakeMessage()]
+            raise KeyboardInterrupt()
+
+        def complete_message(self, _message: Any) -> None:
+            self.completed += 1
+            raise MessageLockLostError()
+
+        def dead_letter_message(self, _message: Any, **__: Any) -> None:
+            raise AssertionError("No message should be dead-lettered in this test")
+
+        def abandon_message(self, _message: Any) -> None:
+            raise AssertionError("No message should be abandoned in this test")
+
+    class _FakeOrchestrator:
+        def __init__(self) -> None:
+            self.enabled = True
+            self.receiver = _FakeReceiver()
+
+        @contextmanager
+        def receive(self, _phase: str, max_wait_time: int = 5):
+            del max_wait_time
+            yield self.receiver
+
+    fake_orchestrator = _FakeOrchestrator()
+
+    class _FakeWorker:
+        def __init__(self, _phase: str) -> None:
+            self.orchestrator = fake_orchestrator
+            self.handled = 0
+
+        def handle_message(self, _message: Any, _body: Any) -> None:
+            self.handled += 1
+
+    fake_worker = _FakeWorker("processing")
+    monkeypatch.setattr(runner_mod, "Worker", lambda _phase: fake_worker)
+
+    with pytest.raises(KeyboardInterrupt):
+        runner_mod.run()
+
+    assert fake_worker.handled == 1
+    assert fake_orchestrator.receiver.completed == 1
 
 
 def test_connection_backoff_seconds_is_bounded(monkeypatch):


### PR DESCRIPTION
## Summary
- raise processing default completion-token ceiling from `8192` to `16384` in `_max_completion_tokens()` to avoid quality-profile JSON truncation
- guard Service Bus settlement calls (`complete_message`, `dead_letter_message`, `abandon_message`) against `MessageLockLostError` so lock expiry no longer crashes worker loop
- add targeted regression tests for both fixes

## Validation
- `pytest -q tests/unit/test_agents.py -k "processing_tokens_default_to_16384 or processing_times_out_long_llm_call"` -> `2 passed`
- `pytest -q tests/unit/test_worker.py -k "message_lock or complete_loses_message_lock or run_recreates_receiver_after_servicebus_error"` -> `2 passed`
- `pytest -q tests/unit tests/integration` -> `361 passed, 2 skipped`

Closes #71
