### PR TITLE
config: default local runtime to PostgreSQL via DATABASE_URL

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3319,3 +3319,38 @@ Implemented a Python Streamlit frontend under `streamlit_app/` to mirror the exi
 ### Open Questions
 
 - None.
+
+---
+
+## Section 15: Issue #81 Local PostgreSQL Default (2026-04-29)
+
+Reconfigured local runtime configuration to default to PostgreSQL while preserving Azure PostgreSQL support through the same `DATABASE_URL` contract.
+
+### Completed
+
+- Updated `docker-compose.local.yml` DB wiring for `api`, `worker-extracting`, `worker-processing`, and `worker-reviewing`:
+  - `DATABASE_URL: ${DATABASE_URL:-sqlite:///./storage/pfcd.db}` → `DATABASE_URL: ${DATABASE_URL}`
+  - Effect: fail-fast when DB URL is not provided; no silent SQLite fallback in local app runtime.
+- Updated `docker-compose.local.env.example`:
+  - Added local PostgreSQL default example using `postgresql+psycopg://...@host.docker.internal...`.
+  - Added commented Azure PostgreSQL Flexible Server example with `sslmode=require`.
+  - Kept SQLite as commented CI/test-only variant.
+  - Added explicit migration reminder before workers (`alembic upgrade head`).
+  - Added clarification that `AZURE_SQL_SERVER_NAME` / `AZURE_SQL_DATABASE_NAME` are informational; `DATABASE_URL` is authoritative.
+- Updated `REFERENCE.md`:
+  - `DATABASE_URL` row now uses PostgreSQL examples as primary guidance.
+  - Added local startup order note: API → Alembic migration → workers/frontends.
+  - Added a `DB Target Check` subsection showing `echo $DATABASE_URL` and `alembic upgrade head`.
+  - Added explicit note that `AZURE_SQL_*` variables are informational only.
+
+### Validation
+
+- `docker compose --env-file docker-compose.local.env.example -f docker-compose.local.yml config --services` ✅
+
+### Decisions
+
+- Runtime DB target remains a single switch (`DATABASE_URL`) for both local and Azure, with no app code change.
+
+### Open Questions
+
+- None.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -112,18 +112,31 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 
-# Run DB migrations
+# Run DB migrations (before starting workers/frontends)
 alembic upgrade head
 
 # Start API server (local dev)
 uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
 ```
 
+Startup order for local stack:
+1. Start API
+2. Run `alembic upgrade head`
+3. Start workers and frontends
+
+### DB Target Check
+
+```bash
+# Verify active DATABASE_URL and migration head before starting workers
+echo $DATABASE_URL   # should show postgresql+psycopg://...
+cd backend && .venv/bin/alembic upgrade head
+```
+
 ### Required Environment Variables
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `DATABASE_URL` | SQLAlchemy connection string | local default `sqlite:///./pfcd.db`; PostgreSQL example `postgresql+psycopg://pfcd_user:password@127.0.0.1:5432/pfcd` |
+| `DATABASE_URL` | SQLAlchemy connection string (authoritative DB target) | PostgreSQL example `postgresql+psycopg://pfcd_user:password@127.0.0.1:5432/pfcd?sslmode=disable`; Azure PostgreSQL example `postgresql+psycopg://pfcd_admin:password@<server>.postgres.database.azure.com:5432/pfcd?sslmode=require` |
 | `AZURE_STORAGE_CONNECTION_STRING` | Blob storage | local fallback if unset |
 | `AZURE_STORAGE_CONTAINER_EVIDENCE` | Blob container for frame captures/evidence assets | `evidence` |
 | `AZURE_SERVICE_BUS_CONNECTION_STRING` | Service Bus namespace | `""` (skips queue dispatch) |
@@ -162,6 +175,8 @@ uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
 | `APP_INSIGHTS_NAME` | Azure Application Insights component name (bootstrap/ops baseline) | `${PROJECT}-${ENVIRONMENT}-appi` |
 | `ALERT_ACTION_GROUP_NAME` | Azure Monitor action group name (bootstrap/ops baseline) | `${PROJECT}-${ENVIRONMENT}-ops-ag` |
 | `ALERT_EMAIL` | Alert notification recipient used by bootstrap action group setup | `""` (alerts created without notifications) |
+
+`AZURE_SQL_SERVER_NAME` and `AZURE_SQL_DATABASE_NAME` are informational only; runtime DB selection is controlled by `DATABASE_URL`.
 
 ### Frontend Dev Environment Variables
 

--- a/docker-compose.local.env.example
+++ b/docker-compose.local.env.example
@@ -35,8 +35,25 @@ AZURE_OPENAI_CHAT_DEPLOYMENT_NAME=local-docker-smoke
 PFCD_PROVIDER=azure_openai
 PFCD_API_KEY=
 
+# --- Database ---
+# After updating DATABASE_URL, run migrations before starting workers:
+#   cd backend && .venv/bin/alembic upgrade head
+#
+# Local PostgreSQL (default for local Docker dev):
+#   host.docker.internal resolves to the Docker host; assumes PG is running on your machine.
+DATABASE_URL=postgresql+psycopg://pfcd_user:changeme@host.docker.internal:5432/pfcd?sslmode=disable
+#
+# Azure PostgreSQL Flexible Server (swap in your actual credentials):
+# DATABASE_URL=postgresql+psycopg://pfcd_admin:YOUR_PASSWORD@pfcd-dev-postgres.postgres.database.azure.com:5432/pfcd?sslmode=require
+#
+# SQLite (CI/test only — not recommended for local app runtime):
+# DATABASE_URL=sqlite:///./storage/pfcd.db
+#
+# Informational: Azure Flexible Server name (not used by the app — DATABASE_URL above is the authority)
+AZURE_SQL_SERVER_NAME=
+AZURE_SQL_DATABASE_NAME=
+
 # Optional backend local-path overrides.
-DATABASE_URL=sqlite:///./storage/pfcd.db
 EXPORTS_BASE_PATH=/app/storage/exports
 PFCD_CORS_ORIGINS=http://127.0.0.1:3000,http://localhost:3000
 UPLOADS_DIR=/app/storage/uploads

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -22,7 +22,7 @@ services:
       OPENAI_CHAT_MODEL_QUALITY: ${OPENAI_CHAT_MODEL_QUALITY:-gpt-4o}
       OPENAI_TRANSCRIPTION_MODEL: ${OPENAI_TRANSCRIPTION_MODEL:-whisper-1}
       OPENAI_VISION_MODEL: ${OPENAI_VISION_MODEL:-gpt-4o-mini}
-      DATABASE_URL: ${DATABASE_URL:-sqlite:///./storage/pfcd.db}
+      DATABASE_URL: ${DATABASE_URL}
       EXPORTS_BASE_PATH: ${EXPORTS_BASE_PATH:-/app/storage/exports}
       PFCD_CORS_ORIGINS: ${PFCD_CORS_ORIGINS:-http://127.0.0.1:3000,http://localhost:3000}
       UPLOADS_DIR: ${UPLOADS_DIR:-/app/storage/uploads}
@@ -126,7 +126,7 @@ services:
       OPENAI_CHAT_MODEL_QUALITY: ${OPENAI_CHAT_MODEL_QUALITY:-gpt-4o}
       OPENAI_TRANSCRIPTION_MODEL: ${OPENAI_TRANSCRIPTION_MODEL:-whisper-1}
       OPENAI_VISION_MODEL: ${OPENAI_VISION_MODEL:-gpt-4o-mini}
-      DATABASE_URL: ${DATABASE_URL:-sqlite:///./storage/pfcd.db}
+      DATABASE_URL: ${DATABASE_URL}
       EXPORTS_BASE_PATH: ${EXPORTS_BASE_PATH:-/app/storage/exports}
       UPLOADS_DIR: ${UPLOADS_DIR:-/app/storage/uploads}
       PFCD_MAX_RETRIES: ${PFCD_MAX_RETRIES:-3}
@@ -173,7 +173,7 @@ services:
       OPENAI_CHAT_MODEL_QUALITY: ${OPENAI_CHAT_MODEL_QUALITY:-gpt-4o}
       OPENAI_TRANSCRIPTION_MODEL: ${OPENAI_TRANSCRIPTION_MODEL:-whisper-1}
       OPENAI_VISION_MODEL: ${OPENAI_VISION_MODEL:-gpt-4o-mini}
-      DATABASE_URL: ${DATABASE_URL:-sqlite:///./storage/pfcd.db}
+      DATABASE_URL: ${DATABASE_URL}
       EXPORTS_BASE_PATH: ${EXPORTS_BASE_PATH:-/app/storage/exports}
       UPLOADS_DIR: ${UPLOADS_DIR:-/app/storage/uploads}
       PFCD_MAX_RETRIES: ${PFCD_MAX_RETRIES:-3}
@@ -220,7 +220,7 @@ services:
       OPENAI_CHAT_MODEL_QUALITY: ${OPENAI_CHAT_MODEL_QUALITY:-gpt-4o}
       OPENAI_TRANSCRIPTION_MODEL: ${OPENAI_TRANSCRIPTION_MODEL:-whisper-1}
       OPENAI_VISION_MODEL: ${OPENAI_VISION_MODEL:-gpt-4o-mini}
-      DATABASE_URL: ${DATABASE_URL:-sqlite:///./storage/pfcd.db}
+      DATABASE_URL: ${DATABASE_URL}
       EXPORTS_BASE_PATH: ${EXPORTS_BASE_PATH:-/app/storage/exports}
       UPLOADS_DIR: ${UPLOADS_DIR:-/app/storage/uploads}
       PFCD_MAX_RETRIES: ${PFCD_MAX_RETRIES:-3}


### PR DESCRIPTION
## Summary
- remove local SQLite fallback from docker-compose service DATABASE_URL wiring
- make local Docker env example PostgreSQL-first with Azure PostgreSQL and SQLite (CI/test-only) variants
- document migration-first startup order and DB target verification in REFERENCE.md
- clarify AZURE_SQL_SERVER_NAME / AZURE_SQL_DATABASE_NAME are informational; DATABASE_URL is authoritative
- append implementation notes in IMPLEMENTATION_SUMMARY.md

## Validation
- docker compose --env-file docker-compose.local.env.example -f docker-compose.local.yml config --services

## Issue
- Closes #81