### PR TITLE
feat: populate exception action/owner and staffing facts in processing prompt

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3247,3 +3247,42 @@ Implemented the issue-specified single-pass quality upgrade across extraction, p
 ### Open questions
 
 - None for this issue scope; next validation should be live transcript rerun to observe improved SLA/frequency/exception carry-through in end-to-end outputs.
+
+## Section 27: Issue #76 — Exception Owner/Action Prompting + Staffing Fact Surfacing (2026-04-22)
+
+Implemented targeted processing prompt upgrades so exception rows are fully populated and staffing facts are not dropped.
+
+### What was added
+
+- `backend/app/agents/processing.py`
+  - Extended quantitative population rule to include `fact_type: "staffing"` with explicit instruction to surface staffing context in either:
+    - `pdd.process_overview` narrative, or
+    - `pdd.metrics.staffing_note`.
+  - Added explicit **Exception population rule** requiring each `pdd.exceptions[]` item to include:
+    - `action_required`
+    - `owner`
+  - Added owner fallback requirement: use a role from `extracted_facts.roles_detected` when available, otherwise use `"Process Owner"`.
+  - Added no-`"Needs Review"` instruction for exception `action_required`/`owner` when context is available.
+
+- `tests/unit/test_agents.py`
+  - Expanded processing prompt contract assertions for:
+    - exception population (`action_required`, `owner`, `Process Owner` fallback)
+    - staffing fact handling (`fact_type: "staffing"` and placement guidance)
+  - Added dedicated prompt contract tests:
+    - `test_processing_prompt_contract_includes_exception_action_owner_population`
+    - `test_processing_prompt_contract_includes_staffing_fact_rule`
+
+### Validation
+
+- `pytest -q tests/unit/test_agents.py -k "processing_prompt_contract or processing_profile_guidance or processing_passes_alignment or processing_uses_quality_profile_guidance"`
+  - Result: `6 passed, 63 deselected, 1 warning`
+- `pytest -q tests/unit/test_agents.py`
+  - Result: `69 passed, 1 warning`
+
+### Decisions
+
+- Kept this issue strictly prompt+tests only, with no processing post-parse mutation, matching issue scope.
+
+### Open questions
+
+- None for this issue scope.

--- a/backend/app/agents/processing.py
+++ b/backend/app/agents/processing.py
@@ -130,11 +130,16 @@ Rules:
 - Quantitative population rule: if extracted_facts.quantitative_facts includes fact_type "sla",
   populate pdd.sla from that fact and do not emit "Needs Review" for SLA. If it includes
   fact_type "volume", populate pdd.frequency from that fact and do not emit "Needs Review"
-  for frequency.
+  for frequency. If it includes fact_type "staffing", include the staffing context in pdd
+  either in process_overview narrative or as staffing_note under pdd.metrics.
 - Full lifecycle rule: if evidence includes a close/confirm/conclude action, include that as
   an explicit closing step. Do not end the process at "escalate" or "resolve" without a close step.
 - Exception completeness rule: for each extracted_facts.exception_patterns entry, include a matching
   entry in pdd.exceptions. Do not collapse distinct exception scenarios into one generic exception.
+- Exception population rule: for each entry in pdd.exceptions[], populate action_required and
+  owner from exception trigger context and step ownership. owner must come from
+  extracted_facts.roles_detected when available; otherwise use "Process Owner". Do not emit
+  "Needs Review" for action_required or owner when exception context and roles are available.
 - Approval matrix coverage rule: every role listed in extracted_facts.roles_detected must appear in
   approval_matrix with explicit responsibility value R/A/C/I.
 - Control type definitions:

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -536,10 +536,33 @@ def test_processing_prompt_contract_includes_alignment_and_priority_rules():
     assert 'do not emit "Needs Review"' in user_prompt
     assert "Full lifecycle rule" in user_prompt
     assert "Exception completeness rule" in user_prompt
+    assert "Exception population rule" in user_prompt
+    assert "action_required and" in user_prompt
+    assert "owner from exception trigger context" in user_prompt
+    assert 'otherwise use "Process Owner"' in user_prompt
     assert "Approval matrix coverage rule" in user_prompt
     assert "manual: human action or decision without system enforcement" in user_prompt
     assert "Automation opportunity completeness" in user_prompt
     assert "Workaround rationale rule" in user_prompt
+    assert 'fact_type "staffing"' in user_prompt
+
+
+def test_processing_prompt_contract_includes_exception_action_owner_population():
+    from app.agents import processing
+
+    user_prompt = processing._USER_PROMPT_TEMPLATE
+    assert "Exception population rule" in user_prompt
+    assert "action_required" in user_prompt
+    assert "owner" in user_prompt
+    assert 'use "Process Owner"' in user_prompt
+
+
+def test_processing_prompt_contract_includes_staffing_fact_rule():
+    from app.agents import processing
+
+    user_prompt = processing._USER_PROMPT_TEMPLATE
+    assert 'fact_type "staffing"' in user_prompt
+    assert "process_overview narrative or as staffing_note under pdd.metrics" in user_prompt
 
 
 def test_processing_profile_guidance_balanced_and_quality():


### PR DESCRIPTION
## Summary
- extend processing prompt with Exception population rule so each `pdd.exceptions[]` row includes `action_required` and `owner`
- require owner from `extracted_facts.roles_detected` with fallback to `"Process Owner"`
- extend quantitative population rule to include `fact_type: "staffing"` and surface staffing context in PDD
- add/expand processing prompt contract tests for exception action/owner and staffing rule coverage

## Validation
- `pytest -q tests/unit/test_agents.py -k "processing_prompt_contract or processing_profile_guidance or processing_passes_alignment or processing_uses_quality_profile_guidance"`
  - `6 passed, 63 deselected, 1 warning`
- `pytest -q tests/unit/test_agents.py`
  - `69 passed, 1 warning`

Closes #76
