### PR TITLE
feat: improve pipeline prompt quality and completeness checks (issue #74)

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3184,3 +3184,66 @@ Implemented two surgical stability fixes for the processing worker repeat-fail l
 ### Open questions
 
 - Optional future hardening: add `AutoLockRenewer` for long-running processing calls to further reduce lock-loss frequency under high-latency model runs.
+
+## Section 26: Issue #74 — Fact-Aware Extraction + Processing Completeness + Reviewing Warnings (2026-04-22)
+
+Implemented the issue-specified single-pass quality upgrade across extraction, processing, reviewing, job defaults, and tests.
+
+### What was added
+
+- `backend/app/agents/extraction.py`
+  - Extended extraction JSON prompt schema with four new top-level fields:
+    - `quantitative_facts`
+    - `exception_patterns`
+    - `workaround_rationale`
+    - `roles_detected`
+  - Added `_parse_fact_extraction()` to safely normalize these containers with graceful list defaults.
+  - Wired extraction output into `job["extracted_facts"]` in both normal and no-content fallback paths.
+
+- `backend/app/agents/processing.py`
+  - Added `Extracted facts:` section to prompt input and passed `job["extracted_facts"]` into `_USER_PROMPT_TEMPLATE`.
+  - Added explicit prompt rules for:
+    - quantitative population for SLA/frequency with "Needs Review" prohibition when facts exist
+    - full lifecycle close-step completeness
+    - exception completeness mapping
+    - approval-matrix role coverage with explicit `R/A/C/I`
+    - control type definitions (`manual/system/preventive/detective`)
+    - automation opportunity completeness on known patterns
+    - workaround rationale surfacing into risks/improvement notes
+  - Updated `_profile_guidance()` to issue-defined targets:
+    - balanced: `Target 8-14 steps... Capture only as-is evidence.`
+    - quality: `Target 10-18 steps... all SLA figures... all named exceptions.`
+  - Added `improvement_notes` default in draft normalization.
+
+- `backend/app/agents/reviewing.py`
+  - Added warning-only completeness flags:
+    - `SLA_UNRESOLVED`
+    - `FREQUENCY_UNRESOLVED`
+    - `EXCEPTIONS_SUPPRESSED`
+  - Flags compare `pdd` fields with `job["extracted_facts"]` content and do not block finalize.
+
+- `backend/app/job_logic.py`
+  - Added `"extracted_facts": {}` default in `default_job_payload()` for backward-safe downstream access.
+
+- `tests/unit/test_agents.py`
+  - Added/updated tests for:
+    - extraction prompt contract includes all four new schema fields
+    - `_parse_fact_extraction()` defaults and normalization behavior
+    - processing prompt includes rule keywords/definitions from the new instruction set
+    - updated profile guidance contract for balanced/quality outputs
+    - reviewing warnings for unresolved SLA/frequency and suppressed exceptions
+    - default job payload includes `extracted_facts`.
+
+### Validation
+
+- `pytest -q tests/unit/test_agents.py`
+  - Result: `67 passed, 1 warning`
+
+### Decisions
+
+- Kept implementation single-pass (no second LLM call) to preserve latency/cost profile.
+- Implemented warning-only reviewing flags exactly as non-blocking quality signals.
+
+### Open questions
+
+- None for this issue scope; next validation should be live transcript rerun to observe improved SLA/frequency/exception carry-through in end-to-end outputs.

--- a/backend/app/agents/extraction.py
+++ b/backend/app/agents/extraction.py
@@ -45,6 +45,29 @@ Return a JSON object with this exact shape:
       "confidence": 0.0
     }}
   ],
+  "quantitative_facts": [
+    {{
+      "fact_type": "volume|sla|effort|staffing|error_rate",
+      "value": "string",
+      "context": "string",
+      "anchor": "HH:MM:SS"
+    }}
+  ],
+  "exception_patterns": [
+    {{
+      "scenario": "string",
+      "trigger": "string",
+      "anchor": "HH:MM:SS"
+    }}
+  ],
+  "workaround_rationale": [
+    {{
+      "workaround": "string",
+      "reason": "string",
+      "anchor": "HH:MM:SS"
+    }}
+  ],
+  "roles_detected": ["role names detected in the process narrative"],
   "speakers_detected": ["name or Unknown Speaker"],
   "process_domain": "string",
   "transcript_quality": "high|medium|low"
@@ -75,6 +98,11 @@ Rules:
 - source_type must be one of video|audio|transcript|frame based on the evidence source
 - confidence: 0.7–0.9 for explicitly stated steps; 0.4–0.6 for inferred; 0.2–0.4 for ambiguous
 - speakers_detected must list all unique speakers; use "Unknown Speaker" if unidentifiable
+- quantitative_facts must capture stated metrics and timings with anchors (volume, sla, effort,
+  staffing, error_rate)
+- exception_patterns must capture distinct exception scenarios and their triggers
+- workaround_rationale must capture workaround + underlying reason pairs, with anchors
+- roles_detected must list all named operational roles discovered in the process content
 - aim for complete extraction: a 60-minute discovery session should yield 15–30 evidence items
 - transcript_quality: high if cues clearly describe process steps; medium if some steps are implicit; low if content is mostly chitchat
 """
@@ -299,6 +327,29 @@ def _apply_source_type_defaults(extracted: Dict[str, Any], primary_source_type: 
             item["source_type"] = resolved
 
 
+def _parse_fact_extraction(extracted: Dict[str, Any]) -> Dict[str, Any]:
+    """Safely pluck extracted fact containers with list defaults."""
+
+    def _as_list(value: Any) -> List[Any]:
+        return value if isinstance(value, list) else []
+
+    quantitative_facts = [item for item in _as_list(extracted.get("quantitative_facts")) if isinstance(item, dict)]
+    exception_patterns = [item for item in _as_list(extracted.get("exception_patterns")) if isinstance(item, dict)]
+    workaround_rationale = [item for item in _as_list(extracted.get("workaround_rationale")) if isinstance(item, dict)]
+    roles_detected = [
+        role.strip()
+        for role in _as_list(extracted.get("roles_detected"))
+        if isinstance(role, str) and role.strip()
+    ]
+
+    return {
+        "quantitative_facts": quantitative_facts,
+        "exception_patterns": exception_patterns,
+        "workaround_rationale": workaround_rationale,
+        "roles_detected": roles_detected,
+    }
+
+
 def _normalize_input(job: Dict[str, Any]) -> Tuple[str, List[Dict[str, Any]], Dict[str, Any]]:
     """
     Use registered adapters to normalize job input into extraction content.
@@ -391,6 +442,7 @@ def run_extraction(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
             "process_domain": "unknown",
             "transcript_quality": "low",
         }
+        job["extracted_facts"] = _parse_fact_extraction({})
         job["agent_signals"]["transcript_parsed"] = False
         return 0.0
 
@@ -438,6 +490,7 @@ def run_extraction(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
     extracted.setdefault("subject_process", extracted.get("process_domain") or "unknown")
 
     job["extracted_evidence"] = extracted
+    job["extracted_facts"] = _parse_fact_extraction(extracted)
     job["agent_signals"]["transcript_parsed"] = True
     job["agent_signals"]["speakers_detected"] = extracted.get("speakers_detected") or []
     from app.job_logic import estimate_cost_usd

--- a/backend/app/agents/processing.py
+++ b/backend/app/agents/processing.py
@@ -81,6 +81,9 @@ _USER_PROMPT_TEMPLATE = """\
 Evidence items:
 {evidence_json}
 
+Extracted facts:
+{extracted_facts_json}
+
 Input manifest:
 {manifest_json}
 
@@ -96,6 +99,7 @@ Generate a complete PDD and SIPOC from the evidence above. Return a JSON object 
   "pdd": {pdd_schema},
   "sipoc": {sipoc_schema},
   "assumptions": ["list of assumptions made"],
+  "improvement_notes": ["list of improvement notes derived from workaround rationale"],
   "automation_opportunities": [
     {{
       "id": "auto-01",
@@ -123,6 +127,26 @@ Generate a complete PDD and SIPOC from the evidence above. Return a JSON object 
 Rules:
 - Evidence priority: video/audio/frame-derived items (source_type video|audio|frame)
   take precedence over transcript-derived items (source_type transcript) for step sequence.
+- Quantitative population rule: if extracted_facts.quantitative_facts includes fact_type "sla",
+  populate pdd.sla from that fact and do not emit "Needs Review" for SLA. If it includes
+  fact_type "volume", populate pdd.frequency from that fact and do not emit "Needs Review"
+  for frequency.
+- Full lifecycle rule: if evidence includes a close/confirm/conclude action, include that as
+  an explicit closing step. Do not end the process at "escalate" or "resolve" without a close step.
+- Exception completeness rule: for each extracted_facts.exception_patterns entry, include a matching
+  entry in pdd.exceptions. Do not collapse distinct exception scenarios into one generic exception.
+- Approval matrix coverage rule: every role listed in extracted_facts.roles_detected must appear in
+  approval_matrix with explicit responsibility value R/A/C/I.
+- Control type definitions:
+  - manual: human action or decision without system enforcement
+  - system: enforced or logged by the software itself
+  - preventive: stops an error before it occurs
+  - detective: identifies an error after it occurs
+- Automation opportunity completeness: create one automation_opportunities[] entry for each detected
+  manual re-keying/copy-paste workaround, shadow spreadsheet/offline tracking tool, and
+  knowledge-dependent decision that could be encoded as a rule engine.
+- Workaround rationale rule: for each extracted_facts.workaround_rationale entry, surface the
+  rationale reason in draft.risks[] or improvement_notes[].
 - If alignment_verdict is "suspected_mismatch", downgrade confidence on transcript-only
   inferences and avoid using transcript-only claims as primary sequencing evidence.
 - Use conservative language: do not invent roles, systems, or business rules not supported by evidence.
@@ -153,13 +177,10 @@ Rules:
 def _profile_guidance(profile: str) -> str:
     if profile == "quality":
         return (
-            "- Be thorough. Include observable sub-steps, exceptions, and system interactions.\n"
-            "- Capture nuance when evidence supports it, while preserving schema precision."
+            "Target 10-18 steps. Preserve distinct steps even if adjacent. "
+            "Capture all named roles, all SLA figures, all named exceptions."
         )
-    return (
-        "- Be concise. Prefer fewer, higher-confidence steps.\n"
-        "- Avoid speculative detail when evidence is ambiguous."
-    )
+    return "Target 8-14 steps. Merge sub-steps. Omit future-state or aspirational content. Capture only as-is evidence."
 
 
 def _safe_int(value: Any) -> int:
@@ -305,6 +326,11 @@ def run_processing(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
 
     user_prompt = _USER_PROMPT_TEMPLATE.format(
         evidence_json=json.dumps(evidence, ensure_ascii=True, separators=(",", ":")),
+        extracted_facts_json=json.dumps(
+            job.get("extracted_facts") or {},
+            ensure_ascii=True,
+            separators=(",", ":"),
+        ),
         manifest_json=json.dumps(manifest, ensure_ascii=True, separators=(",", ":")),
         alignment_verdict=alignment_verdict,
         profile=profile,
@@ -331,6 +357,7 @@ def run_processing(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
     draft.setdefault("generated_at", _utc_now())
     draft.setdefault("version", 1)
     draft.setdefault("assumptions", [])
+    draft.setdefault("improvement_notes", [])
     draft.setdefault("automation_opportunities", [])
     draft.setdefault("faqs", [])
     draft.setdefault("approval_matrix", [])

--- a/backend/app/agents/reviewing.py
+++ b/backend/app/agents/reviewing.py
@@ -118,13 +118,46 @@ def run_reviewing(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:  
             "One or more speakers could not be identified in the transcript.",
         ))
 
+    # 6. Completeness checks from extracted_facts (warning only; do not block finalize)
+    extracted_facts = job.get("extracted_facts") or {}
+    quantitative_facts = extracted_facts.get("quantitative_facts") or []
+    has_sla_fact = any(
+        isinstance(fact, dict) and str(fact.get("fact_type", "")).strip().lower() == "sla"
+        for fact in quantitative_facts
+    )
+    has_volume_fact = any(
+        isinstance(fact, dict) and str(fact.get("fact_type", "")).strip().lower() == "volume"
+        for fact in quantitative_facts
+    )
+    exception_patterns = extracted_facts.get("exception_patterns") or []
+    pdd_exceptions = pdd.get("exceptions") or []
+
+    if has_sla_fact and str(pdd.get("sla", "")).strip() == "Needs Review":
+        flags.append(_flag(
+            "SLA_UNRESOLVED",
+            "warning",
+            "PDD SLA is 'Needs Review' even though extracted facts include SLA values.",
+        ))
+    if has_volume_fact and str(pdd.get("frequency", "")).strip() == "Needs Review":
+        flags.append(_flag(
+            "FREQUENCY_UNRESOLVED",
+            "warning",
+            "PDD frequency is 'Needs Review' even though extracted facts include volume values.",
+        ))
+    if exception_patterns and not pdd_exceptions:
+        flags.append(_flag(
+            "EXCEPTIONS_SUPPRESSED",
+            "warning",
+            "Exception patterns were extracted but pdd.exceptions is empty.",
+        ))
+
     # Merge flags (preserve any flags already set by build_draft fallback)
     existing_codes = {f["code"] for f in job["review_notes"]["flags"]}
     for f in flags:
         if f["code"] not in existing_codes:
             job["review_notes"]["flags"].append(f)
 
-    # 6. Overall confidence + decision
+    # 7. Overall confidence + decision
     all_flags = job["review_notes"]["flags"]
     has_blocker = any(f["severity"] == "blocker" for f in all_flags)
     has_mismatch_warning = any(f["code"] == "transcript_mismatch" for f in all_flags)

--- a/backend/app/job_logic.py
+++ b/backend/app/job_logic.py
@@ -306,6 +306,7 @@ def default_job_payload(payload: JobCreateRequest) -> Dict[str, Any]:
         },
         "draft": None,
         "finalized_draft": None,
+        "extracted_facts": {},
         "speaker_resolutions": {},
         "user_saved_draft": False,
         "user_saved_at": None,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -750,6 +750,9 @@ async def update_draft(job_id: str, payload: DraftUpdateRequest) -> Dict[str, An
         "insufficient_evidence",
         "transcript_mismatch",
         "unknown_speaker",
+        "SLA_UNRESOLVED",
+        "FREQUENCY_UNRESOLVED",
+        "EXCEPTIONS_SUPPRESSED",
     }
     job["review_notes"]["flags"] = [
         flag

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -318,6 +318,41 @@ def test_extraction_prompt_contract_is_media_first():
     assert "do not invent timestamps" in user_prompt.lower()
     assert "15–30 evidence items" in user_prompt
     assert "collapse adjacent steps" in user_prompt.lower()
+    assert '"quantitative_facts": [' in user_prompt
+    assert '"exception_patterns": [' in user_prompt
+    assert '"workaround_rationale": [' in user_prompt
+    assert '"roles_detected": [' in user_prompt
+
+
+def test_parse_fact_extraction_defaults_on_missing_keys():
+    from app.agents.extraction import _parse_fact_extraction
+
+    parsed = _parse_fact_extraction({})
+
+    assert parsed == {
+        "quantitative_facts": [],
+        "exception_patterns": [],
+        "workaround_rationale": [],
+        "roles_detected": [],
+    }
+
+
+def test_parse_fact_extraction_defaults_on_null_and_invalid_types():
+    from app.agents.extraction import _parse_fact_extraction
+
+    parsed = _parse_fact_extraction(
+        {
+            "quantitative_facts": None,
+            "exception_patterns": "not-a-list",
+            "workaround_rationale": [{"workaround": "sheet", "reason": "crm trust gap"}],
+            "roles_detected": ["Analyst", "", None, "Manager", 12],
+        }
+    )
+
+    assert parsed["quantitative_facts"] == []
+    assert parsed["exception_patterns"] == []
+    assert parsed["workaround_rationale"] == [{"workaround": "sheet", "reason": "crm trust gap"}]
+    assert parsed["roles_detected"] == ["Analyst", "Manager"]
 
 
 def test_extraction_tokens_default_to_4096(monkeypatch):
@@ -497,13 +532,24 @@ def test_processing_prompt_contract_includes_alignment_and_priority_rules():
     assert "PDD steps[] must include only current as-is executable actions." in user_prompt
     assert "Future-state proposals, recommendations, target-state workflows" in user_prompt
     assert "Prefer concrete figures (percentages, counts, durations, frequencies, and error rates)" in user_prompt
+    assert "Quantitative population rule" in user_prompt
+    assert 'do not emit "Needs Review"' in user_prompt
+    assert "Full lifecycle rule" in user_prompt
+    assert "Exception completeness rule" in user_prompt
+    assert "Approval matrix coverage rule" in user_prompt
+    assert "manual: human action or decision without system enforcement" in user_prompt
+    assert "Automation opportunity completeness" in user_prompt
+    assert "Workaround rationale rule" in user_prompt
 
 
 def test_processing_profile_guidance_balanced_and_quality():
     from app.agents.processing import _profile_guidance
 
-    assert "Be concise" in _profile_guidance("balanced")
-    assert "Be thorough" in _profile_guidance("quality")
+    assert "Target 8-14 steps" in _profile_guidance("balanced")
+    assert "Capture only as-is evidence" in _profile_guidance("balanced")
+    assert "Target 10-18 steps" in _profile_guidance("quality")
+    assert "all SLA figures" in _profile_guidance("quality")
+    assert "all named exceptions" in _profile_guidance("quality")
 
 
 def test_processing_passes_alignment_and_profile_guidance_to_prompt():
@@ -528,7 +574,7 @@ def test_processing_passes_alignment_and_profile_guidance_to_prompt():
 
     prompt = captured["user_content"]
     assert "Alignment verdict: suspected_mismatch" in prompt
-    assert "Be concise. Prefer fewer, higher-confidence steps." in prompt
+    assert "Target 8-14 steps. Merge sub-steps." in prompt
 
 
 def test_processing_uses_quality_profile_guidance():
@@ -551,7 +597,7 @@ def test_processing_uses_quality_profile_guidance():
         run_processing(job, _quality_profile())
 
     prompt = captured["user_content"]
-    assert "Be thorough. Include observable sub-steps, exceptions, and system interactions." in prompt
+    assert "Target 10-18 steps. Preserve distinct steps even if adjacent." in prompt
 
 
 # ---------------------------------------------------------------------------
@@ -723,6 +769,91 @@ def test_reviewing_flags_unknown_speaker():
     assert "unknown_speaker" in flag_codes
 
 
+def test_reviewing_flags_sla_unresolved_when_sla_fact_exists():
+    from app.agents.reviewing import run_reviewing
+
+    pdd = _full_pdd()
+    pdd["sla"] = "Needs Review"
+    pdd["frequency"] = "Daily"
+    draft = {
+        "pdd": pdd,
+        "sipoc": _full_sipoc(),
+        "confidence_summary": {"overall": 0.7, "source_quality": "high", "evidence_strength": "high"},
+    }
+    job = _job_with_draft(draft, has_video=True, has_audio=True, has_transcript=True)
+    job["extracted_facts"] = {
+        "quantitative_facts": [
+            {"fact_type": "sla", "value": "24h regulatory", "anchor": "00:10:00"}
+        ],
+        "exception_patterns": [],
+        "workaround_rationale": [],
+        "roles_detected": [],
+    }
+
+    run_reviewing(job, _balanced_profile())
+
+    codes = [f["code"] for f in job["review_notes"]["flags"]]
+    assert "SLA_UNRESOLVED" in codes
+    assert job["agent_review"]["decision"] != "blocked"
+
+
+def test_reviewing_flags_frequency_unresolved_when_volume_fact_exists():
+    from app.agents.reviewing import run_reviewing
+
+    pdd = _full_pdd()
+    pdd["sla"] = "24h"
+    pdd["frequency"] = "Needs Review"
+    draft = {
+        "pdd": pdd,
+        "sipoc": _full_sipoc(),
+        "confidence_summary": {"overall": 0.7, "source_quality": "high", "evidence_strength": "high"},
+    }
+    job = _job_with_draft(draft, has_video=True, has_audio=True, has_transcript=True)
+    job["extracted_facts"] = {
+        "quantitative_facts": [
+            {"fact_type": "volume", "value": "180-220/day", "anchor": "00:12:00"}
+        ],
+        "exception_patterns": [],
+        "workaround_rationale": [],
+        "roles_detected": [],
+    }
+
+    run_reviewing(job, _balanced_profile())
+
+    codes = [f["code"] for f in job["review_notes"]["flags"]]
+    assert "FREQUENCY_UNRESOLVED" in codes
+    assert job["agent_review"]["decision"] != "blocked"
+
+
+def test_reviewing_flags_exceptions_suppressed_when_patterns_exist():
+    from app.agents.reviewing import run_reviewing
+
+    pdd = _full_pdd()
+    pdd["sla"] = "24h"
+    pdd["frequency"] = "Daily"
+    pdd["exceptions"] = []
+    draft = {
+        "pdd": pdd,
+        "sipoc": _full_sipoc(),
+        "confidence_summary": {"overall": 0.7, "source_quality": "high", "evidence_strength": "high"},
+    }
+    job = _job_with_draft(draft, has_video=True, has_audio=True, has_transcript=True)
+    job["extracted_facts"] = {
+        "quantitative_facts": [],
+        "exception_patterns": [
+            {"scenario": "Strategic customer bypass", "trigger": "VIP flag", "anchor": "00:15:00"}
+        ],
+        "workaround_rationale": [],
+        "roles_detected": [],
+    }
+
+    run_reviewing(job, _balanced_profile())
+
+    codes = [f["code"] for f in job["review_notes"]["flags"]]
+    assert "EXCEPTIONS_SUPPRESSED" in codes
+    assert job["agent_review"]["decision"] != "blocked"
+
+
 # ---------------------------------------------------------------------------
 # load_transcript_text helper tests
 # ---------------------------------------------------------------------------
@@ -738,6 +869,15 @@ def test_load_transcript_text_inline_fallback():
 
     result = load_transcript_text(job, storage=MagicMock())
     assert result == "Hello world transcript"
+
+
+def test_default_job_payload_has_extracted_facts_default():
+    from app.job_logic import InputFile, JobCreateRequest, default_job_payload
+
+    req = JobCreateRequest(profile="balanced", input_files=[InputFile(source_type="transcript", size_bytes=10)])
+    payload = default_job_payload(req)
+
+    assert payload["extracted_facts"] == {}
 
 
 def test_load_transcript_text_from_storage(tmp_path):

--- a/tests/unit/test_draft_edit.py
+++ b/tests/unit/test_draft_edit.py
@@ -131,3 +131,41 @@ def test_update_draft_re_review_triggers_pdd_blocker(monkeypatch, tmp_path):
     pdd_flags = [flag for flag in response.json()["review_notes"]["flags"] if flag["code"] == "pdd_incomplete"]
     assert pdd_flags
     assert any(flag["severity"] == "blocker" for flag in pdd_flags)
+
+
+def test_update_draft_clears_sla_unresolved_after_user_fixes_sla(monkeypatch, tmp_path):
+    """SLA_UNRESOLVED flag must be cleared on re-review when the user fixes pdd.sla."""
+    main_mod = _reload_app(monkeypatch, tmp_path)
+
+    from starlette.testclient import TestClient
+
+    with TestClient(main_mod.app, raise_server_exceptions=False) as client:
+        job_id = _create_and_simulate(client)
+
+        # Inject extracted_facts with an SLA fact and a stale SLA_UNRESOLVED warning flag.
+        job = main_mod.JOB_REPO.get_job(job_id)
+        job["extracted_facts"] = {
+            "quantitative_facts": [{"fact_type": "sla", "value": "24h regulatory", "anchor": "00:10:00"}],
+            "exception_patterns": [],
+            "workaround_rationale": [],
+            "roles_detected": [],
+        }
+        job["review_notes"]["flags"].append({
+            "code": "SLA_UNRESOLVED",
+            "severity": "warning",
+            "message": "stale pre-fix flag",
+        })
+        main_mod.JOB_REPO.upsert_job(job_id, job)
+
+        # Save draft with SLA now properly populated.
+        draft = client.get(f"/api/jobs/{job_id}/draft").json()["draft"]
+        pdd = _full_pdd()
+        pdd["sla"] = "24h regulatory"
+        response = client.put(
+            f"/api/jobs/{job_id}/draft",
+            json={"draft_version": draft["version"], "pdd": pdd, "sipoc": _full_sipoc()},
+        )
+
+    assert response.status_code == 200
+    flag_codes = [f["code"] for f in response.json()["review_notes"]["flags"]]
+    assert "SLA_UNRESOLVED" not in flag_codes


### PR DESCRIPTION
## Summary
- extend extraction schema to capture quantitative facts, exception patterns, workaround rationale, and roles
- persist normalized fact extraction into `job["extracted_facts"]`
- add extracted-facts-aware processing prompt rules for SLA/frequency/exception/approval/control/automation/workaround completeness
- add reviewing warning flags: `SLA_UNRESOLVED`, `FREQUENCY_UNRESOLVED`, `EXCEPTIONS_SUPPRESSED`
- add `extracted_facts: {}` to default job payload and expand unit coverage

## Validation
- `pytest -q tests/unit/test_agents.py`
  - `67 passed, 1 warning`

Closes #74
