### PR TITLE
fix: PDD export title, exception trigger rendering, and RACI A/C/I mapping

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -3750,3 +3750,38 @@ Branch: `codex/issue-97-llm-semantic-review` → PR #98 (open)
 - Validation run:
   - `backend/.venv/bin/python3.12 -m pytest tests/unit/test_llm_reviewer.py tests/unit/test_worker.py tests/unit/test_export_builder.py -q` → `85 passed`
   - `backend/.venv/bin/python3.12 -m pytest tests/unit/test_job_logic.py -q` → `18 passed`
+
+---
+
+## Section 26 — Issue #99 Export Quality Fixes (PR #100, 2026-05-01)
+
+Branch: `codex/issue-99-export-quality-fixes` → PR #100 (open)
+
+### Title consistency (Markdown/DOCX)
+- `backend/app/export_builder.py`:
+  - Markdown title changed from `# Standard Operating Procedure (SOP)` to `# Process Definition Document`.
+  - DOCX top heading changed from `Standard Operating Procedure (SOP)` to `Process Definition Document`.
+- Aligns Markdown + DOCX with existing PDF heading terminology.
+
+### Exception description field fix
+- `backend/app/export_builder.py`:
+  - Exception table “Description” now renders `exc["trigger"]` (schema-accurate) instead of `exc["description"]`.
+  - Applied in both Markdown and DOCX exception tables.
+
+### RACI per-task A/C/I mapping
+- `backend/app/export_builder.py`:
+  - Added `approval_lookup` from `draft["approval_matrix"]`.
+  - Per-step RACI row logic now renders:
+    - `R` for step actor role,
+    - `A/C/I` from `approval_matrix` for non-actor roles,
+    - fallback `—` when role is not present in approval matrix.
+  - Applied in both Markdown and DOCX RACI section (`2.5`).
+
+### Tests
+- `tests/unit/test_export_builder.py` updated with focused coverage:
+  - Markdown PDD title assertion.
+  - DOCX PDD title assertion.
+  - Markdown/DOCX exception table trigger rendering assertions.
+  - Markdown/DOCX RACI approval-matrix mapping assertions.
+- Validation run:
+  - `backend/.venv/bin/python3.12 -m pytest tests/unit/test_export_builder.py -q` → `57 passed`

--- a/backend/app/export_builder.py
+++ b/backend/app/export_builder.py
@@ -242,6 +242,11 @@ def build_export_markdown(draft: Dict[str, Any], evidence_bundle: Dict[str, Any]
     sipoc_rows = draft.get("sipoc") or []
     roles = _derive_roles(draft)
     approval_rows = draft.get("approval_matrix") or []
+    approval_lookup = {
+        str(entry.get("role") or "").strip(): str(entry.get("responsibility") or "—").strip() or "—"
+        for entry in approval_rows
+        if isinstance(entry, dict)
+    }
     controls = pdd.get("process_controls") or draft.get("process_controls") or []
     llm_semantic_flags = evidence_bundle.get("llm_semantic_flags") or []
     exceptions = pdd.get("exceptions") or []
@@ -252,7 +257,7 @@ def build_export_markdown(draft: Dict[str, Any], evidence_bundle: Dict[str, Any]
     )
 
     parts = [
-        "# Standard Operating Procedure (SOP)",
+        "# Process Definition Document",
         "",
         f"## {process_name}",
         f"**Function:** {_needs_review(pdd.get('function'))}",
@@ -307,10 +312,8 @@ def build_export_markdown(draft: Dict[str, Any], evidence_bundle: Dict[str, Any]
         for role in roles:
             if actor and role == actor:
                 row.append("R")
-            elif actor:
-                row.append("—")
             else:
-                row.append("Needs Review")
+                row.append(approval_lookup.get(role, "—"))
         parts.append("| " + " | ".join(row) + " |")
 
     if not steps:
@@ -384,7 +387,7 @@ def build_export_markdown(draft: Dict[str, Any], evidence_bundle: Dict[str, Any]
                     + " | ".join(
                         [
                             _needs_review(exc.get("scenario")),
-                            _needs_review(exc.get("description")),
+                            _needs_review(exc.get("trigger")),
                             _needs_review(exc.get("action_required")),
                             _needs_review(exc.get("owner")),
                         ]
@@ -671,6 +674,11 @@ def build_export_docx(
     steps = pdd.get("steps") or []
     roles = _derive_roles(draft)
     sipoc = draft.get("sipoc") or []
+    approval_lookup = {
+        str(entry.get("role") or "").strip(): str(entry.get("responsibility") or "—").strip() or "—"
+        for entry in (draft.get("approval_matrix") or [])
+        if isinstance(entry, dict)
+    }
     controls = pdd.get("process_controls") or draft.get("process_controls") or []
     llm_semantic_flags = evidence_bundle.get("llm_semantic_flags") or []
     exceptions = pdd.get("exceptions") or []
@@ -682,7 +690,7 @@ def build_export_docx(
         pdd.get("process_name") or draft.get("subject_process") or pdd.get("purpose")
     )
 
-    doc.add_heading("Standard Operating Procedure (SOP)", level=0)
+    doc.add_heading("Process Definition Document", level=0)
     doc.add_heading(process_name, level=1)
     doc.add_paragraph(f"Function: {_needs_review(pdd.get('function'))}")
     doc.add_paragraph(f"Sub-Function: {_needs_review(pdd.get('sub_function'))}")
@@ -745,10 +753,8 @@ def build_export_docx(
             for i, role in enumerate(roles, start=1):
                 if actor and role == actor:
                     row[i].text = "R"
-                elif actor:
-                    row[i].text = "—"
                 else:
-                    row[i].text = "Needs Review"
+                    row[i].text = approval_lookup.get(role, "—")
     else:
         row = raci.add_row().cells
         row[0].text = "Needs Review"
@@ -808,7 +814,7 @@ def build_export_docx(
             row = ex_table.add_row().cells
             if isinstance(exc, dict):
                 row[0].text = _needs_review(exc.get("scenario"))
-                row[1].text = _needs_review(exc.get("description"))
+                row[1].text = _needs_review(exc.get("trigger"))
                 row[2].text = _needs_review(exc.get("action_required"))
                 row[3].text = _needs_review(exc.get("owner"))
             else:

--- a/tests/unit/test_export_builder.py
+++ b/tests/unit/test_export_builder.py
@@ -265,9 +265,9 @@ class TestBuildExportMarkdown:
     def _bundle(self):
         return build_evidence_bundle(DRAFT_WITH_ANCHORS, JOB_WITH_SIGNALS)
 
-    def test_contains_sop_title(self):
+    def test_contains_pdd_title(self):
         md = build_export_markdown(DRAFT_WITH_ANCHORS, self._bundle())
-        assert "# Standard Operating Procedure (SOP)" in md
+        assert "# Process Definition Document" in md
 
     def test_contains_purpose_and_scope(self):
         md = build_export_markdown(DRAFT_WITH_ANCHORS, self._bundle())
@@ -303,6 +303,51 @@ class TestBuildExportMarkdown:
     def test_frame_captures_note_present(self):
         md = build_export_markdown(DRAFT_WITH_ANCHORS, self._bundle())
         assert "Frame captures" in md
+
+    def test_exceptions_table_uses_trigger_field(self):
+        draft = {
+            "pdd": {
+                "purpose": "p",
+                "scope": "s",
+                "steps": [],
+                "exceptions": [
+                    {
+                        "scenario": "Validation failed",
+                        "trigger": "Missing mandatory field",
+                        "action_required": "Request correction",
+                        "owner": "Analyst",
+                    }
+                ],
+            },
+            "sipoc": [],
+        }
+        md = build_export_markdown(draft, build_evidence_bundle(draft, JOB_MINIMAL))
+        assert "Missing mandatory field" in md
+
+    def test_raci_uses_approval_matrix_for_non_actor_roles(self):
+        draft = {
+            "pdd": {
+                "purpose": "p",
+                "scope": "s",
+                "steps": [
+                    {
+                        "id": "step-01",
+                        "summary": "Capture request",
+                        "actor": "Analyst",
+                        "source_anchors": [{"anchor": "00:00:01-00:00:05", "confidence": 0.9}],
+                    }
+                ],
+                "roles": ["Analyst", "Manager", "Compliance"],
+                "exceptions": [],
+            },
+            "approval_matrix": [
+                {"role": "Manager", "responsibility": "A"},
+                {"role": "Compliance", "responsibility": "C"},
+            ],
+            "sipoc": [],
+        }
+        md = build_export_markdown(draft, build_evidence_bundle(draft, JOB_MINIMAL))
+        assert "| Capture request | R | A | C |" in md
 
     def test_empty_draft_returns_fallback(self):
         md = build_export_markdown({}, build_evidence_bundle({}, {}))
@@ -415,9 +460,79 @@ class TestBuildExportDocx:
         result = build_export_docx(DRAFT_WITH_ANCHORS, self._bundle(), "job-123")
         doc = Document(io.BytesIO(result))
         full_text = "\n".join(p.text for p in doc.paragraphs)
-        assert "Standard Operating Procedure (SOP)" in full_text or any(
-            "Standard Operating Procedure (SOP)" in para.text for para in doc.paragraphs
+        assert "Process Definition Document" in full_text or any(
+            "Process Definition Document" in para.text for para in doc.paragraphs
         )
+
+    def test_docx_exceptions_table_uses_trigger_field(self):
+        import io
+        from docx import Document
+
+        draft = {
+            "pdd": {
+                "purpose": "p",
+                "scope": "s",
+                "steps": [],
+                "exceptions": [
+                    {
+                        "scenario": "Validation failed",
+                        "trigger": "Missing mandatory field",
+                        "action_required": "Request correction",
+                        "owner": "Analyst",
+                    }
+                ],
+            },
+            "sipoc": [],
+        }
+        result = build_export_docx(draft, build_evidence_bundle(draft, JOB_MINIMAL), "job-1")
+        doc = Document(io.BytesIO(result))
+        exception_table = None
+        for table in doc.tables:
+            if table.rows and table.rows[0].cells and table.rows[0].cells[0].text == "Exception Scenario":
+                exception_table = table
+                break
+        assert exception_table is not None
+        assert exception_table.rows[1].cells[1].text == "Missing mandatory field"
+
+    def test_docx_raci_uses_approval_matrix_for_non_actor_roles(self):
+        import io
+        from docx import Document
+
+        draft = {
+            "pdd": {
+                "purpose": "p",
+                "scope": "s",
+                "steps": [
+                    {
+                        "id": "step-01",
+                        "summary": "Capture request",
+                        "actor": "Analyst",
+                        "source_anchors": [{"anchor": "00:00:01-00:00:05", "confidence": 0.9}],
+                    }
+                ],
+                "roles": ["Analyst", "Manager", "Compliance"],
+                "exceptions": [],
+            },
+            "approval_matrix": [
+                {"role": "Manager", "responsibility": "A"},
+                {"role": "Compliance", "responsibility": "C"},
+            ],
+            "sipoc": [],
+        }
+        result = build_export_docx(draft, build_evidence_bundle(draft, JOB_MINIMAL), "job-raci")
+        doc = Document(io.BytesIO(result))
+        raci_table = None
+        for table in doc.tables:
+            if table.rows and table.rows[0].cells and table.rows[0].cells[0].text == "Task":
+                raci_table = table
+                break
+        assert raci_table is not None
+        assert [cell.text for cell in raci_table.rows[1].cells] == [
+            "Capture request",
+            "R",
+            "A",
+            "C",
+        ]
 
     def test_contains_sipoc_table(self):
         import io


### PR DESCRIPTION
Summary: Implements Issue #99 export-quality fixes without schema changes.\n\nFixes:\n1) Markdown and DOCX top title now read Process Definition Document (aligned with PDF).\n2) Process Exceptions table Description column now renders the exception trigger field.\n3) RACI per-task matrix now uses approval_matrix for non-actor roles:\n   - actor role => R\n   - non-actor roles => responsibility from approval_matrix (A/C/I)\n   - fallback => dash when role not present\n\nFiles changed:\n- backend/app/export_builder.py\n- tests/unit/test_export_builder.py\n\nTests run:\n- backend/.venv/bin/python3.12 -m pytest tests/unit/test_export_builder.py -q\n- Result: 57 passed\n\nCloses #99