### PR TITLE
fix: harden export frame key handling (Issue #84 A1/C1)

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3354,3 +3354,35 @@ Reconfigured local runtime configuration to default to PostgreSQL while preservi
 ### Open Questions
 
 - None.
+
+---
+
+## Section 16: Issue #84 (A1/C1) Export Path Traversal Guard (2026-04-30)
+
+Started Phase A hardening from Issue #84 by delivering checklist item **A1 · C1**.
+
+### Completed
+
+- Updated `backend/app/export_builder.py` to reject unsafe frame `storage_key` values when building `evidence_bundle.frame_captures`:
+  - Rejects absolute paths.
+  - Rejects `.` / `..` path segments (including backslash variants).
+- Removed direct filesystem fallback reads (`open(storage_key, "rb")`) from:
+  - `build_export_pdf(...)`
+  - `build_export_docx(...)`
+- Result: export rendering now uses only bytes pre-resolved by storage helpers (`frame_bytes_map` path), eliminating direct local-path reads from export payload values.
+- Added regression test in `tests/unit/test_export_builder.py`:
+  - `test_frame_captures_reject_unsafe_storage_keys`
+  - Verifies only safe storage keys are retained and linked.
+
+### Validation
+
+- `cd backend && .venv/bin/pytest ../tests/unit/test_export_builder.py -x --tb=short` ✅ (49 passed)
+- `cd backend && .venv/bin/pytest ../tests/integration/test_exports.py -x --tb=short` ✅ (8 passed)
+
+### Decisions
+
+- Kept the fix scoped to A1/C1 in Issue #84; no behavior changes to unrelated export or worker flows.
+
+### Open Questions
+
+- None.

--- a/backend/app/export_builder.py
+++ b/backend/app/export_builder.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import io
-import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -35,6 +34,18 @@ def _timestamp_to_seconds(value: str) -> float:
         return total
     except (TypeError, ValueError):
         return -1.0
+
+
+def _is_safe_storage_key(storage_key: str) -> bool:
+    normalized = (storage_key or "").strip().replace("\\", "/")
+    if not normalized:
+        return False
+    if normalized.startswith("/") or normalized.startswith("./"):
+        return False
+    parts = normalized.split("/")
+    if any(part in ("", ".", "..") for part in parts):
+        return False
+    return True
 
 
 def build_evidence_bundle(finalized_draft: Dict[str, Any], job: Dict[str, Any]) -> Dict[str, Any]:
@@ -101,8 +112,12 @@ def build_evidence_bundle(finalized_draft: Dict[str, Any], job: Dict[str, Any]) 
     for item in evidence_items:
         frame_keys = (item.get("metadata") or {}).get("frame_storage_keys") or []
         for storage_key, timestamp_sec in frame_keys:
+            if not _is_safe_storage_key(storage_key):
+                continue
             frame_captures.append({"storage_key": storage_key, "timestamp_sec": timestamp_sec})
     for storage_key, timestamp_sec in (job.get("agent_signals") or {}).get("frame_storage_keys") or []:
+        if not _is_safe_storage_key(storage_key):
+            continue
         if not any(
             existing["storage_key"] == storage_key and existing["timestamp_sec"] == timestamp_sec
             for existing in frame_captures
@@ -583,12 +598,6 @@ def build_export_pdf(
             key = capture.get("storage_key", "")
             timestamp_sec = capture.get("timestamp_sec", 0.0)
             image_bytes = (frame_bytes_map or {}).get(key)
-            if not image_bytes and (os.path.isabs(key) or (key.startswith(".") and os.path.exists(key))):
-                try:
-                    with open(key, "rb") as handle:
-                        image_bytes = handle.read()
-                except OSError:
-                    pass
             if image_bytes:
                 try:
                     pdf.image(io.BytesIO(image_bytes), w=120)
@@ -885,12 +894,6 @@ def build_export_docx(
             key = capture.get("storage_key", "")
             timestamp_sec = capture.get("timestamp_sec", 0.0)
             image_bytes = (frame_bytes_map or {}).get(key)
-            if not image_bytes and (os.path.isabs(key) or (key.startswith(".") and os.path.exists(key))):
-                try:
-                    with open(key, "rb") as handle:
-                        image_bytes = handle.read()
-                except OSError:
-                    pass
             if image_bytes:
                 try:
                     doc.add_picture(io.BytesIO(image_bytes))

--- a/tests/unit/test_export_builder.py
+++ b/tests/unit/test_export_builder.py
@@ -221,6 +221,41 @@ class TestBuildEvidenceBundle:
         values = [a["anchor_value"] for a in bundle["linked_anchors"]]
         assert "00:05:00" in values
 
+    def test_frame_captures_reject_unsafe_storage_keys(self):
+        draft = {
+            "pdd": {
+                "purpose": "p",
+                "scope": "s",
+                "steps": [_step("step-1", "x", [{"anchor": "00:00:10", "confidence": 0.8}])],
+            },
+            "sipoc": [_sipoc_row("x", "00:00:10", ["step-1"])],
+        }
+        job = {
+            "extracted_evidence": {
+                "evidence_items": [
+                    {
+                        "metadata": {
+                            "frame_storage_keys": [
+                                ("job-123/frames/frame_0001.jpg", 10.0),
+                                ("/tmp/frame.jpg", 11.0),
+                                ("../frames/frame_0002.jpg", 12.0),
+                                ("./frames/frame_0003.jpg", 13.0),
+                            ]
+                        }
+                    }
+                ]
+            },
+            "agent_signals": {
+                "frame_storage_keys": [
+                    ("job-123/frames/frame_0001.jpg", 10.0),
+                    ("..\\frames\\frame_0004.jpg", 14.0),
+                ]
+            },
+        }
+        bundle = build_evidence_bundle(draft, job)
+        captures = bundle["frame_captures"]
+        assert captures == [{"storage_key": "job-123/frames/frame_0001.jpg", "timestamp_sec": 10.0, "linked_anchor_ids": ["a-1"]}]
+
 
 # ---------------------------------------------------------------------------
 # build_export_markdown


### PR DESCRIPTION
## Summary
- reject unsafe frame storage keys when building evidence bundle frame captures:
  - absolute paths
  - dot-prefixed relative roots (./)
  - dot-segment traversal (..)
- remove direct local file fallback reads using open(storage_key) from PDF and DOCX export builders
- add regression coverage for unsafe frame storage keys

## Validation
- cd backend && .venv/bin/pytest ../tests/unit/test_export_builder.py -x --tb=short
- cd backend && .venv/bin/pytest ../tests/integration/test_exports.py -x --tb=short

## Scope
Implements Issue #84 checklist item A1/C1 only (path traversal hardening in export path).