### PR TITLE
fix: remove loop-bound kernel caching (Issue #84 A4/H4)

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3389,6 +3389,36 @@ Started Phase A hardening from Issue #84 by delivering checklist item **A1 · C1
 
 ---
 
+## Section 19: Issue #84 (A4/H4) Kernel Cache / Event Loop Safety (2026-04-30)
+
+Completed Phase A checklist item **A4 · H4** on branch `codex/h4-kernel-cache-loop`.
+
+### Completed
+
+- Updated `backend/app/agents/kernel_factory.py`:
+  - Removed `@lru_cache` usage from:
+    - `_cached_kernel_azure(...)`
+    - `_cached_kernel_openai(...)`
+  - Removed now-unused `lru_cache` import.
+- Added regression guard in `tests/unit/test_kernel_factory.py`:
+  - `test_kernel_helpers_are_not_lru_cached`
+  - Verifies helper functions are not cache-decorated.
+
+### Validation
+
+- `cd backend && .venv/bin/pytest ../tests/unit/test_kernel_factory.py -x --tb=short` ✅ (5 passed)
+- `cd backend && .venv/bin/pytest ../tests/unit/test_agents.py -x --tb=short` ✅ (74 passed)
+
+### Decisions
+
+- Kept function names unchanged for compatibility with existing call sites and tests; only cache behavior was removed.
+
+### Open Questions
+
+- None.
+
+---
+
 ## Section 17: Issue #84 (A2/C3) Alignment Self-Compare Regression Guard (2026-04-30)
 
 Completed Phase A checklist item **A2 · C3** on branch `codex/c3-alignment-selfcompare`.

--- a/backend/app/agents/kernel_factory.py
+++ b/backend/app/agents/kernel_factory.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-from functools import lru_cache
 
 from app.job_logic import _provider_name
 
@@ -13,7 +12,6 @@ logger = logging.getLogger(__name__)
 _DEFAULT_AZURE_OPENAI_API_VERSION = "2024-10-21"
 
 
-@lru_cache(maxsize=8)
 def _cached_kernel_azure(endpoint: str, deployment: str, api_version: str):
     from azure.identity import DefaultAzureCredential, get_bearer_token_provider
     from semantic_kernel import Kernel
@@ -35,7 +33,6 @@ def _cached_kernel_azure(endpoint: str, deployment: str, api_version: str):
     return kernel
 
 
-@lru_cache(maxsize=8)
 def _cached_kernel_openai(api_key: str, model: str):
     from semantic_kernel import Kernel
     from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion

--- a/tests/unit/test_kernel_factory.py
+++ b/tests/unit/test_kernel_factory.py
@@ -7,6 +7,11 @@ from unittest.mock import patch
 import app.agents.kernel_factory as kernel_factory
 
 
+def test_kernel_helpers_are_not_lru_cached():
+    assert not hasattr(kernel_factory._cached_kernel_azure, "cache_info")
+    assert not hasattr(kernel_factory._cached_kernel_openai, "cache_info")
+
+
 def test_get_kernel_uses_default_api_version(monkeypatch):
     endpoint = "https://example.openai.azure.com/"
     monkeypatch.delenv("PFCD_PROVIDER", raising=False)


### PR DESCRIPTION
## Summary
- remove lru_cache from kernel factory helper constructors to prevent loop-bound kernel reuse across jobs
- keep existing API and call sites unchanged (get_kernel/get_chat_service)
- add regression guard asserting kernel helpers are not cache-decorated

## Validation
- cd backend && .venv/bin/pytest ../tests/unit/test_kernel_factory.py -x --tb=short
- cd backend && .venv/bin/pytest ../tests/unit/test_agents.py -x --tb=short

## Scope
Implements Issue #84 item A4/H4 only.