### PR TITLE
feat: Phase D — opus review hygiene items (M5–M17, L1–L10)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -19,42 +19,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_DB: pfcd_test
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d pfcd_test"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies
-        run: pip install -r backend/requirements.txt
-
-      - name: Run tests
-        run: pytest tests/unit tests/integration -x --tb=short
-        env:
-          DATABASE_URL: "sqlite:///./test-ci.db"
-          PYTHONPATH: backend
-
-      - name: Run PostgreSQL smoke test
-        run: pytest tests/integration/test_postgres_smoke.py -x --tb=short
-        env:
-          PFCD_POSTGRES_SMOKE_DATABASE_URL: "postgresql+psycopg://postgres:postgres@127.0.0.1:5432/pfcd_test"
-          PYTHONPATH: backend
+    uses: ./.github/workflows/pg-smoke.yml
 
   deploy:
     needs: test
@@ -173,7 +138,6 @@ jobs:
       - name: Render backend ACA manifest
         env:
           PFCD_CORS_ORIGINS_VALUE: ${{ secrets.PFCD_CORS_ORIGINS }}
-          PFCD_API_KEY_VALUE: ${{ secrets.PFCD_API_KEY }}
           AZURE_OPENAI_ENDPOINT_VALUE: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
         run: |
           env_id="$(az containerapp env show \
@@ -215,6 +179,9 @@ jobs:
                 - name: sbconn
                   keyVaultUrl: https://${{ vars.AZURE_KEY_VAULT_NAME }}.vault.azure.net/secrets/service-bus-connection-string
                   identity: system
+                - name: pfcd-api-key
+                  keyVaultUrl: https://${{ vars.AZURE_KEY_VAULT_NAME }}.vault.azure.net/secrets/pfcd-api-key
+                  identity: system
             template:
               containers:
                 - name: api
@@ -223,7 +190,7 @@ jobs:
                     - name: PFCD_CORS_ORIGINS
                       value: "${PFCD_CORS_ORIGINS_VALUE}"
                     - name: PFCD_API_KEY
-                      value: "${PFCD_API_KEY_VALUE}"
+                      secretRef: pfcd-api-key
                     - name: DATABASE_URL
                       secretRef: dburl
                     - name: AZURE_STORAGE_CONNECTION_STRING

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -24,42 +24,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_DB: pfcd_test
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d pfcd_test"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies
-        run: pip install -r backend/requirements.txt
-
-      - name: Run tests
-        run: pytest tests/unit tests/integration -x --tb=short
-        env:
-          DATABASE_URL: "sqlite:///./test-ci.db"
-          PYTHONPATH: backend
-
-      - name: Run PostgreSQL smoke test
-        run: pytest tests/integration/test_postgres_smoke.py -x --tb=short
-        env:
-          PFCD_POSTGRES_SMOKE_DATABASE_URL: "postgresql+psycopg://postgres:postgres@127.0.0.1:5432/pfcd_test"
-          PYTHONPATH: backend
+    uses: ./.github/workflows/pg-smoke.yml
 
   build:
     needs: test

--- a/.github/workflows/pg-smoke.yml
+++ b/.github/workflows/pg-smoke.yml
@@ -1,0 +1,43 @@
+name: Python Tests + PostgreSQL Smoke
+
+on:
+  workflow_call: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: pfcd_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d pfcd_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r backend/requirements.txt
+
+      - name: Run unit and integration tests
+        run: pytest tests/unit tests/integration -x --tb=short
+        env:
+          DATABASE_URL: "sqlite:///./test-ci.db"
+          PYTHONPATH: backend
+
+      - name: Run PostgreSQL smoke test
+        run: pytest tests/integration/test_postgres_smoke.py -x --tb=short
+        env:
+          PFCD_POSTGRES_SMOKE_DATABASE_URL: "postgresql+psycopg://postgres:postgres@127.0.0.1:5432/pfcd_test"
+          PYTHONPATH: backend

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3601,3 +3601,39 @@ Completed the remaining Phase A checklist items in one combined branch: `codex/i
 ### B8·H15 — RFC 4122 v4 UUID polyfill
 - `frontend/src/api.js`: replaced `upload-${Date.now()}-${Math.random().toString(16).slice(2)}` fallback with RFC 4122 v4 bit-manipulation polyfill.
 - `streamlit_app/api_client.py`: replaced `f"upload-{os.urandom(8).hex()}"` with `str(uuid.uuid4())`.
+
+---
+
+## Section 23 — Phase C: Stability & Infrastructure Hardening (2026-04-20)
+
+**Branch:** `codex/issue-86-phase-c` → PR #95 → merged to main  
+**Tests:** 385 passed, 2 skipped  
+**Issue:** #86
+
+### C1·H8 — Lazy SQLAlchemy engine
+- `backend/app/db.py`: complete rewrite — `get_engine(url)` per-URL cache, `_get_session_factory(url)` factory cache, `session_scope(database_url=None)` parameter, `clear_engine_cache()` test isolation helper. Removed module-level `ENGINE`/`SessionLocal` globals.
+- `backend/app/repository.py`: removed `ENGINE` import; added `_database_url` instance var, `from_url(database_url)` classmethod, `engine` property. All 8 `session_scope()` calls updated to `session_scope(self._database_url)`.
+
+### C2·M1 — Atomic manifest write
+- `backend/app/main.py`: `_save_upload_manifest` now writes to a `tempfile.NamedTemporaryFile` in the same directory as the destination, then calls `os.replace` to atomically rename. Crash mid-write no longer leaves truncated JSON.
+
+### C3·M2 — Streaming upload
+- `backend/app/main.py`: `upload_file` endpoint reads the `SpooledTemporaryFile` in 64 KB chunks inside `anyio.to_thread.run_sync`. Avoids a single large `bytes` allocation for large uploads.
+
+### C4·M3 — CORS validation deferred to lifespan
+- `backend/app/main.py`: added `_cors_origins_safe()` — parses CORS origins without raising; invalid entries are logged and skipped (used at module level for `add_middleware` registration). Added `_cors_origins()` call in `_lifespan` for strict validation at startup — bad config now fails with a clear logged error rather than an opaque import-time `RuntimeError`.
+
+### C5·M4 — Concurrent draft update returns 409
+- `backend/app/main.py`: both `_repo_upsert_job` calls in `update_draft` now catch `ConcurrentModificationError` and raise `HTTPException(409)`. Previously a concurrent edit+finalize race would return a 500.
+
+### C6·M8 — Frame size caps in PDF/DOCX export
+- `backend/app/export_builder.py`: both `build_export_pdf` and `build_export_docx` now cap frame rendering to `_MAX_FRAMES = 10` and skip individual frames exceeding `_MAX_FRAME_BYTES = 5 MB`. Oversized frames render a placeholder text row instead.
+
+### C7·M9 — Purge retry counter
+- `backend/app/workers/cleanup.py`: `purge_pending_jobs` now reads/increments `purge_attempt_count` on the job before each attempt. After `MAX_PURGE_ATTEMPTS` (default 5, env: `PFCD_MAX_PURGE_ATTEMPTS`) the job is skipped and a `GDPR retention warning` is logged.
+
+### C8·M10 — SIGTERM graceful shutdown
+- `backend/app/workers/cleanup.py`: `time.sleep(POLL_INTERVAL_SECONDS)` replaced with `_shutdown_event.wait(POLL_INTERVAL_SECONDS)`. A `SIGTERM` handler sets `_shutdown_event` to break the poll loop after the current pass completes. Prevents hard-kill mid-purge on rolling restart.
+
+### Test fix
+- `tests/unit/test_repository.py`: `_stale_session_scope` mock updated to accept `database_url=None` parameter to match the new `session_scope` signature.

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3637,3 +3637,71 @@ Completed the remaining Phase A checklist items in one combined branch: `codex/i
 
 ### Test fix
 - `tests/unit/test_repository.py`: `_stale_session_scope` mock updated to accept `database_url=None` parameter to match the new `session_scope` signature.
+
+---
+
+## Section 24 — Phase D Hygiene Items (PR #96, 2026-04-30)
+
+Branch: `codex/issue-87-phase-d` → squash merged to main via PR #96  
+Tests: 385 passed, 2 skipped
+
+### M5 — storage.py migration fallback
+- `backend/app/storage.py`: when blob-mode `load_bytes()` cannot find a blob but the export metadata has a local path, falls back to local file read. Supports graceful migration for exports written before blob storage was configured.
+
+### M6 — load_transcript_text path traversal defence
+- `backend/app/job_logic.py`: `_is_safe_storage_key()` validates that `inp["storage_key"]` is within `_UPLOADS_DIR` (resolved via `os.path.abspath`). Absolute paths and `../` traversal sequences are rejected with a warning; returns `None` rather than opening arbitrary paths.
+
+### M7 — _format_date tz-aware strings
+- `backend/app/export_builder.py`: replaced manual strptime loop with `datetime.fromisoformat()` (Python 3.7+). Handles timezone-aware strings including `+05:30` offsets. Legacy `Z`-suffix handled separately for Python < 3.11.
+
+### M11 — api.js same-origin gate for SAS uploads
+- `frontend/src/api.js`: added `_isSameOrigin(url)` helper. `X-API-Key` header only sent to upload URLs that share the same origin as the API base. Prevents auth header leakage to external SAS blob URLs.
+
+### M12 — api.js dead exportUrl removed
+- `frontend/src/api.js`: deleted unauthenticated dead `exportUrl(jobId, fmt)` function. No callers remain; all downloads go through `downloadExport` which uses `_fetch`.
+
+### M13 — Streamlit lazy export cache
+- `streamlit_app/app.py`: export bytes cached in `st.session_state[f"_export_{job_id}_{fmt}"]`. `download_export()` only called once per job+format combination, not on every rerun.
+
+### M14 — requirements.txt pinned versions
+- `backend/requirements.txt`: `azure-ai-agents>=1.2.0b3` → `==1.2.0b6`; `pydantic>=2.11.0` → `==2.12.5` (installed versions at time of audit).
+
+### M15 — Reusable CI pg-smoke workflow
+- `.github/workflows/pg-smoke.yml`: new `workflow_call` workflow with Postgres 16 service, unit+integration tests, and PostgreSQL smoke test.
+- `deploy-backend.yml` and `deploy-workers.yml`: replaced duplicate 30-line `test:` job with a single `uses: ./.github/workflows/pg-smoke.yml` call.
+
+### M16 — reviewing.py exact Unknown speaker match
+- `backend/app/agents/reviewing.py`: `any("Unknown" in s ...)` → `any(s.strip() in {"Unknown", "Unknown Speaker"} ...)`. Prevents false positives for speakers whose names contain the word "Unknown" as a substring.
+
+### M17 — processing.py post-parse guard
+- `backend/app/agents/processing.py`: after `_parse_processing_json(raw)`, raises `RuntimeError` if both `pdd` and `sipoc` keys are absent. Surfaces unexpected LLM response shapes early instead of silently producing a stub draft.
+
+### L1 — auth.py per-request env read retained
+- `backend/app/auth.py`: kept per-request `os.environ.get("PFCD_API_KEY", "")` (original pattern). Startup caching was tested but broke `importlib.reload(main_mod)` in auth tests (lifespan not triggered by Starlette TestClient without context manager). Decision: per-request read is correct for this test pattern; overhead is negligible.
+
+### L2 — deploy-backend.yml Key Vault secretRef for PFCD_API_KEY
+- `.github/workflows/deploy-backend.yml`: `PFCD_API_KEY` now uses `secretRef: pfcd-api-key` (KV URL `https://{KV}.vault.azure.net/secrets/pfcd-api-key`). Removed plaintext `"${PFCD_API_KEY_VALUE}"` from manifest env and `PFCD_API_KEY_VALUE` from step env.
+
+### L3 — pytest.ini postgres marker
+- `pytest.ini`: added `postgres: PostgreSQL integration tests` marker to suppress `PytestUnknownMarkWarning`.
+
+### L4 — extraction.py brace escape
+- `backend/app/agents/extraction.py`: escapes `{` and `}` in `content_text` before `_USER_PROMPT_TEMPLATE.format(transcript_text=...)` to prevent `KeyError` if transcript contains Python format-string placeholders.
+
+### L6 — docker-compose.local.yml worker build contexts
+- `docker-compose.local.yml`: added `build: context: ./backend / dockerfile: Dockerfile / target: worker` to `worker-processing` and `worker-reviewing` services. Previously these relied on `image: pfcd-worker:local` already existing; now they build correctly from source.
+
+### L7 — SipocTable.jsx step_anchor column
+- `frontend/src/components/SipocTable.jsx`: added `Step Anchor` column (reads `row.step_anchor`). Now shows 7 columns matching the editable table in `DraftReview.jsx`.
+
+### L8 — Streamlit confirm_cost session state persistence
+- `streamlit_app/app.py`: pending job ID stored in `st.session_state["_pending_confirm_job_id"]` on cost-confirmation creation. Confirm button rendered outside the form submission block so it survives reruns.
+
+### L9 — kernel_factory.py rename
+- `backend/app/agents/kernel_factory.py`: `_cached_kernel_azure` → `_build_kernel_azure`; `_cached_kernel_openai` → `_build_kernel_openai`. Names were misleading (no caching). Tests updated.
+
+### L10 — media_preprocessor.py keep-in-sync comment
+- `backend/app/agents/media_preprocessor.py`: added keep-in-sync comment for `_MAX_TRANSCRIPTION_BYTES = 24 * 1024 * 1024`. True consolidation via import is blocked by a circular import (`transcription` imports `media_preprocessor` at module level).
+
+### Bug fix caught in review
+- `frontend/src/api.js`: `_resolveUploadUrl` function declaration was accidentally dropped when inserting `_isSameOrigin`. Fixed before merge.

--- a/backend/app/agents/extraction.py
+++ b/backend/app/agents/extraction.py
@@ -458,7 +458,11 @@ def run_extraction(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
                 _call_extraction(
                     deployment,
                     _SYSTEM_PROMPT,
-                    _USER_PROMPT_TEMPLATE.format(transcript_text=content_text) + _build_speaker_hint(job),
+                    # Escape braces in transcript so .format() doesn't treat them as
+                    # interpolation targets (theoretical prompt injection via {…} sequences).
+                    _USER_PROMPT_TEMPLATE.format(
+                        transcript_text=content_text.replace("{", "{{").replace("}", "}}")
+                    ) + _build_speaker_hint(job),
                 ),
                 timeout=timeout_seconds,
             )

--- a/backend/app/agents/kernel_factory.py
+++ b/backend/app/agents/kernel_factory.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_AZURE_OPENAI_API_VERSION = "2024-10-21"
 
 
-def _cached_kernel_azure(endpoint: str, deployment: str, api_version: str):
+def _build_kernel_azure(endpoint: str, deployment: str, api_version: str):
     from azure.identity import DefaultAzureCredential, get_bearer_token_provider
     from semantic_kernel import Kernel
     from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
@@ -33,7 +33,7 @@ def _cached_kernel_azure(endpoint: str, deployment: str, api_version: str):
     return kernel
 
 
-def _cached_kernel_openai(api_key: str, model: str):
+def _build_kernel_openai(api_key: str, model: str):
     from semantic_kernel import Kernel
     from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
 
@@ -49,7 +49,7 @@ def get_kernel(deployment: str):
             "Initializing Semantic Kernel OpenAIChatCompletion with model=%s",
             deployment,
         )
-        return _cached_kernel_openai(os.environ["OPENAI_API_KEY"], deployment)
+        return _build_kernel_openai(os.environ["OPENAI_API_KEY"], deployment)
 
     endpoint = os.environ["AZURE_OPENAI_ENDPOINT"]
     api_version = os.environ.get("AZURE_OPENAI_API_VERSION", _DEFAULT_AZURE_OPENAI_API_VERSION)
@@ -59,7 +59,7 @@ def get_kernel(deployment: str):
         deployment,
         api_version,
     )
-    return _cached_kernel_azure(endpoint, deployment, api_version)
+    return _build_kernel_azure(endpoint, deployment, api_version)
 
 
 def get_chat_service(deployment: str):

--- a/backend/app/agents/media_preprocessor.py
+++ b/backend/app/agents/media_preprocessor.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+# Keep in sync with transcription.py:_MAX_TRANSCRIPTION_BYTES (24 MB Whisper limit).
 _MAX_TRANSCRIPTION_BYTES = 24 * 1024 * 1024
 _FFMPEG_TIMEOUT_SEC = max(1.0, float(os.environ.get("PFCD_FFMPEG_TIMEOUT_SEC", "120")))
 _TIMESTAMP_RE = re.compile(

--- a/backend/app/agents/processing.py
+++ b/backend/app/agents/processing.py
@@ -365,6 +365,15 @@ def run_processing(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:
     if processing_fallback_used:
         job.setdefault("agent_signals", {})["processing_fallback"] = True
 
+    # Guard: if the LLM returned a JSON object that is missing both pdd and sipoc,
+    # the response likely has a different shape (e.g., wrapped in a "result" key).
+    # Surface this as a clear runtime error rather than masking it with sipoc_empty.
+    if not isinstance(draft.get("pdd"), dict) and not isinstance(draft.get("sipoc"), list):
+        raise RuntimeError(
+            f"Processing LLM response is missing required 'pdd' and 'sipoc' keys; "
+            f"top-level keys present: {list(draft.keys())!r}"
+        )
+
     # Ensure required top-level keys are present
     draft.setdefault("generated_at", _utc_now())
     draft.setdefault("version", 1)

--- a/backend/app/agents/reviewing.py
+++ b/backend/app/agents/reviewing.py
@@ -111,7 +111,7 @@ def run_reviewing(job: Dict[str, Any], profile_conf: Dict[str, Any]) -> float:  
     # 5. Unknown speakers
     extracted = job.get("extracted_evidence") or {}
     speakers = extracted.get("speakers_detected") or []
-    if any("Unknown" in s for s in speakers):
+    if any(s.strip() in {"Unknown", "Unknown Speaker"} for s in speakers):
         flags.append(_flag(
             "unknown_speaker",
             "warning",

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -12,6 +12,10 @@ from fastapi.security import APIKeyHeader
 _API_KEY_HEADER = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 
+def _reload_configured_key() -> None:
+    """No-op shim — kept for lifespan callers. The key is read per-request."""
+
+
 async def verify_api_key(api_key: Optional[str] = Security(_API_KEY_HEADER)) -> None:
     """Enforce X-API-Key header when PFCD_API_KEY env var is set.
 

--- a/backend/app/export_builder.py
+++ b/backend/app/export_builder.py
@@ -189,12 +189,18 @@ def _format_date(value: Any) -> str:
         return "Needs Review"
     from datetime import datetime
     s = str(value).strip()
-    for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%SZ",
-                "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d"):
+    # datetime.fromisoformat handles both naive and tz-aware ISO 8601 strings
+    # (including "+05:30" offsets) natively in Python 3.7+.
+    try:
+        return datetime.fromisoformat(s).strftime("%d-%b-%Y")
+    except ValueError:
+        pass
+    # Legacy fallback for "Z"-suffixed strings not handled by fromisoformat < 3.11
+    if s.endswith("Z"):
         try:
-            return datetime.strptime(s[:26].rstrip("Z"), fmt.rstrip("z").rstrip("%z")).strftime("%d-%b-%Y")
+            return datetime.fromisoformat(s[:-1]).strftime("%d-%b-%Y")
         except ValueError:
-            continue
+            pass
     return s or "Needs Review"
 
 

--- a/backend/app/job_logic.py
+++ b/backend/app/job_logic.py
@@ -416,13 +416,27 @@ def apply_cost_tracking_and_cap_warning(job: Dict[str, Any], *, phase: str, cost
     )
 
 
+_UPLOADS_DIR = os.environ.get("UPLOADS_DIR", "./storage/uploads")
+
+
+def _is_safe_storage_key(key: str) -> bool:
+    """Return True if *key* is a relative path within the uploads directory."""
+    abs_key = os.path.abspath(key)
+    abs_dir = os.path.abspath(_UPLOADS_DIR) + os.sep
+    return abs_key.startswith(abs_dir)
+
+
 def load_transcript_text(job: Dict[str, Any], storage: Any) -> Optional[str]:
     """Load transcript text from storage. Returns None if no transcript input."""
     for inp in job.get("input_manifest", {}).get("inputs", []):
         if inp.get("source_type") == "transcript":
             if inp.get("storage_key"):
+                key = inp["storage_key"]
+                if not _is_safe_storage_key(key):
+                    logger.warning("Rejecting transcript storage_key outside uploads dir: %r", key)
+                    return None
                 try:
-                    with open(inp["storage_key"], "rb") as handle:
+                    with open(key, "rb") as handle:
                         return handle.read().decode("utf-8")
                 except Exception:
                     return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
-from app.auth import verify_api_key
+from app.auth import _reload_configured_key, verify_api_key
 from app.export_builder import (
     build_evidence_bundle,
     build_export_docx,
@@ -55,6 +55,8 @@ ORCHESTRATOR = ServiceBusOrchestrator()
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
+    # Refresh auth key cache so test reloads pick up monkeypatched env
+    _reload_configured_key()
     # Validate CORS config at startup so bad env vars produce a clear logged error
     # rather than an opaque RuntimeError buried in the import chain.
     _cors_origins()

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -127,6 +127,14 @@ class ExportStorage:
             blob_client = self._client.get_blob_client(self.container, location)
             return blob_client.download_blob().readall()
         if storage == "local" and self._client:
+            # Graceful fallback: historical exports written in local mode are still readable
+            # even after the deployment migrated to blob storage.
+            if location and os.path.isfile(location):
+                logger.warning(
+                    "Reading local export %r in blob storage mode (migration fallback)", location
+                )
+                with open(location, "rb") as handle:
+                    return handle.read()
             raise FileNotFoundError("Local export metadata cannot be read in blob storage mode.")
         if not location:
             raise FileNotFoundError("Export location missing")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,9 +1,9 @@
 fastapi==0.135.3
 python-multipart==0.0.20
 semantic-kernel==1.41.2
-azure-ai-agents>=1.2.0b3
+azure-ai-agents==1.2.0b6
 uvicorn[standard]==0.34.0
-pydantic>=2.11.0
+pydantic==2.12.5
 SQLAlchemy==2.0.38
 alembic==1.13.3
 azure-storage-blob==12.25.0

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -152,6 +152,10 @@ services:
       - pfcd-local-storage:/app/storage
 
   worker-processing:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      target: worker
     image: pfcd-worker:local
     depends_on:
       api:
@@ -199,6 +203,10 @@ services:
       - pfcd-local-storage:/app/storage
 
   worker-reviewing:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      target: worker
     image: pfcd-worker:local
     depends_on:
       api:

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -69,9 +69,15 @@ export async function listJobs() {
   return res.json()
 }
 
-export function exportUrl(jobId, fmt) {
-  return `${BASE}/jobs/${jobId}/exports/${fmt}`
+
+function _isSameOrigin(url) {
+  try {
+    return new URL(url).origin === new URL(BASE, window.location.href).origin
+  } catch {
+    return true // relative URL — safe to include auth header
+  }
 }
+
 
 function _resolveUploadUrl(url) {
   if (/^https?:\/\//i.test(url)) return url
@@ -104,7 +110,7 @@ export async function uploadFile(file, sourceType = 'document') {
   const uploadUrl = _resolveUploadUrl(uploadMeta.upload.url)
   const uploadHeaders = {
     ...(uploadMeta.upload.headers ?? {}),
-    ...(uploadMeta.upload.requires_api_auth ? authHeaders() : {}),
+    ...(uploadMeta.upload.requires_api_auth && _isSameOrigin(uploadUrl) ? authHeaders() : {}),
   }
   const uploadRes = await fetch(uploadUrl, {
     method: uploadMeta.upload.method ?? 'PUT',

--- a/frontend/src/components/SipocTable.jsx
+++ b/frontend/src/components/SipocTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const HEADERS = ['Supplier', 'Input', 'Process Step', 'Output', 'Customer', 'Anchor']
+const HEADERS = ['Supplier', 'Input', 'Process Step', 'Output', 'Customer', 'Step Anchor', 'Source Anchor']
 
 export default function SipocTable({ sipoc }) {
   if (!sipoc || sipoc.length === 0) {
@@ -29,6 +29,9 @@ export default function SipocTable({ sipoc }) {
                 <td className="border border-gray-200 px-3 py-2 font-medium">{row.process_step ?? '—'}</td>
                 <td className="border border-gray-200 px-3 py-2">{row.output ?? '—'}</td>
                 <td className="border border-gray-200 px-3 py-2">{row.customer ?? '—'}</td>
+                <td className="border border-gray-200 px-3 py-2">
+                  <span className="font-mono text-xs">{row.step_anchor ?? '—'}</span>
+                </td>
                 <td className="border border-gray-200 px-3 py-2">
                   {hasAnchorIssue ? (
                     <span className="text-gray-400 italic text-xs">{row.anchor_missing_reason}</span>

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ python_functions = test_*
 markers =
     unit: unit tests (fully mocked)
     integration: integration tests (real SQLite, mocked Azure)
+    postgres: integration tests that require a live PostgreSQL instance

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -242,15 +242,26 @@ def render_new_job_tab() -> None:
                     f"Estimated profile={create_res.get('cost_estimate', {}).get('profile', profile)}, "
                     f"cap=${create_res.get('cost_estimate', {}).get('cost_cap_usd', 'n/a')}."
                 )
-                if st.button("Confirm cost and start", key="new_confirm_cost", use_container_width=True):
-                    confirmed = confirm_cost(api_base(), api_key(), create_res["job_id"])
-                    st.session_state["current_job"] = get_job(api_base(), api_key(), confirmed["job_id"])
-                    st.success(f"Job started: {confirmed['job_id']}")
+                # Persist the job_id across reruns so the confirm button still works
+                st.session_state["_pending_confirm_job_id"] = create_res["job_id"]
             else:
                 st.session_state["current_job"] = get_job(api_base(), api_key(), create_res["job_id"])
                 st.success(f"Job created: {create_res['job_id']}")
         except Exception as exc:
             st.error(f"Create job failed: {exc}")
+
+    # Confirm cost button rendered outside the form submission block so it
+    # survives the Streamlit rerun that clears the form submission state.
+    pending_confirm_id = st.session_state.get("_pending_confirm_job_id")
+    if pending_confirm_id:
+        if st.button("Confirm cost and start", key="new_confirm_cost", use_container_width=True):
+            try:
+                confirmed = confirm_cost(api_base(), api_key(), pending_confirm_id)
+                st.session_state["current_job"] = get_job(api_base(), api_key(), confirmed["job_id"])
+                del st.session_state["_pending_confirm_job_id"]
+                st.success(f"Job started: {confirmed['job_id']}")
+            except Exception as exc:
+                st.error(f"Confirm cost failed: {exc}")
 
 
 def _phase_dot(done: bool, active: bool) -> str:
@@ -470,18 +481,24 @@ def render_exports_tab() -> None:
         ("pdf", "Download PDF", "application/pdf"),
         ("docx", "Download DOCX", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
     ]:
-        try:
-            blob, filename = download_export(api_base(), api_key(), job["job_id"], fmt)
-            st.download_button(
-                label,
-                data=blob,
-                file_name=filename,
-                mime=mime,
-                key=f"exports_download_{fmt}",
-                use_container_width=True,
-            )
-        except Exception as exc:
-            st.warning(f"{fmt.upper()} unavailable: {exc}")
+        cache_key = f"_export_{job['job_id']}_{fmt}"
+        cached = st.session_state.get(cache_key)
+        if cached is None:
+            try:
+                cached = download_export(api_base(), api_key(), job["job_id"], fmt)
+                st.session_state[cache_key] = cached
+            except Exception as exc:
+                st.warning(f"{fmt.upper()} unavailable: {exc}")
+                continue
+        blob, filename = cached
+        st.download_button(
+            label,
+            data=blob,
+            file_name=filename,
+            mime=mime,
+            key=f"exports_download_{fmt}",
+            use_container_width=True,
+        )
 
 
 def main() -> None:

--- a/tests/unit/test_kernel_factory.py
+++ b/tests/unit/test_kernel_factory.py
@@ -8,8 +8,8 @@ import app.agents.kernel_factory as kernel_factory
 
 
 def test_kernel_helpers_are_not_lru_cached():
-    assert not hasattr(kernel_factory._cached_kernel_azure, "cache_info")
-    assert not hasattr(kernel_factory._cached_kernel_openai, "cache_info")
+    assert not hasattr(kernel_factory._build_kernel_azure, "cache_info")
+    assert not hasattr(kernel_factory._build_kernel_openai, "cache_info")
 
 
 def test_get_kernel_uses_default_api_version(monkeypatch):
@@ -18,7 +18,7 @@ def test_get_kernel_uses_default_api_version(monkeypatch):
     monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", endpoint)
     monkeypatch.delenv("AZURE_OPENAI_API_VERSION", raising=False)
 
-    with patch("app.agents.kernel_factory._cached_kernel_azure", return_value="kernel") as cached:
+    with patch("app.agents.kernel_factory._build_kernel_azure", return_value="kernel") as cached:
         result = kernel_factory.get_kernel("my-deployment")
 
     assert result == "kernel"
@@ -31,7 +31,7 @@ def test_get_kernel_uses_env_api_version(monkeypatch):
     monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", endpoint)
     monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2025-01-01-preview")
 
-    with patch("app.agents.kernel_factory._cached_kernel_azure", return_value="kernel") as cached:
+    with patch("app.agents.kernel_factory._build_kernel_azure", return_value="kernel") as cached:
         result = kernel_factory.get_kernel("my-deployment")
 
     assert result == "kernel"
@@ -42,7 +42,7 @@ def test_get_kernel_openai_provider_uses_openai_cache(monkeypatch):
     monkeypatch.setenv("PFCD_PROVIDER", "openai")
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
-    with patch("app.agents.kernel_factory._cached_kernel_openai", return_value="kernel") as cached:
+    with patch("app.agents.kernel_factory._build_kernel_openai", return_value="kernel") as cached:
         result = kernel_factory.get_kernel("gpt-4o-mini")
 
     assert result == "kernel"


### PR DESCRIPTION
## Summary

Implements all Phase D hygiene items from the Opus 4.7 code review (issue #87).

### Backend Python (M5–M9, M11–M12, M16–M17, L1–L10)
- **M5** `storage.py` — graceful fallback when blob-mode reads local export paths (migration safety)
- **M6** `job_logic.py` — path traversal defense in `load_transcript_text`; rejects storage_keys outside `UPLOADS_DIR`
- **M7** `export_builder.py` — replace manual strptime loop with `datetime.fromisoformat()` for tz-aware ISO strings
- **M11** `api.js` — same-origin gate for `X-API-Key` on SAS upload URLs (`_isSameOrigin` helper)
- **M12** `api.js` — delete dead `exportUrl` function
- **M13** `streamlit_app/app.py` — lazy export download with `st.session_state` cache (no eager re-fetch on rerun)
- **M14** `requirements.txt` — pin `azure-ai-agents==1.2.0b6`, `pydantic==2.12.5`
- **M15** CI — extract reusable `.github/workflows/pg-smoke.yml`; both deploy workflows call it
- **M16** `reviewing.py` — exact set-membership check for "Unknown" speakers (was substring match)
- **M17** `processing.py` — guard: raise `RuntimeError` if both `pdd` and `sipoc` missing after parse

### Infrastructure / Config
- **L2** `deploy-backend.yml` — `PFCD_API_KEY` injected via Key Vault `secretRef` (not plaintext env)
- **L3** `pytest.ini` — add `postgres` marker
- **L5** `runner.py` — already correct `min(60, 2**attempt)`, no change
- **L6** `docker-compose.local.yml` — add `build:` context to worker-processing + worker-reviewing

### Frontend / Streamlit
- **L7** `SipocTable.jsx` — add `step_anchor` column (was missing vs EditableSipocTable)
- **L8** `streamlit_app/app.py` — persist pending confirm_cost `job_id` in `session_state` across reruns

### Naming / Cosmetic
- **L1** `auth.py` — kept per-request env read (startup caching broke test `importlib.reload` pattern)
- **L9** `kernel_factory.py` — rename `_cached_kernel_*` → `_build_kernel_*` (misleading name)
- **L10** `media_preprocessor.py` — keep-in-sync comment (circular import prevents true consolidation)

## Tests
```
385 passed, 2 skipped
```

Closes #87