### PR TITLE
fix(phase-c): stability hardening — C1-C8 (lazy engine, atomic writes, frame caps, SIGTERM, retry counter)

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -11,6 +11,9 @@ from sqlalchemy.orm import Session, sessionmaker
 
 DEFAULT_DATABASE_URL = "sqlite:///./pfcd.db"
 
+_engine_cache: dict[str, object] = {}
+_factory_cache: dict[str, object] = {}
+
 
 def _build_engine(database_url: str):
     if database_url.startswith("sqlite"):
@@ -26,13 +29,37 @@ def get_database_url() -> str:
     return os.environ.get("DATABASE_URL", DEFAULT_DATABASE_URL)
 
 
-ENGINE = _build_engine(get_database_url())
-SessionLocal = sessionmaker(bind=ENGINE, autoflush=False, autocommit=False, future=True)
+def get_engine(database_url: str | None = None):
+    """Return a cached SQLAlchemy engine for *database_url* (or env URL)."""
+    url = database_url or get_database_url()
+    if url not in _engine_cache:
+        _engine_cache[url] = _build_engine(url)
+    return _engine_cache[url]
+
+
+def _get_session_factory(database_url: str | None = None):
+    url = database_url or get_database_url()
+    if url not in _factory_cache:
+        _factory_cache[url] = sessionmaker(
+            bind=get_engine(url), autoflush=False, autocommit=False, future=True
+        )
+    return _factory_cache[url]
+
+
+def clear_engine_cache() -> None:
+    """Dispose all cached engines and clear caches (test isolation helper)."""
+    for engine in _engine_cache.values():
+        try:
+            engine.dispose()
+        except Exception:
+            pass
+    _engine_cache.clear()
+    _factory_cache.clear()
 
 
 @contextmanager
-def session_scope() -> Iterator[Session]:
-    session = SessionLocal()
+def session_scope(database_url: str | None = None) -> Iterator[Session]:
+    session = _get_session_factory(database_url)()
     try:
         yield session
         session.commit()

--- a/backend/app/export_builder.py
+++ b/backend/app/export_builder.py
@@ -590,22 +590,28 @@ def build_export_pdf(
         pdf.ln(2)
         _row(f"Note: {note}")
 
+    _MAX_FRAMES = 10
+    _MAX_FRAME_BYTES = 5 * 1024 * 1024  # 5 MB per frame
+
     frame_captures = evidence_bundle.get("frame_captures") or []
     if frame_captures:
         pdf.ln(3)
         _heading("Frame Captures", bold=True)
-        for capture in frame_captures:
+        for capture in frame_captures[:_MAX_FRAMES]:
             key = capture.get("storage_key", "")
             timestamp_sec = capture.get("timestamp_sec", 0.0)
             image_bytes = (frame_bytes_map or {}).get(key)
             if image_bytes:
-                try:
-                    pdf.image(io.BytesIO(image_bytes), w=120)
-                    pdf.set_font("Helvetica", size=8)
-                    pdf.cell(0, 5, f"Frame @ {timestamp_sec:.1f}s — {key}", new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-                    pdf.set_font("Helvetica", size=11)
-                except Exception:
-                    _row(f"Frame @ {timestamp_sec:.1f}s (image unreadable): {key}")
+                if len(image_bytes) > _MAX_FRAME_BYTES:
+                    _row(f"Frame @ {timestamp_sec:.1f}s (skipped — image too large): {key}")
+                else:
+                    try:
+                        pdf.image(io.BytesIO(image_bytes), w=120)
+                        pdf.set_font("Helvetica", size=8)
+                        pdf.cell(0, 5, f"Frame @ {timestamp_sec:.1f}s — {key}", new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+                        pdf.set_font("Helvetica", size=11)
+                    except Exception:
+                        _row(f"Frame @ {timestamp_sec:.1f}s (image unreadable): {key}")
             else:
                 pdf.set_font("Helvetica", size=8)
                 pdf.cell(
@@ -887,19 +893,25 @@ def build_export_docx(
     else:
         doc.add_paragraph("No linked evidence anchors found.")
 
+    _MAX_FRAMES = 10
+    _MAX_FRAME_BYTES = 5 * 1024 * 1024  # 5 MB per frame
+
     frame_captures = evidence_bundle.get("frame_captures") or []
     if frame_captures:
         doc.add_heading("Frame Captures", level=1)
-        for capture in frame_captures:
+        for capture in frame_captures[:_MAX_FRAMES]:
             key = capture.get("storage_key", "")
             timestamp_sec = capture.get("timestamp_sec", 0.0)
             image_bytes = (frame_bytes_map or {}).get(key)
             if image_bytes:
-                try:
-                    doc.add_picture(io.BytesIO(image_bytes))
-                    doc.add_paragraph(f"Frame @ {timestamp_sec:.1f}s — {key}")
-                except Exception:
-                    doc.add_paragraph(f"Frame @ {timestamp_sec:.1f}s (image unreadable): {key}")
+                if len(image_bytes) > _MAX_FRAME_BYTES:
+                    doc.add_paragraph(f"Frame @ {timestamp_sec:.1f}s (skipped — image too large): {key}")
+                else:
+                    try:
+                        doc.add_picture(io.BytesIO(image_bytes))
+                        doc.add_paragraph(f"Frame @ {timestamp_sec:.1f}s — {key}")
+                    except Exception:
+                        doc.add_paragraph(f"Frame @ {timestamp_sec:.1f}s (image unreadable): {key}")
             else:
                 doc.add_paragraph(f"Frame @ {timestamp_sec:.1f}s: {key} (not available)")
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -55,6 +55,9 @@ ORCHESTRATOR = ServiceBusOrchestrator()
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
+    # Validate CORS config at startup so bad env vars produce a clear logged error
+    # rather than an opaque RuntimeError buried in the import chain.
+    _cors_origins()
     await anyio.to_thread.run_sync(JOB_REPO.init_db)
     logger.info("Database initialised")
     try:
@@ -87,6 +90,20 @@ def _cors_origins() -> list[str]:
     return validated
 
 
+def _cors_origins_safe() -> list[str]:
+    """Parse CORS origins without raising; invalid entries are skipped.
+
+    Used at module load time so a misconfigured env var does not prevent
+    the application from being imported.  The strict version ``_cors_origins()``
+    is called inside ``_lifespan`` where a failure produces a clear startup error.
+    """
+    try:
+        return _cors_origins()
+    except RuntimeError as exc:
+        logger.error("PFCD_CORS_ORIGINS misconfigured: %s — using empty allow-list", exc)
+        return []
+
+
 def _resolve_upload_path(upload_id: str, file_name: str | None) -> str:
     file_part = file_name or "upload"
     return os.path.join(UPLOADS_DIR, upload_id, file_part)
@@ -110,8 +127,14 @@ def _parse_iso8601(value: str | None) -> datetime | None:
 
 def _save_upload_manifest(upload_id: str, payload: Dict[str, Any]) -> None:
     os.makedirs(UPLOAD_META_DIR, exist_ok=True)
-    with open(_upload_manifest_path(upload_id), "w", encoding="utf-8") as handle:
-        json.dump(payload, handle, ensure_ascii=True, separators=(",", ":"))
+    dest = _upload_manifest_path(upload_id)
+    # Write to a temp file then atomically rename so a crash mid-write never
+    # leaves a truncated JSON file that blocks subsequent upload-url resolution.
+    dir_ = os.path.dirname(dest)
+    with tempfile.NamedTemporaryFile("w", dir=dir_, suffix=".tmp", delete=False, encoding="utf-8") as tmp:
+        json.dump(payload, tmp, ensure_ascii=True, separators=(",", ":"))
+        tmp_path = tmp.name
+    os.replace(tmp_path, dest)
 
 
 def _load_upload_manifest(upload_id: str) -> Dict[str, Any] | None:
@@ -272,7 +295,7 @@ def _resolve_input_files(payload: JobCreateRequest) -> JobCreateRequest:
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=_cors_origins(),
+    allow_origins=_cors_origins_safe(),
     allow_methods=["GET", "POST", "PUT", "DELETE"],
     allow_headers=["*"],
 )
@@ -552,19 +575,37 @@ async def upload_content_via_api(upload_id: str, request: Request) -> Dict[str, 
 @api_router.post("/upload", status_code=201)
 async def upload_file(file: UploadFile = File(...)) -> Dict[str, Any]:
     upload_id = str(uuid4())
-    content = await file.read()
-    size_bytes = len(content)
-    if size_bytes > MAX_UPLOAD_BYTES:
-        raise HTTPException(status_code=413, detail=f"File exceeds 500MB limit.")
-
     safe_name = _safe_upload_name(file.filename)
     dest_dir = os.path.join(UPLOADS_DIR, upload_id)
     await anyio.to_thread.run_sync(lambda: os.makedirs(dest_dir, exist_ok=True))
     dest_path = os.path.join(dest_dir, safe_name)
-    def _write():
+
+    # Stream from the SpooledTemporaryFile to disk in chunks so we never
+    # allocate the entire upload body as a single Python bytes object.
+    def _stream_to_disk() -> int:
+        written = 0
         with open(dest_path, "wb") as fh:
-            fh.write(content)
-    await anyio.to_thread.run_sync(_write)
+            while True:
+                chunk = file.file.read(65536)
+                if not chunk:
+                    break
+                written += len(chunk)
+                if written > MAX_UPLOAD_BYTES:
+                    fh.close()
+                    try:
+                        os.remove(dest_path)
+                    except OSError:
+                        pass
+                    raise HTTPException(status_code=413, detail="File exceeds 500MB limit.")
+                fh.write(chunk)
+        return written
+
+    try:
+        size_bytes = await anyio.to_thread.run_sync(_stream_to_disk)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Upload write failed: {exc}") from exc
 
     source_type = MIME_TO_SOURCE_TYPE.get(file.content_type or "", "document")
     _save_upload_manifest(
@@ -738,7 +779,10 @@ async def update_draft(job_id: str, payload: DraftUpdateRequest) -> Dict[str, An
     job["user_saved_at"] = job["updated_at"]
     job["draft"]["user_reconciled_at"] = _utc_now()
     job["draft"]["version"] = current_draft_version + 1
-    await _repo_upsert_job(job_id, job)
+    try:
+        await _repo_upsert_job(job_id, job)
+    except ConcurrentModificationError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     # Re-run the pure-Python reviewing gate so flags reflect the edited draft.
     from app.agents.reviewing import run_reviewing
 
@@ -761,7 +805,10 @@ async def update_draft(job_id: str, payload: DraftUpdateRequest) -> Dict[str, An
         and not str(flag.get("code", "")).startswith("sipoc_")
     ]
     run_reviewing(job, {})
-    await _repo_upsert_job(job_id, job)
+    try:
+        await _repo_upsert_job(job_id, job)
+    except ConcurrentModificationError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     await anyio.to_thread.run_sync(
         JOB_REPO.append_job_event,
         job_id,

--- a/backend/app/repository.py
+++ b/backend/app/repository.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 from sqlalchemy import delete, select
 from sqlalchemy.orm.exc import StaleDataError
 
-from app.db import ENGINE, session_scope
+from app.db import get_engine, session_scope
 from app.job_logic import JobStatus, _utc_now
 from app.models import AgentRun, Draft, ExportPayload, InputManifest, Job, JobEvent, ReviewNotes
 
@@ -42,12 +42,21 @@ class ConcurrentModificationError(RuntimeError):
 
 
 class JobRepository:
-    def __init__(self) -> None:
-        self.engine = ENGINE
+    def __init__(self, database_url: str | None = None) -> None:
+        self._database_url = database_url
+
+    @property
+    def engine(self):
+        return get_engine(self._database_url)
 
     @classmethod
     def from_env(cls) -> "JobRepository":
         return cls()
+
+    @classmethod
+    def from_url(cls, database_url: str) -> "JobRepository":
+        """Create a repository bound to a specific database URL (for test isolation)."""
+        return cls(database_url=database_url)
 
     def init_db(self) -> None:
         from app.models import Base
@@ -162,7 +171,7 @@ class JobRepository:
         }
 
     def get_job(self, job_id: str) -> Optional[Dict[str, Any]]:
-        with session_scope() as session:
+        with session_scope(self._database_url) as session:
             job = session.get(Job, job_id)
             if not job:
                 return None
@@ -179,7 +188,7 @@ class JobRepository:
 
     def list_jobs(self, limit: int = 50) -> list[dict]:
         """Return lightweight job summaries, most recent first, excluding deleted."""
-        with session_scope() as session:
+        with session_scope(self._database_url) as session:
             rows = session.execute(
                 select(Job)
                 .where(Job.deleted_at.is_(None))
@@ -205,7 +214,7 @@ class JobRepository:
         logger.debug("Upserting job %s status=%s", job_id, payload.get("status"))
         persisted_version: int | None = None
         try:
-            with session_scope() as session:
+            with session_scope(self._database_url) as session:
                 job = session.get(Job, job_id)
                 if not job:
                     job = Job(job_id=job_id, version=int(payload.get("version") or 1))
@@ -342,7 +351,7 @@ class JobRepository:
             payload["version"] = persisted_version
 
     def append_job_event(self, job_id: str, event_type: str, payload: Dict[str, Any]) -> None:
-        with session_scope() as session:
+        with session_scope(self._database_url) as session:
             session.add(
                 JobEvent(
                     event_id=str(uuid4()),
@@ -361,7 +370,7 @@ class JobRepository:
             JobStatus.COMPLETED.value,
             JobStatus.FAILED.value,
         }
-        with session_scope() as session:
+        with session_scope(self._database_url) as session:
             rows = session.execute(
                 select(Job.job_id).where(
                     Job.ttl_expires_at != None,  # noqa: E711
@@ -373,7 +382,7 @@ class JobRepository:
 
     def find_cleanup_pending_jobs(self) -> list[str]:
         """Return job_ids where cleanup_pending=True."""
-        with session_scope() as session:
+        with session_scope(self._database_url) as session:
             rows = session.execute(
                 select(Job.job_id).where(Job.cleanup_pending == True)  # noqa: E712
             ).fetchall()
@@ -385,7 +394,7 @@ class JobRepository:
         Used by the cleanup sweeper to recover jobs whose enqueue call was lost
         after the phase completed but before the Service Bus send succeeded.
         """
-        with session_scope() as session:
+        with session_scope(self._database_url) as session:
             rows = session.execute(
                 select(Job.job_id).where(
                     Job.pending_next_phase != None,  # noqa: E711
@@ -396,7 +405,7 @@ class JobRepository:
 
     def purge_job_data(self, job_id: str) -> None:
         """Delete all related rows for a job; set cleanup_pending=False on the Job row."""
-        with session_scope() as session:
+        with session_scope(self._database_url) as session:
             for model in (InputManifest, ReviewNotes, Draft, AgentRun, ExportPayload, JobEvent):
                 session.execute(delete(model).where(model.job_id == job_id))
             job = session.get(Job, job_id)

--- a/backend/app/workers/cleanup.py
+++ b/backend/app/workers/cleanup.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 import os
+import signal
+import threading
 import time
 from datetime import datetime, timedelta, timezone
 
@@ -16,6 +18,9 @@ logger = logging.getLogger(__name__)
 
 POLL_INTERVAL_SECONDS = int(os.environ.get("PFCD_CLEANUP_INTERVAL_SECONDS", "300"))
 STALE_PHASE_WINDOW_SECONDS = int(os.environ.get("PFCD_STALE_PHASE_WINDOW_SECONDS", "120"))
+MAX_PURGE_ATTEMPTS = int(os.environ.get("PFCD_MAX_PURGE_ATTEMPTS", "5"))
+
+_shutdown_event = threading.Event()
 
 
 def _utc_now() -> str:
@@ -83,14 +88,34 @@ class CleanupWorker:
                 self.repo.append_job_event(job_id, "cleanup_failed", {"phase": "expire", "message": str(exc)})
 
     def purge_pending_jobs(self) -> None:
-        """Phase B: delete export files and purge DB rows for cleanup_pending jobs."""
+        """Phase B: delete export files and purge DB rows for cleanup_pending jobs.
+
+        Tracks purge_attempt_count so jobs that repeatedly fail don't block indefinitely.
+        After MAX_PURGE_ATTEMPTS the job is logged as a GDPR retention warning and left
+        with cleanup_pending=True for manual remediation.
+        """
         job_ids = self.repo.find_cleanup_pending_jobs()
         for job_id in job_ids:
             try:
+                job = self.repo.get_job(job_id)
+                if not job:
+                    continue
+                attempt = int(job.get("purge_attempt_count") or 0) + 1
+                if attempt > MAX_PURGE_ATTEMPTS:
+                    logger.error(
+                        "GDPR retention warning: job %s exceeded %d purge attempts; "
+                        "manual intervention required",
+                        job_id,
+                        MAX_PURGE_ATTEMPTS,
+                    )
+                    continue
+                job["purge_attempt_count"] = attempt
+                job["updated_at"] = _utc_now()
+                self.repo.upsert_job(job_id, job)
                 self.storage.delete_job_exports(job_id)
                 self.repo.purge_job_data(job_id)
                 self.repo.append_job_event(job_id, "cleanup_completed", {"at": _utc_now()})
-                logger.info("Purged data for job %s", job_id)
+                logger.info("Purged data for job %s (attempt %d)", job_id, attempt)
             except Exception as exc:
                 logger.error("Failed to purge job %s: %s", job_id, exc, exc_info=True)
                 # Keep cleanup_pending=True so the next cleanup pass can retry the purge.
@@ -107,14 +132,23 @@ def run() -> None:
     storage = ExportStorage.from_env()
     orchestrator = ServiceBusOrchestrator()
     worker = CleanupWorker(repo=repo, storage=storage, orchestrator=orchestrator)
+
+    def _handle_sigterm(signum: int, frame: object) -> None:
+        logger.info("SIGTERM received; cleanup worker shutting down after current pass")
+        _shutdown_event.set()
+
+    signal.signal(signal.SIGTERM, _handle_sigterm)
+
     logger.info("Cleanup worker starting (interval=%ds)", POLL_INTERVAL_SECONDS)
-    while True:
+    while not _shutdown_event.is_set():
         logger.info("Cleanup pass starting")
         worker.reenqueue_stale_phases()
         worker.expire_ttl_jobs()
         worker.purge_pending_jobs()
         logger.info("Cleanup pass complete; sleeping %ds", POLL_INTERVAL_SECONDS)
-        time.sleep(POLL_INTERVAL_SECONDS)
+        _shutdown_event.wait(POLL_INTERVAL_SECONDS)
+
+    logger.info("Cleanup worker stopped")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -133,7 +133,7 @@ def test_upsert_converts_staledataerror_to_concurrent_modification(monkeypatch):
     _, repo = _reload_modules()
 
     @contextmanager
-    def _stale_session_scope():
+    def _stale_session_scope(database_url=None):
         raise repo.StaleDataError("simulated stale row update")
         yield
 


### PR DESCRIPTION
## Phase C — Stability Hardening (Issue #86)

All 8 items implemented. **385 tests passed, 2 skipped.**

### Changes

| Item | Code | Description |
|------|------|-------------|
| C1 | H8 | Lazy SQLAlchemy engine — `get_engine(url)` per-URL cache, `session_scope(database_url)` param, `clear_engine_cache()` helper; `JobRepository.from_url()` for test isolation |
| C2 | M1 | Atomic manifest write — `NamedTemporaryFile` + `os.replace` prevents truncated JSON on crash |
| C3 | M2 | Streaming upload — 64 KB chunk reads in `anyio.to_thread.run_sync`; avoids large bytes allocation |
| C4 | M3 | CORS validation in lifespan — `_cors_origins_safe()` at module level (no import crash); `_cors_origins()` called in `_lifespan` for strict startup error |
| C5 | M4 | Concurrent draft update returns 409 — both `upsert_job` calls in `update_draft` catch `ConcurrentModificationError` → `HTTPException(409)` |
| C6 | M8 | Frame size caps — 5 MB per-frame limit + 10-frame total cap in PDF/DOCX export; prevents worker OOM |
| C7 | M9 | Purge retry counter — `purge_attempt_count` tracked; GDPR retention warning logged after `MAX_PURGE_ATTEMPTS` (default 5) |
| C8 | M10 | SIGTERM graceful shutdown — `threading.Event.wait()` replaces `time.sleep()`; SIGTERM handler sets event to break poll loop cleanly |

### Files changed
- `backend/app/db.py` — lazy engine cache
- `backend/app/repository.py` — URL-bound repo, from_url()
- `backend/app/main.py` — CORS safe init, streaming upload, 409 on concurrent draft
- `backend/app/export_builder.py` — frame caps
- `backend/app/workers/cleanup.py` — retry counter + SIGTERM handler
- `tests/unit/test_repository.py` — mock signature fix for new `database_url` param

Closes #86