### PR TITLE
feat: add advisory LLM semantic review layer in reviewing worker

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3705,3 +3705,48 @@ Tests: 385 passed, 2 skipped
 
 ### Bug fix caught in review
 - `frontend/src/api.js`: `_resolveUploadUrl` function declaration was accidentally dropped when inserting `_isSameOrigin`. Fixed before merge.
+
+---
+
+## Section 25 — Issue #97 LLM Semantic Review Layer (PR #98, 2026-05-01)
+
+Branch: `codex/issue-97-llm-semantic-review` → PR #98 (open)
+
+### Advisory semantic review module
+- Added `backend/app/agents/llm_reviewer.py` with `run_llm_semantic_review(job, profile_conf, storage) -> float`.
+- LLM pass remains advisory-only and writes to `review_notes.llm_semantic_flags` (separate from deterministic `review_notes.flags`).
+- Feature gate added: `PFCD_REVIEW_LLM_ENABLED` (`false` by default), auto-enabled for `quality` profile.
+- Citation filter implemented: `_drop_uncited_flags` drops flags missing `evidence_id` or `anchor`.
+- Transcript grounding implemented via `_build_anchor_slices` using transcript snippets keyed by evidence anchors.
+- Coverage-gap fallback is deterministic for unmapped evidence anchors to ensure actionable advisory output.
+
+### Reviewing worker integration
+- `backend/app/workers/runner.py`: reviewing phase now calls `run_llm_semantic_review(...)` only when deterministic decision is not `blocked`.
+- LLM review cost is added into phase cost tracking (`cost += llm_cost`).
+
+### Payload contract updates
+- `backend/app/job_logic.py`:
+  - Added `review_notes.llm_semantic_flags` default `[]`.
+  - Added `agent_signals.llm_review_stats` with `{total_flags: 0, accepted_by_human: 0}`.
+
+### Export updates
+- `backend/app/export_builder.py`:
+  - Evidence bundle now carries `llm_semantic_flags` from job review notes.
+  - Added Markdown section `## 5A. AI Semantic Review Notes` (rendered only when flags exist).
+  - Added DOCX section `5A. AI Semantic Review Notes` (rendered only when flags exist).
+  - Section columns: `Flag | Evidence ID | Step | Anchor | Snippet`.
+
+### Reference docs
+- `REFERENCE.md` env table updated with `PFCD_REVIEW_LLM_ENABLED` and auto-enable behavior for quality profile.
+
+### Tests
+- Added `tests/unit/test_llm_reviewer.py` with 5 tests:
+  - uncited flags dropped
+  - coverage flag for unmapped evidence
+  - no flags when all evidence mapped
+  - disabled by default (no LLM call)
+  - runner skips LLM review when deterministic decision is `blocked`
+- Extended `tests/unit/test_export_builder.py` to cover Markdown/DOCX semantic review section visibility and rendering.
+- Validation run:
+  - `backend/.venv/bin/python3.12 -m pytest tests/unit/test_llm_reviewer.py tests/unit/test_worker.py tests/unit/test_export_builder.py -q` → `85 passed`
+  - `backend/.venv/bin/python3.12 -m pytest tests/unit/test_job_logic.py -q` → `18 passed`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -150,6 +150,7 @@ cd backend && .venv/bin/alembic upgrade head
 | `PFCD_CLEANUP_INTERVAL_SECONDS` | Cleanup worker poll interval | `300` |
 | `PFCD_JOB_TTL_DAYS` | Job retention window before expiry/cleanup | `7` |
 | `PFCD_LLM_TIMEOUT_SECONDS` | Max seconds allowed for a single extraction/processing LLM call | `120` |
+| `PFCD_REVIEW_LLM_ENABLED` | Enables advisory LLM semantic review flags in reviewing phase (`true`/`false`). Auto-enabled for `quality` profile. | `false` |
 | `PFCD_MAX_COMPLETION_TOKENS` | Max completion tokens for processing/vision LLM calls (fallback for extraction) | `2048` |
 | `PFCD_MAX_EXTRACTION_TOKENS` | Max completion tokens for extraction LLM calls (overrides `PFCD_MAX_COMPLETION_TOKENS`; higher budget for dense transcripts) | `4096` |
 | `PFCD_API_KEY` | Static API key for `X-API-Key` header | `""` (auth disabled if unset) |

--- a/backend/app/agents/llm_reviewer.py
+++ b/backend/app/agents/llm_reviewer.py
@@ -1,0 +1,450 @@
+"""LLM semantic reviewer: grounded advisory checks after deterministic review.
+
+This module adds warning/info-only semantic flags. It never blocks finalize.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+from typing import Any, Dict, List
+
+from app.agents.alignment import parse_vtt_cues
+from app.job_logic import estimate_cost_usd, load_transcript_text
+
+_SYSTEM_PROMPT = (
+    "You are a strict process-documentation QA reviewer. "
+    "You verify a draft against supplied evidence items and transcript snippets. "
+    "Return JSON only. Do not invent facts. Use warning/info severities only."
+)
+
+_USER_PROMPT_TEMPLATE = """\
+Check two things only:
+1) Coverage gap: evidence items not represented in any PDD step.
+2) Factual consistency: mapped PDD step mismatches actor/system/action in evidence.
+
+Draft PDD steps:
+{steps_json}
+
+Unmapped evidence candidates:
+{unmapped_json}
+
+Top mapped evidence candidates:
+{mapped_json}
+
+Return JSON with exact shape:
+{{
+  "coverage_flags": [
+    {{
+      "code": "coverage_gap",
+      "severity": "warning",
+      "message": "string",
+      "evidence_id": "ev-01",
+      "anchor": "00:00:10-00:00:20",
+      "step_id": "",
+      "snippet": "string"
+    }}
+  ],
+  "consistency_flags": [
+    {{
+      "code": "factual_drift",
+      "severity": "warning",
+      "message": "string",
+      "evidence_id": "ev-02",
+      "anchor": "00:00:30-00:00:35",
+      "step_id": "step-04",
+      "snippet": "string"
+    }}
+  ]
+}}
+"""
+
+_TS_RANGE_RE = re.compile(
+    r"^(\d{2}:\d{2}:\d{2})(?:[.,]\d+)?(?:-(\d{2}:\d{2}:\d{2})(?:[.,]\d+)?)?$"
+)
+_VTT_LINE_RE = re.compile(
+    r"(?m)^(\d{2}:\d{2}:\d{2}[.,]\d+)\s*-->\s*(\d{2}:\d{2}:\d{2}[.,]\d+)\s*$"
+)
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _extract_usage_tokens(metadata: Dict[str, Any]) -> tuple[int, int]:
+    usage = metadata.get("usage")
+    if usage is None:
+        return 0, 0
+    if isinstance(usage, dict):
+        return _safe_int(usage.get("prompt_tokens")), _safe_int(usage.get("completion_tokens"))
+    return _safe_int(getattr(usage, "prompt_tokens", 0)), _safe_int(
+        getattr(usage, "completion_tokens", 0)
+    )
+
+
+def _max_completion_tokens() -> int:
+    raw = os.environ.get("PFCD_MAX_COMPLETION_TOKENS", "2048").strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        return 2048
+    return max(256, value)
+
+
+def _llm_timeout_seconds() -> float:
+    raw = os.environ.get("PFCD_LLM_TIMEOUT_SECONDS", "120").strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        return 120.0
+    return max(1.0, value)
+
+
+def _ts_to_sec(ts: str) -> float:
+    parts = ts.replace(",", ".").split(":")
+    h, m, s = int(parts[0]), int(parts[1]), float(parts[2])
+    return h * 3600 + m * 60 + s
+
+
+def _anchor_bounds(anchor: str) -> tuple[float, float] | None:
+    match = _TS_RANGE_RE.match((anchor or "").strip())
+    if not match:
+        return None
+    start = _ts_to_sec(match.group(1))
+    end = _ts_to_sec(match.group(2) or match.group(1))
+    return (start, end)
+
+
+def _extract_balanced_json_object(text: str) -> str | None:
+    start = text.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    in_string = False
+    escaped = False
+    for idx in range(start, len(text)):
+        ch = text[idx]
+        if escaped:
+            escaped = False
+            continue
+        if ch == "\\":
+            escaped = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : idx + 1]
+    return None
+
+
+def _parse_llm_json(raw: str) -> Dict[str, Any]:
+    candidates: List[str] = [raw.strip()]
+    fenced = re.findall(r"```(?:json)?\s*(.*?)```", raw, flags=re.IGNORECASE | re.DOTALL)
+    candidates.extend(chunk.strip() for chunk in fenced if chunk.strip())
+    balanced = _extract_balanced_json_object(raw)
+    if balanced:
+        candidates.append(balanced.strip())
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            parsed = json.loads(candidate)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            continue
+    return {}
+
+
+def _llm_review_enabled(profile_conf: Dict[str, Any]) -> bool:
+    raw = os.environ.get("PFCD_REVIEW_LLM_ENABLED", "false").strip().lower()
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    return str(profile_conf.get("profile", "")).strip().lower() == "quality"
+
+
+def _step_anchor_map(draft: Dict[str, Any]) -> Dict[str, List[str]]:
+    mapping: Dict[str, List[str]] = {}
+    steps = (draft.get("pdd") or {}).get("steps") or []
+    for step in steps:
+        step_id = str((step or {}).get("id") or "").strip()
+        for source_anchor in (step.get("source_anchors") or []):
+            anchor = str((source_anchor or {}).get("anchor") or "").strip()
+            if not anchor:
+                continue
+            mapping.setdefault(anchor, [])
+            if step_id and step_id not in mapping[anchor]:
+                mapping[anchor].append(step_id)
+    return mapping
+
+
+def _vtt_blocks(transcript_text: str) -> List[Dict[str, Any]]:
+    lines = transcript_text.splitlines()
+    blocks: List[Dict[str, Any]] = []
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx].strip()
+        match = _VTT_LINE_RE.match(line)
+        if not match:
+            idx += 1
+            continue
+        start = _ts_to_sec(match.group(1))
+        end = _ts_to_sec(match.group(2))
+        text_lines: List[str] = []
+        idx += 1
+        while idx < len(lines) and lines[idx].strip():
+            value = lines[idx].strip()
+            if not value.isdigit():
+                text_lines.append(value)
+            idx += 1
+        blocks.append({"start": start, "end": end, "text": " ".join(text_lines).strip()})
+        idx += 1
+    return blocks
+
+
+def _build_anchor_slices(evidence_items: List[Dict[str, Any]], transcript_text: str) -> Dict[str, str]:
+    """Build short evidence snippets keyed by anchor."""
+    slices: Dict[str, str] = {}
+    if not transcript_text:
+        return slices
+
+    # Keep this call to reuse alignment parsing behavior and VTT detection path.
+    cues = parse_vtt_cues(transcript_text)
+    blocks = _vtt_blocks(transcript_text) if cues else []
+    lower_text = transcript_text.lower()
+
+    for item in evidence_items:
+        anchor = str(item.get("anchor") or "").strip()
+        if not anchor or anchor in slices:
+            continue
+
+        bounds = _anchor_bounds(anchor)
+        if bounds and blocks:
+            start, end = bounds
+            matched = [
+                b["text"]
+                for b in blocks
+                if start <= b["end"] + 2.0 and end >= b["start"] - 2.0 and b["text"]
+            ]
+            if matched:
+                slices[anchor] = " ".join(matched)[:280]
+                continue
+
+        key = anchor.lower()
+        pos = lower_text.find(key)
+        if pos >= 0:
+            left = max(0, pos - 120)
+            right = min(len(transcript_text), pos + len(anchor) + 120)
+            slices[anchor] = transcript_text[left:right].replace("\n", " ").strip()[:280]
+            continue
+
+        slices[anchor] = str(item.get("summary") or "").strip()[:280]
+
+    return slices
+
+
+def _drop_uncited_flags(flags: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    kept: List[Dict[str, Any]] = []
+    for flag in flags:
+        evidence_id = str(flag.get("evidence_id") or "").strip()
+        anchor = str(flag.get("anchor") or "").strip()
+        if not evidence_id or not anchor:
+            continue
+        kept.append(
+            {
+                "code": str(flag.get("code") or "llm_semantic_flag").strip(),
+                "severity": str(flag.get("severity") or "warning").strip().lower(),
+                "message": str(flag.get("message") or "").strip(),
+                "evidence_id": evidence_id,
+                "anchor": anchor,
+                "step_id": str(flag.get("step_id") or "").strip(),
+                "snippet": str(flag.get("snippet") or "").strip(),
+            }
+        )
+    return kept
+
+
+async def _call_llm_review(deployment: str, system_prompt: str, user_content: str):
+    from semantic_kernel.connectors.ai.open_ai import OpenAIChatPromptExecutionSettings
+    from semantic_kernel.contents import ChatHistory
+
+    from app.agents.kernel_factory import get_chat_service, get_kernel
+
+    kernel = get_kernel(deployment)
+    chat = ChatHistory()
+    chat.add_system_message(system_prompt)
+    chat.add_user_message(user_content)
+    settings = OpenAIChatPromptExecutionSettings(
+        response_format={"type": "json_object"},
+        max_completion_tokens=_max_completion_tokens(),
+    )
+    svc = get_chat_service(deployment)
+    result = await svc.get_chat_message_content(chat, settings, kernel=kernel)
+    prompt_tokens, completion_tokens = _extract_usage_tokens(result.metadata)
+    return str(result), prompt_tokens, completion_tokens
+
+
+def _deterministic_coverage_flags(
+    unmapped_items: List[Dict[str, Any]],
+    slices: Dict[str, str],
+) -> List[Dict[str, Any]]:
+    flags: List[Dict[str, Any]] = []
+    for item in unmapped_items:
+        evidence_id = str(item.get("id") or "").strip()
+        anchor = str(item.get("anchor") or "").strip()
+        if not evidence_id or not anchor:
+            continue
+        flags.append(
+            {
+                "code": "coverage_gap",
+                "severity": "warning",
+                "message": f"Evidence {evidence_id} is not mapped to any PDD step.",
+                "evidence_id": evidence_id,
+                "anchor": anchor,
+                "step_id": "",
+                "snippet": slices.get(anchor, ""),
+            }
+        )
+    return flags
+
+
+def run_llm_semantic_review(job: Dict[str, Any], profile_conf: Dict[str, Any], storage: Any) -> float:
+    """Run advisory semantic checks and persist `review_notes.llm_semantic_flags`.
+
+    Returns LLM cost in USD.
+    """
+    review_notes = job.setdefault("review_notes", {})
+    review_notes.setdefault("llm_semantic_flags", [])
+    stats = job.setdefault("agent_signals", {}).setdefault(
+        "llm_review_stats",
+        {"total_flags": 0, "accepted_by_human": 0},
+    )
+
+    if not _llm_review_enabled(profile_conf):
+        review_notes["llm_semantic_flags"] = []
+        return 0.0
+
+    if str((job.get("agent_review") or {}).get("decision") or "").strip().lower() == "blocked":
+        review_notes["llm_semantic_flags"] = []
+        return 0.0
+
+    draft = job.get("draft") or {}
+    evidence_items: List[Dict[str, Any]] = (
+        (job.get("extracted_evidence") or {}).get("evidence_items") or []
+    )
+    if not draft or not evidence_items:
+        review_notes["llm_semantic_flags"] = []
+        return 0.0
+
+    step_anchor_map = _step_anchor_map(draft)
+    step_index = {
+        str((step or {}).get("id") or "").strip(): step
+        for step in ((draft.get("pdd") or {}).get("steps") or [])
+    }
+
+    unmapped_items: List[Dict[str, Any]] = []
+    mapped_candidates: List[Dict[str, Any]] = []
+    for item in evidence_items:
+        anchor = str(item.get("anchor") or "").strip()
+        mapped_step_ids = step_anchor_map.get(anchor, [])
+        confidence = float(item.get("confidence") or 0.0)
+        if mapped_step_ids:
+            mapped_candidates.append(
+                {
+                    "evidence_id": item.get("id"),
+                    "anchor": anchor,
+                    "summary": item.get("summary"),
+                    "confidence": confidence,
+                    "step_id": mapped_step_ids[0],
+                    "step_summary": (step_index.get(mapped_step_ids[0]) or {}).get("summary"),
+                }
+            )
+        else:
+            unmapped_items.append(item)
+
+    transcript_text = load_transcript_text(job, storage) or job.get("_transcript_text_inline") or ""
+    slices = _build_anchor_slices(evidence_items, transcript_text)
+    top_mapped = sorted(
+        mapped_candidates,
+        key=lambda c: float(c.get("confidence") or 0.0),
+        reverse=True,
+    )[:5]
+    for candidate in top_mapped:
+        candidate["snippet"] = slices.get(str(candidate.get("anchor") or ""), "")
+
+    llm_flags: List[Dict[str, Any]] = []
+    deployment = profile_conf.get("model")
+    if deployment and (unmapped_items or top_mapped):
+        user_prompt = _USER_PROMPT_TEMPLATE.format(
+            steps_json=json.dumps(
+                (draft.get("pdd") or {}).get("steps") or [],
+                ensure_ascii=True,
+                separators=(",", ":"),
+            ),
+            unmapped_json=json.dumps(
+                [
+                    {
+                        "evidence_id": item.get("id"),
+                        "anchor": item.get("anchor"),
+                        "summary": item.get("summary"),
+                        "snippet": slices.get(str(item.get("anchor") or ""), ""),
+                    }
+                    for item in unmapped_items
+                ],
+                ensure_ascii=True,
+                separators=(",", ":"),
+            ),
+            mapped_json=json.dumps(top_mapped, ensure_ascii=True, separators=(",", ":")),
+        )
+        timeout_seconds = _llm_timeout_seconds()
+        try:
+            raw, prompt_tokens, completion_tokens = asyncio.run(
+                asyncio.wait_for(
+                    _call_llm_review(deployment, _SYSTEM_PROMPT, user_prompt),
+                    timeout=timeout_seconds,
+                )
+            )
+            parsed = _parse_llm_json(raw)
+            llm_flags.extend(parsed.get("coverage_flags") or [])
+            llm_flags.extend(parsed.get("consistency_flags") or [])
+            cost = estimate_cost_usd(deployment, prompt_tokens, completion_tokens)
+        except Exception:
+            cost = 0.0
+    else:
+        cost = 0.0
+
+    # Always include deterministic coverage gap flags when items are unmapped.
+    llm_flags.extend(_deterministic_coverage_flags(unmapped_items, slices))
+    llm_flags = _drop_uncited_flags(llm_flags)
+
+    deduped: List[Dict[str, Any]] = []
+    seen: set[tuple[str, str, str, str]] = set()
+    for flag in llm_flags:
+        key = (
+            flag.get("code", ""),
+            flag.get("evidence_id", ""),
+            flag.get("anchor", ""),
+            flag.get("step_id", ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(flag)
+
+    review_notes["llm_semantic_flags"] = deduped
+    stats["total_flags"] = int(stats.get("total_flags") or 0) + len(deduped)
+    stats.setdefault("accepted_by_human", 0)
+    return cost
+

--- a/backend/app/export_builder.py
+++ b/backend/app/export_builder.py
@@ -159,6 +159,7 @@ def build_evidence_bundle(finalized_draft: Dict[str, Any], job: Dict[str, Any]) 
 
     return {
         "evidence_strength": (job.get("agent_signals") or {}).get("evidence_strength"),
+        "llm_semantic_flags": (job.get("review_notes") or {}).get("llm_semantic_flags") or [],
         "frame_policy": (
             (job.get("input_manifest") or {}).get("video", {}).get("frame_extraction_policy")
         ),
@@ -242,6 +243,7 @@ def build_export_markdown(draft: Dict[str, Any], evidence_bundle: Dict[str, Any]
     roles = _derive_roles(draft)
     approval_rows = draft.get("approval_matrix") or []
     controls = pdd.get("process_controls") or draft.get("process_controls") or []
+    llm_semantic_flags = evidence_bundle.get("llm_semantic_flags") or []
     exceptions = pdd.get("exceptions") or []
     automation = draft.get("automation_opportunities") or []
     faqs = draft.get("faqs") or []
@@ -275,7 +277,7 @@ def build_export_markdown(draft: Dict[str, Any], evidence_bundle: Dict[str, Any]
         "---",
         "",
         "## Index",
-        "1. Document Control  2. Introduction  3. Process Steps  4. Process Exceptions  5. Process Controls  6. Approval Matrix  7. Appendix",
+        "1. Document Control  2. Introduction  3. Process Steps  4. Process Exceptions  5. Process Controls  5A. AI Semantic Review Notes  6. Approval Matrix  7. Appendix",
         "",
         "---",
         "",
@@ -421,6 +423,29 @@ def build_export_markdown(draft: Dict[str, Any], evidence_bundle: Dict[str, Any]
                 parts.append(f"| control-{idx:02d} | Needs Review | {_needs_review(ctl)} | Needs Review | Needs Review |")
     else:
         parts.append("| control-01 | Needs Review | Needs Review | Needs Review | Needs Review |")
+
+    if llm_semantic_flags:
+        parts.extend(["", "## 5A. AI Semantic Review Notes"])
+        parts.extend(
+            [
+                "| Flag | Evidence ID | Step | Anchor | Snippet |",
+                "|------|-------------|------|--------|---------|",
+            ]
+        )
+        for flag in llm_semantic_flags:
+            parts.append(
+                "| "
+                + " | ".join(
+                    [
+                        _needs_review(flag.get("message") or flag.get("code")),
+                        _needs_review(flag.get("evidence_id")),
+                        _needs_review(flag.get("step_id")),
+                        _needs_review(flag.get("anchor")),
+                        _needs_review(flag.get("snippet"))[:120],
+                    ]
+                )
+                + " |"
+            )
 
     parts.extend(["", "## 6. Approval Matrix"])
     parts.extend(["| Role | Responsibility |", "|------|----------------|"])
@@ -647,6 +672,7 @@ def build_export_docx(
     roles = _derive_roles(draft)
     sipoc = draft.get("sipoc") or []
     controls = pdd.get("process_controls") or draft.get("process_controls") or []
+    llm_semantic_flags = evidence_bundle.get("llm_semantic_flags") or []
     exceptions = pdd.get("exceptions") or []
     approval_rows = draft.get("approval_matrix") or []
     automation = draft.get("automation_opportunities") or []
@@ -690,7 +716,10 @@ def build_export_docx(
     row[5].text = "Initial export"
 
     doc.add_heading("Index", level=1)
-    doc.add_paragraph("1. Document Control  2. Introduction  3. Process Steps  4. Process Exceptions  5. Process Controls  6. Approval Matrix  7. Appendix")
+    doc.add_paragraph(
+        "1. Document Control  2. Introduction  3. Process Steps  4. Process Exceptions  "
+        "5. Process Controls  5A. AI Semantic Review Notes  6. Approval Matrix  7. Appendix"
+    )
 
     doc.add_heading("2. Introduction", level=1)
     doc.add_heading("2.1 Process Overview", level=2)
@@ -821,6 +850,20 @@ def build_export_docx(
         row[2].text = "Needs Review"
         row[3].text = "Needs Review"
         row[4].text = "Needs Review"
+
+    if llm_semantic_flags:
+        doc.add_heading("5A. AI Semantic Review Notes", level=1)
+        sem_table = doc.add_table(rows=1, cols=5)
+        sem_table.style = "Table Grid"
+        for i, h in enumerate(["Flag", "Evidence ID", "Step", "Anchor", "Snippet"]):
+            sem_table.rows[0].cells[i].text = h
+        for flag in llm_semantic_flags:
+            row = sem_table.add_row().cells
+            row[0].text = _needs_review(flag.get("message") or flag.get("code"))
+            row[1].text = _needs_review(flag.get("evidence_id"))
+            row[2].text = _needs_review(flag.get("step_id"))
+            row[3].text = _needs_review(flag.get("anchor"))
+            row[4].text = _needs_review(flag.get("snippet"))[:180]
 
     doc.add_heading("6. Approval Matrix", level=1)
     appr_table = doc.add_table(rows=1, cols=2)

--- a/backend/app/job_logic.py
+++ b/backend/app/job_logic.py
@@ -294,10 +294,18 @@ def default_job_payload(payload: JobCreateRequest) -> Dict[str, Any]:
             "verdict": "inconclusive",
             "similarity_score": None,
         },
-        "review_notes": {"flags": [], "assumptions": []},
+        "review_notes": {
+            "flags": [],
+            "assumptions": [],
+            "llm_semantic_flags": [],
+        },
         "agent_signals": {
             "evidence_strength": None,  # set authoritatively by reviewing agent
             "alignment": None,
+            "llm_review_stats": {
+                "total_flags": 0,
+                "accepted_by_human": 0,
+            },
         },
         "agent_review": {
             "decision": None,

--- a/backend/app/workers/runner.py
+++ b/backend/app/workers/runner.py
@@ -20,6 +20,7 @@ from azure.servicebus.exceptions import (
 
 from app.agents.alignment import run_anchor_alignment
 from app.agents.extraction import run_extraction
+from app.agents.llm_reviewer import run_llm_semantic_review
 from app.agents.processing import run_processing
 from app.agents.reviewing import run_reviewing
 from app.job_logic import (
@@ -178,6 +179,10 @@ class Worker:
             if not job.get("draft"):
                 build_draft(job)
             cost = run_reviewing(job, profile_conf)
+            if job.get("agent_review", {}).get("decision") != "blocked":
+                cost += run_llm_semantic_review(job, profile_conf, self.storage)
+            else:
+                job.setdefault("review_notes", {}).setdefault("llm_semantic_flags", [])
             job["agent_review"]["decision_at"] = _utc_now()
             # All reviewing outcomes transition to NEEDS_REVIEW so a human can
             # inspect before finalizing.  The agent's decision is recorded in

--- a/backend/app/workers/runner.py
+++ b/backend/app/workers/runner.py
@@ -179,7 +179,7 @@ class Worker:
             if not job.get("draft"):
                 build_draft(job)
             cost = run_reviewing(job, profile_conf)
-            if job.get("agent_review", {}).get("decision") != "blocked":
+            if str((job.get("agent_review") or {}).get("decision") or "").strip().lower() != "blocked":
                 cost += run_llm_semantic_review(job, profile_conf, self.storage)
             else:
                 job.setdefault("review_notes", {}).setdefault("llm_semantic_flags", [])

--- a/tests/unit/test_export_builder.py
+++ b/tests/unit/test_export_builder.py
@@ -308,6 +308,27 @@ class TestBuildExportMarkdown:
         md = build_export_markdown({}, build_evidence_bundle({}, {}))
         assert "No finalized draft available" in md
 
+    def test_semantic_review_section_hidden_when_empty(self):
+        md = build_export_markdown(DRAFT_WITH_ANCHORS, self._bundle())
+        assert "## 5A. AI Semantic Review Notes" not in md
+
+    def test_semantic_review_section_rendered_when_flags_present(self):
+        bundle = self._bundle()
+        bundle["llm_semantic_flags"] = [
+            {
+                "code": "coverage_gap",
+                "message": "Evidence ev-03 is not mapped to any PDD step.",
+                "evidence_id": "ev-03",
+                "step_id": "",
+                "anchor": "00:00:20-00:00:30",
+                "snippet": "Analyst reconciles ERP billing",
+            }
+        ]
+        md = build_export_markdown(DRAFT_WITH_ANCHORS, bundle)
+        assert "## 5A. AI Semantic Review Notes" in md
+        assert "ev-03" in md
+        assert "00:00:20-00:00:30" in md
+
     def test_no_anchors_shows_fallback_message(self):
         draft = {"pdd": {"purpose": "p", "scope": "s", "steps": []}, "sipoc": []}
         bundle = {"linked_anchors": [], "evidence_strength": None, "frame_captures_note": ""}
@@ -462,3 +483,31 @@ class TestBuildExportDocx:
         result = build_export_docx(DRAFT_WITH_ANCHORS, bundle, "job-123", frame_bytes_map={})
         assert isinstance(result, bytes)
         assert result[:2] == b"PK"
+
+    def test_docx_semantic_review_section_hidden_when_empty(self):
+        import io
+        from docx import Document
+
+        result = build_export_docx(DRAFT_WITH_ANCHORS, self._bundle(), "job-123")
+        doc = Document(io.BytesIO(result))
+        assert not any(p.text.strip() == "5A. AI Semantic Review Notes" for p in doc.paragraphs)
+
+    def test_docx_semantic_review_section_rendered_when_flags_present(self):
+        import io
+        from docx import Document
+
+        bundle = self._bundle()
+        bundle["llm_semantic_flags"] = [
+            {
+                "code": "factual_drift",
+                "message": "Actor mismatch against cited evidence.",
+                "evidence_id": "ev-02",
+                "step_id": "step-02",
+                "anchor": "00:01:15",
+                "snippet": "Manager receives a copy only",
+            }
+        ]
+        result = build_export_docx(DRAFT_WITH_ANCHORS, bundle, "job-123")
+        doc = Document(io.BytesIO(result))
+        assert any(p.text.strip() == "5A. AI Semantic Review Notes" for p in doc.paragraphs)
+        assert any("ev-02" in cell.text for table in doc.tables for row in table.rows for cell in row.cells)

--- a/tests/unit/test_llm_reviewer.py
+++ b/tests/unit/test_llm_reviewer.py
@@ -1,0 +1,179 @@
+"""Unit tests for advisory LLM semantic reviewer."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import pathlib
+import sys
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+BACKEND = ROOT / "backend"
+sys.path.insert(0, str(BACKEND))
+
+
+def _reload_modules():
+    import app.db as db
+    import app.repository as repo
+
+    importlib.reload(db)
+    importlib.reload(repo)
+    return db, repo
+
+
+def _make_job() -> Dict[str, Any]:
+    from app.job_logic import InputFile, JobCreateRequest, default_job_payload
+
+    req = JobCreateRequest(
+        profile="balanced",
+        input_files=[InputFile(source_type="transcript", size_bytes=128)],
+    )
+    job = default_job_payload(req)
+    job["job_id"] = str(uuid4())
+    job["draft"] = {
+        "pdd": {
+            "steps": [
+                {
+                    "id": "step-01",
+                    "summary": "Capture request",
+                    "source_anchors": [{"anchor": "00:00:01-00:00:05", "confidence": 0.9}],
+                }
+            ]
+        },
+        "sipoc": [],
+    }
+    job["extracted_evidence"] = {
+        "evidence_items": [
+            {
+                "id": "ev-01",
+                "summary": "Capture request in system",
+                "anchor": "00:00:01-00:00:05",
+                "confidence": 0.9,
+            }
+        ]
+    }
+    job["_transcript_text_inline"] = (
+        "WEBVTT\n\n"
+        "00:00:01.000 --> 00:00:05.000\n"
+        "Analyst: Capture request in system\n"
+    )
+    job["agent_review"]["decision"] = "needs_review"
+    return job
+
+
+def _balanced_profile() -> Dict[str, Any]:
+    return {"profile": "balanced", "model": "gpt-4o-mini", "cost_cap_usd": 4.0}
+
+
+def test_uncited_flags_are_dropped():
+    from app.agents.llm_reviewer import _drop_uncited_flags
+
+    raw_flags = [
+        {"code": "ok", "evidence_id": "ev-01", "anchor": "00:00:01-00:00:05", "message": "valid"},
+        {"code": "missing_anchor", "evidence_id": "ev-02", "anchor": "", "message": "drop"},
+        {"code": "missing_evidence", "anchor": "00:00:10-00:00:12", "message": "drop"},
+    ]
+
+    kept = _drop_uncited_flags(raw_flags)
+    assert len(kept) == 1
+    assert kept[0]["code"] == "ok"
+    assert kept[0]["evidence_id"] == "ev-01"
+
+
+def test_coverage_flag_for_unmapped_evidence(monkeypatch):
+    from app.agents.llm_reviewer import run_llm_semantic_review
+
+    monkeypatch.setenv("PFCD_REVIEW_LLM_ENABLED", "true")
+    job = _make_job()
+    job["extracted_evidence"]["evidence_items"].append(
+        {
+            "id": "ev-03",
+            "summary": "Reconcile ERP billing",
+            "anchor": "00:00:20-00:00:30",
+            "confidence": 0.8,
+        }
+    )
+    job["_transcript_text_inline"] += (
+        "\n00:00:20.000 --> 00:00:30.000\nAnalyst: Reconcile ERP billing\n"
+    )
+
+    async def _fake_call(*_args, **_kwargs):
+        return '{"coverage_flags":[],"consistency_flags":[]}', 10, 10
+
+    with patch("app.agents.llm_reviewer._call_llm_review", side_effect=_fake_call):
+        run_llm_semantic_review(job, _balanced_profile(), MagicMock())
+
+    flags = job["review_notes"]["llm_semantic_flags"]
+    assert any(flag["evidence_id"] == "ev-03" and flag["code"] == "coverage_gap" for flag in flags)
+
+
+def test_no_flags_when_all_evidence_mapped(monkeypatch):
+    from app.agents.llm_reviewer import run_llm_semantic_review
+
+    monkeypatch.setenv("PFCD_REVIEW_LLM_ENABLED", "true")
+    job = _make_job()
+
+    async def _fake_call(*_args, **_kwargs):
+        return '{"coverage_flags":[],"consistency_flags":[]}', 10, 10
+
+    with patch("app.agents.llm_reviewer._call_llm_review", side_effect=_fake_call):
+        run_llm_semantic_review(job, _balanced_profile(), MagicMock())
+
+    assert job["review_notes"]["llm_semantic_flags"] == []
+
+
+def test_llm_review_disabled_by_default(monkeypatch):
+    from app.agents.llm_reviewer import run_llm_semantic_review
+
+    monkeypatch.delenv("PFCD_REVIEW_LLM_ENABLED", raising=False)
+    job = _make_job()
+
+    with patch("app.agents.llm_reviewer._call_llm_review") as call_mock:
+        run_llm_semantic_review(job, _balanced_profile(), MagicMock())
+
+    call_mock.assert_not_called()
+    assert job["review_notes"]["llm_semantic_flags"] == []
+
+
+def test_skipped_when_decision_is_blocked(tmp_path, monkeypatch):
+    db_path = tmp_path / "llm-reviewer-blocked.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("PFCD_REVIEW_LLM_ENABLED", "true")
+
+    _, repo_mod = _reload_modules()
+    from app.servicebus import build_message
+    from app.workers.runner import Worker
+
+    repository = repo_mod.JobRepository.from_env()
+    repository.init_db()
+
+    job = _make_job()
+    job["status"] = "processing"
+    job_id = job["job_id"]
+    repository.upsert_job(job_id, job)
+
+    worker = Worker("reviewing")
+    worker.repo = repository
+    worker.orchestrator = MagicMock()
+
+    message = build_message(
+        job_id=job_id,
+        phase="reviewing",
+        attempt=0,
+        requested_by="test",
+        trace_id=str(uuid4()),
+    )
+
+    def _fake_run_reviewing(job_payload: Dict[str, Any], _profile_conf: Dict[str, Any]) -> float:
+        job_payload["agent_review"]["decision"] = "blocked"
+        return 0.0
+
+    with patch("app.workers.runner.run_reviewing", side_effect=_fake_run_reviewing):
+        with patch("app.workers.runner.run_llm_semantic_review") as llm_mock:
+            worker._run_phase(job, message)
+
+    llm_mock.assert_not_called()
+


### PR DESCRIPTION
Summary: Implements Issue #97 with an advisory LLM semantic review pass after deterministic reviewing checks. Deterministic checks remain the only hard gate.\n\nChanges:\n- Added backend/app/agents/llm_reviewer.py with run_llm_semantic_review(job, profile_conf, storage).\n- Feature gate: PFCD_REVIEW_LLM_ENABLED (default false), plus auto-enable for quality profile.\n- Runner integration: reviewing phase calls LLM semantic review only when decision is not blocked; adds LLM cost to phase cost.\n- Added citation filtering: flags missing evidence_id or anchor are dropped.\n- Added anchor-sliced transcript snippets for grounded review context.\n- Added default payload fields: review_notes.llm_semantic_flags and agent_signals.llm_review_stats.\n- Added export sections in Markdown and DOCX: 5A. AI Semantic Review Notes (hidden when empty).\n- Documented PFCD_REVIEW_LLM_ENABLED in REFERENCE.md.\n\nTests run:\n1) backend/.venv/bin/python3.12 -m pytest tests/unit/test_llm_reviewer.py tests/unit/test_worker.py tests/unit/test_export_builder.py -q\nResult: 85 passed\n2) backend/.venv/bin/python3.12 -m pytest tests/unit/test_job_logic.py -q\nResult: 18 passed\n\nCloses #97