### PR TITLE
test: lock alignment mismatch regression (Issue #84 A2/C3)

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3386,3 +3386,33 @@ Started Phase A hardening from Issue #84 by delivering checklist item **A1 · C1
 ### Open Questions
 
 - None.
+
+---
+
+## Section 17: Issue #84 (A2/C3) Alignment Self-Compare Regression Guard (2026-04-30)
+
+Completed Phase A checklist item **A2 · C3** on branch `codex/c3-alignment-selfcompare`.
+
+### Completed
+
+- Added regression test in `tests/unit/test_agents.py`:
+  - `test_run_anchor_alignment_marks_suspected_mismatch_for_divergent_texts`
+- Test setup intentionally provides divergent values for:
+  - `job["_video_transcript_inline"]`
+  - `job["_transcript_text_inline"]`
+- Assertions verify:
+  - `consistency_method == "text_similarity"`
+  - verdict resolves to `suspected_mismatch`
+  - `transcript_media_consistency.verdict` is also `suspected_mismatch`
+
+### Validation
+
+- `cd backend && .venv/bin/pytest ../tests/unit/test_agents.py -k divergent_texts -x --tb=short` ✅ (1 passed)
+
+### Decisions
+
+- No patch to `backend/app/agents/alignment.py`; regression test confirms existing behavior is correct and the reported self-compare concern is a false alarm for current fields.
+
+### Open Questions
+
+- None.

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -1229,6 +1229,30 @@ def test_run_anchor_alignment_uses_text_similarity_when_video_transcript_present
     assert summary["similarity_score"] >= 0.99
 
 
+def test_run_anchor_alignment_marks_suspected_mismatch_for_divergent_texts():
+    """Divergent uploaded vs video transcript inline text must produce suspected_mismatch."""
+    from app.agents.alignment import run_anchor_alignment
+
+    job = _make_job()
+    job["_transcript_text_inline"] = "Approve vendor invoice in SAP and schedule payment."
+    job["_video_transcript_inline"] = "Troubleshoot warehouse barcode scanner and reset mobile device."
+    job["extracted_evidence"] = {
+        "evidence_items": [
+            {"id": "ev-01", "summary": "test", "anchor": "00:00:01-00:00:05", "confidence": 0.9}
+        ],
+        "speakers_detected": [],
+        "process_domain": "test",
+        "transcript_quality": "high",
+    }
+
+    run_anchor_alignment(job)
+
+    summary = job["agent_signals"]["anchor_alignment_summary"]
+    assert summary["consistency_method"] == "text_similarity"
+    assert summary["verdict"] == "suspected_mismatch"
+    assert job["transcript_media_consistency"]["verdict"] == "suspected_mismatch"
+
+
 def test_anchor_alignment_fallback_uses_configurable_inconclusive_threshold(monkeypatch):
     import app.agents.alignment as alignment
 


### PR DESCRIPTION
## Summary
- add regression coverage for divergent inline transcript fields in alignment checks
- verify `_video_transcript_inline` and `_transcript_text_inline` divergence yields `suspected_mismatch`
- no code patch in `backend/app/agents/alignment.py` because behavior already matches expected outcome

## Validation
- cd backend && .venv/bin/pytest ../tests/unit/test_agents.py -k divergent_texts -x --tb=short

## Scope
Implements Issue #84 item A2/C3 only.