### PR TITLE
fix: complete remaining Issue #84 critical/high fixes

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3509,3 +3509,58 @@ Completed Phase A checklist item **A5 · H5** on branch `codex/h5-ffmpeg-timeout
 ### Open Questions
 
 - None.
+
+---
+
+## Section 21: Issue #84 Remaining Set (A6/H1, A7/H6, A8/H7, A9/H13) (2026-04-30)
+
+Completed the remaining Phase A checklist items in one combined branch: `codex/issue-84-rest`.
+
+### Completed
+
+- **A6/H1 — Service Bus lock-renewal guard (`backend/app/workers/runner.py`)**
+  - Added `AutoLockRenewer` registration for each received message before phase processing.
+  - Added `PFCD_WORKER_LOCK_RENEWAL_SECONDS` (default `900`, bounded to `60..3600`).
+  - Worker runtime log now reports lock-renew duration.
+  - Added regression test in `tests/unit/test_worker.py`:
+    - `test_run_registers_autolock_renewer_for_each_message`
+
+- **A7/H6 — 429/5xx bounded retry for transcription and vision**
+  - `backend/app/agents/transcription.py`:
+    - Added bounded backoff retries (1/2/4s) for HTTP `429/5xx`.
+    - Added `TranscriptionQuotaError` when `429` persists after retries.
+    - Added shared post helper to reopen file handles per attempt safely.
+  - `backend/app/agents/vision.py`:
+    - Added bounded backoff retries (1/2/4s) for HTTP `429/5xx` on both OpenAI and Azure calls.
+    - Added `VisionQuotaError` when `429` persists after retries.
+    - Added explicit quota-limited warning path in `analyze_frames(...)`.
+  - Added tests:
+    - New file `tests/unit/test_transcription.py` (retry success, retry exhaustion, quota-distinct surfacing)
+    - Extended `tests/unit/test_vision.py` (retry success and quota exhaustion)
+
+- **A8/H7 — finalize/save race in frontend (`frontend/src/components/DraftReview.jsx`)**
+  - Added `inFlightSaveRef` promise chain to serialize saves.
+  - Added `persistDraft(...)` + `queueSave(...)` so save operations do not overlap.
+  - `handleFinalize()` now awaits any in-flight save before executing the final save+finalize sequence.
+  - Debounced save callback now feeds into the shared in-flight queue.
+
+- **A9/H13 — bootstrap vestigial vars (`infra/dev-bootstrap.sh`)**
+  - Removed undefined SQL-era variable usage under `set -u`.
+  - Replaced with PostgreSQL secret writes:
+    - `postgres-server-name`
+    - `postgres-db-name`
+
+### Validation
+
+- `cd backend && .venv/bin/pytest ../tests/unit/test_worker.py -x --tb=short` ✅ (27 passed)
+- `cd backend && .venv/bin/pytest ../tests/unit/test_vision.py -x --tb=short` ✅ (12 passed)
+- `cd backend && .venv/bin/pytest ../tests/unit/test_transcription.py -x --tb=short` ✅ (3 passed)
+- `cd frontend && npm run build` ✅
+
+### Decisions
+
+- Combined remaining Issue #84 checklist items into one delivery branch/PR per user direction, while preserving item-level test coverage and file-local scope.
+
+### Open Questions
+
+- None.

--- a/backend/app/agents/transcription.py
+++ b/backend/app/agents/transcription.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import time
 
 import httpx
 
@@ -25,10 +26,55 @@ logger = logging.getLogger(__name__)
 _DEFAULT_AZURE_OPENAI_API_VERSION = "2024-10-21"
 _MAX_TRANSCRIPTION_BYTES = 24 * 1024 * 1024
 _CHUNK_DURATION_SEC = 600
+_HTTP_RETRY_DELAYS_SEC = (1.0, 2.0, 4.0)
+_RETRYABLE_HTTP_STATUSES = {429, 500, 502, 503, 504}
+
+
+class TranscriptionQuotaError(RuntimeError):
+    """Quota/rate-limit error raised after bounded retries."""
 
 
 def _too_large_stub() -> str:
     return "[transcription_skipped:file_too_large — chunked transcription pending MediaPreprocessor]"
+
+
+def _post_transcription_with_retry(
+    url: str,
+    *,
+    headers: dict[str, str],
+    storage_key: str,
+    data: dict[str, str],
+) -> httpx.Response:
+    total_attempts = len(_HTTP_RETRY_DELAYS_SEC) + 1
+    for attempt in range(1, total_attempts + 1):
+        with open(storage_key, "rb") as fh:
+            files = {"file": (os.path.basename(storage_key), fh, "application/octet-stream")}
+            response = httpx.post(url, headers=headers, files=files, data=data, timeout=120.0)
+        status = response.status_code
+        if status not in _RETRYABLE_HTTP_STATUSES:
+            response.raise_for_status()
+            return response
+
+        if status == 429 and attempt >= total_attempts:
+            raise TranscriptionQuotaError(
+                f"Transcription quota/rate limit persisted after {attempt} attempts (HTTP 429)."
+            )
+
+        if attempt < total_attempts:
+            delay = _HTTP_RETRY_DELAYS_SEC[attempt - 1]
+            logger.warning(
+                "Transcription HTTP %d on attempt %d/%d; retrying in %.1fs",
+                status,
+                attempt,
+                total_attempts,
+                delay,
+            )
+            time.sleep(delay)
+            continue
+
+        response.raise_for_status()
+
+    raise RuntimeError("Unreachable transcription retry state")
 
 
 def _transcribe_with_azure(storage_key: str, *, deployment: str) -> str:
@@ -44,31 +90,27 @@ def _transcribe_with_azure(storage_key: str, *, deployment: str) -> str:
     credential = DefaultAzureCredential()
     token = credential.get_token("https://cognitiveservices.azure.com/.default")
     headers = {"Authorization": f"Bearer {token.token}"}
-
-    with open(storage_key, "rb") as fh:
-        files = {"file": (os.path.basename(storage_key), fh, "application/octet-stream")}
-        data = {"response_format": "vtt"}
-        response = httpx.post(url, headers=headers, files=files, data=data, timeout=120.0)
-        response.raise_for_status()
-        return response.text
+    data = {"response_format": "vtt"}
+    response = _post_transcription_with_retry(
+        url,
+        headers=headers,
+        storage_key=storage_key,
+        data=data,
+    )
+    return response.text
 
 
 def _transcribe_with_openai(storage_key: str, *, model: str) -> str:
     api_key = os.environ["OPENAI_API_KEY"]
     headers = {"Authorization": f"Bearer {api_key}"}
-
-    with open(storage_key, "rb") as fh:
-        files = {"file": (os.path.basename(storage_key), fh, "application/octet-stream")}
-        data = {"model": model, "response_format": "vtt"}
-        response = httpx.post(
-            "https://api.openai.com/v1/audio/transcriptions",
-            headers=headers,
-            files=files,
-            data=data,
-            timeout=120.0,
-        )
-        response.raise_for_status()
-        return response.text
+    data = {"model": model, "response_format": "vtt"}
+    response = _post_transcription_with_retry(
+        "https://api.openai.com/v1/audio/transcriptions",
+        headers=headers,
+        storage_key=storage_key,
+        data=data,
+    )
+    return response.text
 
 
 def _resolve_profile(profile: str | None) -> Profile:

--- a/backend/app/agents/vision.py
+++ b/backend/app/agents/vision.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import time
 from typing import Any
 
 import httpx
@@ -15,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 _MAX_FRAMES_PER_CALL = int(os.environ.get("PFCD_VISION_FRAMES_PER_CALL", "4"))
 _MAX_FRAMES_TOTAL = int(os.environ.get("PFCD_VISION_MAX_FRAMES", "40"))
+_HTTP_RETRY_DELAYS_SEC = (1.0, 2.0, 4.0)
+_RETRYABLE_HTTP_STATUSES = {429, 500, 502, 503, 504}
 
 _SYSTEM_PROMPT = """You are a process documentation assistant. For each video frame shown, describe:
 1. What the user is doing (actions, clicks, navigation)
@@ -23,6 +26,10 @@ _SYSTEM_PROMPT = """You are a process documentation assistant. For each video fr
 
 Be concise. Focus on process-relevant actions, not aesthetics.
 Output one paragraph per frame, prefixed with the frame timestamp."""
+
+
+class VisionQuotaError(RuntimeError):
+    """Quota/rate-limit error raised after bounded retries."""
 
 
 def _max_completion_tokens() -> int:
@@ -70,18 +77,39 @@ def _call_vision_openai(messages: list[dict], *, model: str | None = None) -> st
     """POST to OpenAI chat completions with vision content."""
     api_key = os.environ["OPENAI_API_KEY"]
     resolved_model = model or os.environ.get("OPENAI_VISION_MODEL", "gpt-4o-mini")
-    response = httpx.post(
-        "https://api.openai.com/v1/chat/completions",
-        headers={"Authorization": f"Bearer {api_key}"},
-        json={
-            "model": resolved_model,
-            "messages": messages,
-            "max_completion_tokens": _max_completion_tokens(),
-        },
-        timeout=60.0,
-    )
-    response.raise_for_status()
-    return response.json()["choices"][0]["message"]["content"]
+    total_attempts = len(_HTTP_RETRY_DELAYS_SEC) + 1
+    for attempt in range(1, total_attempts + 1):
+        response = httpx.post(
+            "https://api.openai.com/v1/chat/completions",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={
+                "model": resolved_model,
+                "messages": messages,
+                "max_completion_tokens": _max_completion_tokens(),
+            },
+            timeout=60.0,
+        )
+        status = response.status_code
+        if status not in _RETRYABLE_HTTP_STATUSES:
+            response.raise_for_status()
+            return response.json()["choices"][0]["message"]["content"]
+        if status == 429 and attempt >= total_attempts:
+            raise VisionQuotaError(
+                f"Vision quota/rate limit persisted after {attempt} attempts (HTTP 429)."
+            )
+        if attempt < total_attempts:
+            delay = _HTTP_RETRY_DELAYS_SEC[attempt - 1]
+            logger.warning(
+                "Vision OpenAI HTTP %d on attempt %d/%d; retrying in %.1fs",
+                status,
+                attempt,
+                total_attempts,
+                delay,
+            )
+            time.sleep(delay)
+            continue
+        response.raise_for_status()
+    raise RuntimeError("Unreachable vision retry state")
 
 
 def _call_vision_azure(messages: list[dict], *, deployment: str | None = None) -> str:
@@ -100,14 +128,35 @@ def _call_vision_azure(messages: list[dict], *, deployment: str | None = None) -
     )
     credential = DefaultAzureCredential()
     token = credential.get_token("https://cognitiveservices.azure.com/.default")
-    response = httpx.post(
-        url,
-        headers={"Authorization": f"Bearer {token.token}"},
-        json={"messages": messages, "max_completion_tokens": _max_completion_tokens()},
-        timeout=60.0,
-    )
-    response.raise_for_status()
-    return response.json()["choices"][0]["message"]["content"]
+    total_attempts = len(_HTTP_RETRY_DELAYS_SEC) + 1
+    for attempt in range(1, total_attempts + 1):
+        response = httpx.post(
+            url,
+            headers={"Authorization": f"Bearer {token.token}"},
+            json={"messages": messages, "max_completion_tokens": _max_completion_tokens()},
+            timeout=60.0,
+        )
+        status = response.status_code
+        if status not in _RETRYABLE_HTTP_STATUSES:
+            response.raise_for_status()
+            return response.json()["choices"][0]["message"]["content"]
+        if status == 429 and attempt >= total_attempts:
+            raise VisionQuotaError(
+                f"Vision quota/rate limit persisted after {attempt} attempts (HTTP 429)."
+            )
+        if attempt < total_attempts:
+            delay = _HTTP_RETRY_DELAYS_SEC[attempt - 1]
+            logger.warning(
+                "Vision Azure HTTP %d on attempt %d/%d; retrying in %.1fs",
+                status,
+                attempt,
+                total_attempts,
+                delay,
+            )
+            time.sleep(delay)
+            continue
+        response.raise_for_status()
+    raise RuntimeError("Unreachable vision retry state")
 
 
 def _resolve_profile(profile: str | None) -> Profile:
@@ -135,6 +184,9 @@ def analyze_frames(frames: list[tuple[str, float]], policy: dict, *, profile: st
                 responses.append(_call_vision_azure(messages, deployment=vision_model))
 
         return "\n\n".join(text for text in responses if text)
+    except VisionQuotaError as exc:
+        logger.warning("Frame analysis quota-limited: %s", exc)
+        return ""
     except Exception as exc:  # pragma: no cover - exercised by unit tests
         logger.warning("Frame analysis failed: %s", exc)
         return ""

--- a/backend/app/workers/runner.py
+++ b/backend/app/workers/runner.py
@@ -12,7 +12,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any, Dict
 from uuid import uuid4
 
-from azure.servicebus import ServiceBusMessage
+from azure.servicebus import AutoLockRenewer, ServiceBusMessage
 from azure.servicebus.exceptions import (
     MessageLockLostError,
     ServiceBusConnectionError as SBConnectionError,
@@ -55,6 +55,7 @@ PHASE_NEXT = {
 PHASE_ORDER = ["extracting", "processing", "reviewing"]
 
 MAX_MESSAGE_BODY_BYTES = 10 * 1024 * 1024  # 10 MB
+DEFAULT_LOCK_RENEWAL_SECONDS = 900
 
 _TERMINAL_STATUSES = {
     JobStatus.COMPLETED.value,
@@ -344,6 +345,13 @@ def _receive_wait_seconds() -> int:
     return 5
 
 
+def _message_lock_renewal_seconds() -> int:
+    value = os.environ.get("PFCD_WORKER_LOCK_RENEWAL_SECONDS", str(DEFAULT_LOCK_RENEWAL_SECONDS)).strip()
+    if value.isdigit():
+        return max(60, min(int(value), 3600))
+    return DEFAULT_LOCK_RENEWAL_SECONDS
+
+
 def _idle_backoff_seconds(consecutive_empty_receives: int) -> float:
     if consecutive_empty_receives <= 0:
         return 0.0
@@ -365,13 +373,15 @@ def run() -> None:
     _health_server = _maybe_start_health_server()
     phase = _resolve_phase()
     receive_wait_seconds = _receive_wait_seconds()
+    lock_renewal_seconds = _message_lock_renewal_seconds()
     logger.info(
-        "Worker runtime OpenAI config: role=%s endpoint=%s chat_deployment=%s api_version=%s receive_wait=%ss",
+        "Worker runtime OpenAI config: role=%s endpoint=%s chat_deployment=%s api_version=%s receive_wait=%ss lock_renew=%ss",
         phase,
         os.environ.get("AZURE_OPENAI_ENDPOINT"),
         os.environ.get("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"),
         os.environ.get("AZURE_OPENAI_API_VERSION"),
         receive_wait_seconds,
+        lock_renewal_seconds,
     )
     worker = Worker(phase)
     if not worker.orchestrator.enabled:
@@ -392,56 +402,65 @@ def run() -> None:
                 consecutive_connection_errors = 0
                 logger.info("Worker listening on phase %s", phase)
                 consecutive_empty_receives = 0
-                while True:
-                    try:
-                        messages = receiver.receive_messages(
-                            max_message_count=1,
-                            max_wait_time=receive_wait_seconds,
-                        )
-                    except SBConnectionError as exc:
-                        consecutive_connection_errors += 1
-                        delay = _connection_backoff_seconds(consecutive_connection_errors)
-                        logger.warning(
-                            "Service Bus receive error on phase %s (consecutive=%d); "
-                            "recreating receiver in %.1fs: %s",
-                            phase,
-                            consecutive_connection_errors,
-                            delay,
-                            exc,
-                        )
-                        time.sleep(delay)
-                        break
-                    if not messages:
-                        consecutive_empty_receives += 1
-                        delay = _idle_backoff_seconds(consecutive_empty_receives)
-                        if delay > 0:
-                            time.sleep(delay)
-                        continue
-                    consecutive_empty_receives = 0
-                    for message in messages:
+                with AutoLockRenewer() as lock_renewer:
+                    while True:
                         try:
-                            body = _read_message_body(message.body)
-                            worker.handle_message(message, body)
-                            try:
-                                receiver.complete_message(message)
-                            except MessageLockLostError:
-                                logger.warning(
-                                    "Message lock expired before complete; message will be retried by Service Bus"
+                                messages = receiver.receive_messages(
+                                    max_message_count=1,
+                                    max_wait_time=receive_wait_seconds,
                                 )
-                        except json.JSONDecodeError as exc:
-                            logger.error("Unparseable message body; dead-lettering: %s", exc)
+                        except SBConnectionError as exc:
+                            consecutive_connection_errors += 1
+                            delay = _connection_backoff_seconds(consecutive_connection_errors)
+                            logger.warning(
+                                "Service Bus receive error on phase %s (consecutive=%d); "
+                                "recreating receiver in %.1fs: %s",
+                                phase,
+                                consecutive_connection_errors,
+                                delay,
+                                exc,
+                            )
+                            time.sleep(delay)
+                            break
+                        if not messages:
+                            consecutive_empty_receives += 1
+                            delay = _idle_backoff_seconds(consecutive_empty_receives)
+                            if delay > 0:
+                                time.sleep(delay)
+                            continue
+                        consecutive_empty_receives = 0
+                        for message in messages:
                             try:
-                                receiver.dead_letter_message(message, reason="UnparseableBody")
-                            except MessageLockLostError:
-                                logger.warning("Message lock expired before dead-letter")
-                        except Exception as exc:
-                            logger.error("Unhandled error processing message; abandoning: %s", exc, exc_info=True)
-                            try:
-                                receiver.abandon_message(message)
-                            except MessageLockLostError:
-                                logger.warning(
-                                    "Message lock expired before abandon; Service Bus will retry"
+                                lock_renewer.register(
+                                    receiver,
+                                    message,
+                                    max_lock_renewal_duration=lock_renewal_seconds,
                                 )
+                            except Exception as exc:
+                                logger.warning("Failed to register lock renewer for message: %s", exc)
+                            try:
+                                body = _read_message_body(message.body)
+                                worker.handle_message(message, body)
+                                try:
+                                    receiver.complete_message(message)
+                                except MessageLockLostError:
+                                    logger.warning(
+                                        "Message lock expired before complete; message will be retried by Service Bus"
+                                    )
+                            except json.JSONDecodeError as exc:
+                                logger.error("Unparseable message body; dead-lettering: %s", exc)
+                                try:
+                                    receiver.dead_letter_message(message, reason="UnparseableBody")
+                                except MessageLockLostError:
+                                    logger.warning("Message lock expired before dead-letter")
+                            except Exception as exc:
+                                logger.error("Unhandled error processing message; abandoning: %s", exc, exc_info=True)
+                                try:
+                                    receiver.abandon_message(message)
+                                except MessageLockLostError:
+                                    logger.warning(
+                                        "Message lock expired before abandon; Service Bus will retry"
+                                    )
         except SBConnectionError as exc:
             consecutive_connection_errors += 1
             delay = _connection_backoff_seconds(consecutive_connection_errors)

--- a/frontend/src/components/DraftReview.jsx
+++ b/frontend/src/components/DraftReview.jsx
@@ -218,6 +218,7 @@ export default function DraftReview({ job, onFinalized }) {
   const [speakerResolutions, setSpeakerResolutions] = useState(() => job?.speaker_resolutions ?? {})
   const [saveState, setSaveState] = useState('idle')
   const saveTimer = useRef(null)
+  const inFlightSaveRef = useRef(Promise.resolve())
 
   useEffect(() => {
     setEditedDraft(job?.draft ?? {})
@@ -229,19 +230,30 @@ export default function DraftReview({ job, onFinalized }) {
 
   useEffect(() => () => clearTimeout(saveTimer.current), [])
 
+  async function persistDraft(nextDraft, nextResolutions) {
+    const result = await saveDraft(job.job_id, nextDraft, nextResolutions ?? speakerResolutions)
+    setEditedDraft(result.draft ?? nextDraft)
+    setLiveFlags(result.review_notes?.flags ?? [])
+    setSpeakerResolutions(result.speaker_resolutions ?? (nextResolutions ?? speakerResolutions))
+    setSaveState('saved')
+    return result
+  }
+
+  function queueSave(nextDraft, nextResolutions) {
+    const chained = inFlightSaveRef.current
+      .catch(() => {})
+      .then(() => persistDraft(nextDraft, nextResolutions))
+    inFlightSaveRef.current = chained
+    return chained
+  }
+
   function scheduleSave(nextDraft, nextResolutions) {
     clearTimeout(saveTimer.current)
     setSaveState('saving')
-    saveTimer.current = setTimeout(async () => {
-      try {
-        const result = await saveDraft(job.job_id, nextDraft, nextResolutions ?? speakerResolutions)
-        setEditedDraft(result.draft ?? nextDraft)
-        setLiveFlags(result.review_notes?.flags ?? [])
-        setSpeakerResolutions(result.speaker_resolutions ?? (nextResolutions ?? speakerResolutions))
-        setSaveState('saved')
-      } catch {
+    saveTimer.current = setTimeout(() => {
+      queueSave(nextDraft, nextResolutions).catch(() => {
         setSaveState('error')
-      }
+      })
     }, 1500)
   }
 
@@ -269,7 +281,9 @@ export default function DraftReview({ job, onFinalized }) {
     setError(null)
     setLoading(true)
     try {
-      const saved = await saveDraft(job.job_id, editedDraft, speakerResolutions)
+      await inFlightSaveRef.current.catch(() => {})
+      setSaveState('saving')
+      const saved = await queueSave(editedDraft, speakerResolutions)
       setEditedDraft(saved.draft ?? editedDraft)
       setLiveFlags(saved.review_notes?.flags ?? [])
       setSpeakerResolutions(saved.speaker_resolutions ?? speakerResolutions)

--- a/infra/dev-bootstrap.sh
+++ b/infra/dev-bootstrap.sh
@@ -190,8 +190,8 @@ ensure_key_vault() {
   az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "service-bus-queue-extracting" --value "$SERVICE_BUS_QUEUE_EXTRACTING" --output none
   az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "service-bus-queue-processing" --value "$SERVICE_BUS_QUEUE_PROCESSING" --output none
   az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "service-bus-queue-reviewing" --value "$SERVICE_BUS_QUEUE_REVIEWING" --output none
-  az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "sql-server-name" --value "$SQL_SERVER_NAME" --output none
-  az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "sql-db-name" --value "$SQL_DATABASE_NAME" --output none
+  az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "postgres-server-name" --value "$POSTGRES_SERVER_NAME" --output none
+  az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "postgres-db-name" --value "$POSTGRES_DATABASE_NAME" --output none
 
   local storage_conn
   storage_conn="$(az storage account show-connection-string --resource-group "$RESOURCE_GROUP" --name "$STORAGE_ACCOUNT" --query connectionString -o tsv)"

--- a/tests/unit/test_transcription.py
+++ b/tests/unit/test_transcription.py
@@ -1,0 +1,85 @@
+"""Unit tests for transcription HTTP retry and quota handling."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import httpx
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+BACKEND = ROOT / "backend"
+sys.path.insert(0, str(BACKEND))
+
+
+class _Resp:
+    def __init__(self, status_code: int, text: str = "") -> None:
+        self.status_code = status_code
+        self.text = text
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            request = httpx.Request("POST", "https://example.com")
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError("boom", request=request, response=response)
+
+
+def test_transcribe_with_openai_retries_429_and_5xx_then_succeeds(monkeypatch, tmp_path):
+    from app.agents import transcription
+
+    sample = tmp_path / "sample.wav"
+    sample.write_bytes(b"audio")
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    sleeps = []
+    monkeypatch.setattr(transcription.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    statuses = iter([429, 503, 200])
+
+    def _fake_post(*args, **kwargs):
+        status = next(statuses)
+        if status == 200:
+            return _Resp(200, "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nok\n")
+        return _Resp(status)
+
+    monkeypatch.setattr(transcription.httpx, "post", _fake_post)
+
+    result = transcription._transcribe_with_openai(str(sample), model="gpt-4o-mini")
+
+    assert result.startswith("WEBVTT")
+    assert sleeps == [1.0, 2.0]
+
+
+def test_transcribe_with_openai_raises_quota_after_bounded_retries(monkeypatch, tmp_path):
+    from app.agents import transcription
+
+    sample = tmp_path / "sample.wav"
+    sample.write_bytes(b"audio")
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    sleeps = []
+    monkeypatch.setattr(transcription.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(transcription.httpx, "post", lambda *args, **kwargs: _Resp(429))
+
+    with pytest.raises(transcription.TranscriptionQuotaError):
+        transcription._transcribe_with_openai(str(sample), model="gpt-4o-mini")
+
+    assert sleeps == [1.0, 2.0, 4.0]
+
+
+def test_transcribe_audio_blob_surfaces_quota_distinct_error(monkeypatch):
+    from app.agents import transcription
+
+    monkeypatch.setattr(transcription.os.path, "getsize", lambda _path: 1024)
+    monkeypatch.setattr(
+        transcription,
+        "_transcribe_single",
+        lambda _path, _profile=None: (_ for _ in ()).throw(
+            transcription.TranscriptionQuotaError("rate limited")
+        ),
+    )
+
+    result = transcription.transcribe_audio_blob("/tmp/audio.mp3")
+
+    assert result == "[transcription_failed:TranscriptionQuotaError]"

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -85,6 +85,8 @@ def test_call_vision_openai_uses_max_completion_tokens(monkeypatch):
     captured: dict = {}
 
     class _Resp:
+        status_code = 200
+
         def raise_for_status(self):
             return None
 
@@ -116,6 +118,8 @@ def test_call_vision_azure_uses_max_completion_tokens(monkeypatch):
     captured: dict = {}
 
     class _Resp:
+        status_code = 200
+
         def raise_for_status(self):
             return None
 
@@ -143,6 +147,71 @@ def test_call_vision_azure_uses_max_completion_tokens(monkeypatch):
     assert result == "ok"
     assert captured["json"]["max_completion_tokens"] == 444
     assert "max_tokens" not in captured["json"]
+
+
+def test_call_vision_openai_retries_then_succeeds(monkeypatch):
+    from app.agents import vision
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    sleeps = []
+    monkeypatch.setattr(vision.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    class _Resp:
+        def __init__(self, status_code: int):
+            self.status_code = status_code
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+                response = httpx.Response(self.status_code, request=request)
+                raise httpx.HTTPStatusError("boom", request=request, response=response)
+
+        def json(self):
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+    statuses = iter([429, 500, 200])
+    monkeypatch.setattr(vision.httpx, "post", lambda *args, **kwargs: _Resp(next(statuses)))
+
+    result = vision._call_vision_openai([{"role": "user", "content": "x"}], model="gpt-4o-mini")
+
+    assert result == "ok"
+    assert sleeps == [1.0, 2.0]
+
+
+def test_call_vision_azure_raises_quota_after_bounded_retries(monkeypatch):
+    from app.agents import vision
+
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-10-21")
+    monkeypatch.setenv("AZURE_OPENAI_VISION_DEPLOYMENT", "vision-deployment")
+    sleeps = []
+    monkeypatch.setattr(vision.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    class _Credential:
+        def get_token(self, _scope):
+            class _Token:
+                token = "fake-token"
+
+            return _Token()
+
+    class _Resp:
+        status_code = 429
+
+        def raise_for_status(self):
+            request = httpx.Request("POST", "https://example.openai.azure.com")
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError("boom", request=request, response=response)
+
+        def json(self):
+            return {"choices": [{"message": {"content": "ignored"}}]}
+
+    monkeypatch.setattr("azure.identity.DefaultAzureCredential", lambda: _Credential())
+    monkeypatch.setattr(vision.httpx, "post", lambda *args, **kwargs: _Resp())
+
+    with pytest.raises(vision.VisionQuotaError):
+        vision._call_vision_azure([{"role": "user", "content": "x"}], deployment="vision-deployment")
+
+    assert sleeps == [1.0, 2.0, 4.0]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -427,6 +427,18 @@ def test_run_uses_configured_receive_wait_and_idle_backoff(monkeypatch):
     monkeypatch.setattr(runner_mod.logging, "basicConfig", lambda **_: None)
     monkeypatch.setattr(runner_mod, "_maybe_start_health_server", lambda: None)
 
+    class _NoopRenewer:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def register(self, *_args, **_kwargs):
+            return None
+
+    monkeypatch.setattr(runner_mod, "AutoLockRenewer", lambda: _NoopRenewer())
+
     sleeps = []
     monkeypatch.setattr(runner_mod.time, "sleep", lambda seconds: sleeps.append(seconds))
 
@@ -538,6 +550,79 @@ def test_run_continues_when_complete_loses_message_lock(monkeypatch):
 
     assert fake_worker.handled == 1
     assert fake_orchestrator.receiver.completed == 1
+
+
+def test_run_registers_autolock_renewer_for_each_message(monkeypatch):
+    from app.workers import runner as runner_mod
+
+    monkeypatch.setenv("PFCD_WORKER_ROLE", "processing")
+    monkeypatch.setenv("PFCD_WORKER_LOCK_RENEWAL_SECONDS", "321")
+    monkeypatch.setattr(runner_mod.logging, "basicConfig", lambda **_: None)
+    monkeypatch.setattr(runner_mod, "_maybe_start_health_server", lambda: None)
+
+    registered = []
+
+    class _FakeRenewer:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def register(self, receiver, message, max_lock_renewal_duration):
+            registered.append((receiver, message, max_lock_renewal_duration))
+
+    monkeypatch.setattr(runner_mod, "AutoLockRenewer", lambda: _FakeRenewer())
+
+    class _FakeMessage:
+        body = [b"{}"]
+
+    class _FakeReceiver:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def receive_messages(self, **_: Any):
+            self.calls += 1
+            if self.calls == 1:
+                return [_FakeMessage()]
+            raise KeyboardInterrupt()
+
+        def complete_message(self, _message: Any) -> None:
+            return None
+
+        def dead_letter_message(self, _message: Any, **__: Any) -> None:
+            raise AssertionError("No message should be dead-lettered in this test")
+
+        def abandon_message(self, _message: Any) -> None:
+            raise AssertionError("No message should be abandoned in this test")
+
+    class _FakeOrchestrator:
+        def __init__(self) -> None:
+            self.enabled = True
+            self.receiver = _FakeReceiver()
+
+        @contextmanager
+        def receive(self, _phase: str, max_wait_time: int = 5):
+            del max_wait_time
+            yield self.receiver
+
+    fake_orchestrator = _FakeOrchestrator()
+
+    class _FakeWorker:
+        def __init__(self, _phase: str) -> None:
+            self.orchestrator = fake_orchestrator
+
+        def handle_message(self, _message: Any, _body: Any) -> None:
+            return None
+
+    monkeypatch.setattr(runner_mod, "Worker", _FakeWorker)
+
+    with pytest.raises(KeyboardInterrupt):
+        runner_mod.run()
+
+    assert len(registered) == 1
+    assert registered[0][0] is fake_orchestrator.receiver
+    assert registered[0][2] == 321
 
 
 def test_connection_backoff_seconds_is_bounded(monkeypatch):


### PR DESCRIPTION
## Summary
This PR bundles the remaining Issue #84 checklist items in one shot:

1) A6 / H1
- add AutoLockRenewer registration in worker run loop to prevent message lock loss during long SK calls
- add PFCD_WORKER_LOCK_RENEWAL_SECONDS (bounded 60..3600, default 900)
- add worker test coverage for renewer registration

2) A7 / H6
- add bounded exponential backoff retry (1/2/4s) for transcription and vision HTTP calls on 429/5xx
- add quota-distinct exceptions:
  - TranscriptionQuotaError
  - VisionQuotaError
- add focused unit tests for retry success and bounded retry exhaustion

3) A8 / H7
- fix DraftReview save/finalize race by serializing save operations with an in-flight promise chain
- finalize now awaits pending saves before issuing save+finalize sequence

4) A9 / H13
- remove undefined SQL-era variables in infra bootstrap script under set -u path
- replace with postgres-server-name and postgres-db-name key vault entries

Also updates IMPLEMENTATION_SUMMARY.md Section 21.

## Validation
- cd backend && .venv/bin/pytest ../tests/unit/test_worker.py -x --tb=short
- cd backend && .venv/bin/pytest ../tests/unit/test_vision.py -x --tb=short
- cd backend && .venv/bin/pytest ../tests/unit/test_transcription.py -x --tb=short
- cd frontend && npm run build

## Scope
Implements remaining Issue #84 items: A6/H1, A7/H6, A8/H7, A9/H13 in a single PR per request.