### PR TITLE
fix: add ffmpeg timeouts to media preprocessing (Issue #84 A5/H5)

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3476,3 +3476,36 @@ Completed Phase A checklist item **A3 · C2** on branch `codex/c2-evidence-video
 ### Open Questions
 
 - None.
+
+---
+
+## Section 20: Issue #84 (A5/H5) ffmpeg Timeout Hardening (2026-04-30)
+
+Completed Phase A checklist item **A5 · H5** on branch `codex/h5-ffmpeg-timeout`.
+
+### Completed
+
+- Updated `backend/app/agents/media_preprocessor.py`:
+  - Added `_FFMPEG_TIMEOUT_SEC` from env (`PFCD_FFMPEG_TIMEOUT_SEC`, default `120`).
+  - Added `timeout=_FFMPEG_TIMEOUT_SEC` to all ffmpeg `subprocess.run(...)` calls:
+    - `is_ffmpeg_available()`
+    - `extract_audio_track(...)`
+    - `split_audio_chunks(...)`
+    - `extract_keyframes(...)`
+  - `is_ffmpeg_available()` now treats `subprocess.TimeoutExpired` as unavailable (`False`).
+- Added regression test in `tests/unit/test_media_preprocessor.py`:
+  - `test_ffmpeg_calls_include_timeout`
+  - Verifies all four ffmpeg subprocess invocations carry the timeout kwarg.
+
+### Validation
+
+- `cd backend && .venv/bin/pytest ../tests/unit/test_media_preprocessor.py -x --tb=short` ✅ (10 passed)
+- `cd backend && .venv/bin/pytest ../tests/unit/test_adapters.py -x --tb=short` ✅ (48 passed)
+
+### Decisions
+
+- Kept timeout policy centralized via a single env-backed constant to avoid diverging limits across media preprocessing steps.
+
+### Open Questions
+
+- None.

--- a/backend/app/agents/media_preprocessor.py
+++ b/backend/app/agents/media_preprocessor.py
@@ -12,6 +12,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 _MAX_TRANSCRIPTION_BYTES = 24 * 1024 * 1024
+_FFMPEG_TIMEOUT_SEC = max(1.0, float(os.environ.get("PFCD_FFMPEG_TIMEOUT_SEC", "120")))
 _TIMESTAMP_RE = re.compile(
     r"^(?P<start>\d{2}:\d{2}:\d{2}[.,]\d{3})\s+-->\s+"
     r"(?P<end>\d{2}:\d{2}:\d{2}[.,]\d{3})(?P<rest>.*)$"
@@ -25,8 +26,9 @@ def is_ffmpeg_available() -> bool:
             ["ffmpeg", "-version"],
             capture_output=True,
             check=False,
+            timeout=_FFMPEG_TIMEOUT_SEC,
         )
-    except FileNotFoundError:
+    except (FileNotFoundError, subprocess.TimeoutExpired):
         return False
     return result.returncode == 0
 
@@ -51,6 +53,7 @@ def extract_audio_track(video_path: str, output_dir: str) -> str | None:
             ],
             capture_output=True,
             check=False,
+            timeout=_FFMPEG_TIMEOUT_SEC,
         )
         if result.returncode != 0:
             logger.warning("ffmpeg audio extraction failed for %s", video_path)
@@ -88,6 +91,7 @@ def split_audio_chunks(
             ],
             capture_output=True,
             check=False,
+            timeout=_FFMPEG_TIMEOUT_SEC,
         )
         if result.returncode != 0:
             logger.warning("ffmpeg chunking failed for %s", audio_path)
@@ -129,6 +133,7 @@ def extract_keyframes(
             ],
             capture_output=True,
             check=False,
+            timeout=_FFMPEG_TIMEOUT_SEC,
         )
         if result.returncode != 0:
             logger.warning("ffmpeg keyframe extraction failed for %s", video_path)

--- a/tests/unit/test_media_preprocessor.py
+++ b/tests/unit/test_media_preprocessor.py
@@ -100,6 +100,32 @@ def test_extract_keyframes_returns_list_of_tuples(monkeypatch):
     ]
 
 
+def test_ffmpeg_calls_include_timeout(monkeypatch, tmp_path):
+    import app.agents.media_preprocessor as media_preprocessor
+
+    calls: list[dict] = []
+
+    def _run(*args, **kwargs):
+        calls.append(kwargs)
+        return subprocess.CompletedProcess(args[0], 0)
+
+    monkeypatch.setattr(media_preprocessor.subprocess, "run", _run)
+    monkeypatch.setattr(
+        media_preprocessor.os.path,
+        "getsize",
+        lambda _path: media_preprocessor._MAX_TRANSCRIPTION_BYTES + 1,
+    )
+    monkeypatch.setattr(media_preprocessor.glob, "glob", lambda _pattern: [])
+
+    media_preprocessor.is_ffmpeg_available()
+    media_preprocessor.extract_audio_track("/tmp/demo.mp4", str(tmp_path))
+    media_preprocessor.split_audio_chunks("/tmp/demo.mp3")
+    media_preprocessor.extract_keyframes("/tmp/demo.mp4", str(tmp_path))
+
+    assert len(calls) == 4
+    assert all(call.get("timeout") == media_preprocessor._FFMPEG_TIMEOUT_SEC for call in calls)
+
+
 def test_transcribe_audio_blob_uses_preprocessor_for_large_file(monkeypatch, tmp_path):
     from app.agents.transcription import transcribe_audio_blob
 


### PR DESCRIPTION
## Summary
- add bounded ffmpeg subprocess timeout across media preprocessing helpers
- apply timeout to all ffmpeg subprocess.run call sites in media_preprocessor
- treat ffmpeg availability probe timeout as unavailable and fail-safe
- add regression coverage that verifies timeout kwarg is present in all ffmpeg call paths

## Validation
- cd backend && .venv/bin/pytest ../tests/unit/test_media_preprocessor.py -x --tb=short
- cd backend && .venv/bin/pytest ../tests/unit/test_adapters.py -x --tb=short

## Scope
Implements Issue #84 item A5/H5 only.