### PR TITLE
fix: correct video-only evidence tier (Issue #84 A3/C2)

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3416,3 +3416,33 @@ Completed Phase A checklist item **A2 · C3** on branch `codex/c3-alignment-self
 ### Open Questions
 
 - None.
+
+---
+
+## Section 18: Issue #84 (A3/C2) Evidence Tier Correction (2026-04-30)
+
+Completed Phase A checklist item **A3 · C2** on branch `codex/c2-evidence-video-tier`.
+
+### Completed
+
+- Updated `backend/app/agents/evidence.py` structural hierarchy:
+  - `video + audio` remains `high`.
+  - `video-only` (no audio, no transcript) now resolves to `medium` (was `low`).
+  - `video + transcript` remains `medium`.
+  - `transcript-only` remains `medium`.
+  - `audio-only` and no-source fallbacks remain `low`.
+- Updated `tests/unit/test_agents.py`:
+  - Renamed/updated video-only evidence test to expect `medium`.
+  - Updated reviewing-path assertion to expect computed `medium` evidence strength while preserving blocker behavior for explicit insufficient-evidence flags.
+
+### Validation
+
+- `cd backend && .venv/bin/pytest ../tests/unit/test_agents.py -x --tb=short` ✅ (73 passed)
+
+### Decisions
+
+- Kept reviewing blocker semantics unchanged; this item corrects evidence tiering only.
+
+### Open Questions
+
+- None.

--- a/backend/app/agents/evidence.py
+++ b/backend/app/agents/evidence.py
@@ -29,9 +29,9 @@ def compute_evidence_strength(
 
     Structural rules (PRD §7 evidence hierarchy):
       video + audio (with or without transcript) -> high
-      video + transcript, no audio              -> medium
+      video only (with or without transcript)   -> medium
       transcript only                           -> medium
-      video only, or no sources                 -> low
+      no sources, or audio only                 -> low
 
     Confidence degradation (applied after structural rule):
       If evidence_items provided and mean confidence < LOW_THRESHOLD,
@@ -39,7 +39,7 @@ def compute_evidence_strength(
     """
     if has_video and has_audio:
         strength = "high"
-    elif has_video and has_transcript:
+    elif has_video:
         strength = "medium"
     elif has_transcript:
         strength = "medium"

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -697,7 +697,7 @@ def test_reviewing_blocks_on_insufficient_evidence():
     flag_codes = [f["code"] for f in job["review_notes"]["flags"]]
     assert "insufficient_evidence" in flag_codes
     assert job["agent_review"]["decision"] == "blocked"
-    assert job["agent_signals"]["evidence_strength"] == "low"
+    assert job["agent_signals"]["evidence_strength"] == "medium"
 
 
 def test_reviewing_sets_frame_first_evidence_flag():
@@ -1159,9 +1159,9 @@ def test_evidence_strength_medium_transcript_only():
     assert compute_evidence_strength(False, False, True) == "medium"
 
 
-def test_evidence_strength_low_video_only():
+def test_evidence_strength_medium_video_only():
     from app.agents.evidence import compute_evidence_strength
-    assert compute_evidence_strength(True, False, False) == "low"
+    assert compute_evidence_strength(True, False, False) == "medium"
 
 
 def test_evidence_strength_low_no_sources():


### PR DESCRIPTION
## Summary
- update evidence hierarchy so video-only inputs classify as medium instead of low
- keep confidence degradation behavior unchanged (medium can still degrade to low when confidence is weak)
- update reviewing/evidence tests for the corrected tier

## Validation
- cd backend && .venv/bin/pytest ../tests/unit/test_agents.py -x --tb=short

## Scope
Implements Issue #84 item A3/C2 only.