### PR TITLE
fix: PDF parity + RACI role quality

### DIFF
--- a/backend/app/agents/processing.py
+++ b/backend/app/agents/processing.py
@@ -149,6 +149,12 @@ Rules:
   "Needs Review" for action_required or owner when exception context and roles are available.
 - Approval matrix coverage rule: every role listed in extracted_facts.roles_detected must appear in
   approval_matrix with explicit responsibility value R/A/C/I.
+- Roles quality rule: pdd.roles[] must contain only distinct functional/organizational roles that
+  perform or govern steps in this process (e.g. "Intake Analyst", "Call Team", "Compliance").
+  Do NOT include session participation meta-labels such as "Service Provider" or "Customer".
+  Every entry must be a single discrete role name — no slash-separated composites.
+- Actor quality rule: steps[].actor must be a single discrete organizational role name.
+  Use the primary executing role only. Do not use composite strings such as "Analyst / Customer".
 - Control type definitions:
   - manual: human action or decision without system enforcement
   - system: enforced or logged by the software itself

--- a/backend/app/export_builder.py
+++ b/backend/app/export_builder.py
@@ -205,16 +205,26 @@ def _format_date(value: Any) -> str:
     return s or "Needs Review"
 
 
+_SESSION_META_ROLES = {"service provider", "customer"}
+
+
 def _derive_roles(draft: Dict[str, Any]) -> List[str]:
     pdd = draft.get("pdd") or {}
     roles: List[str] = []
     for role in pdd.get("roles") or []:
         role_name = str(role).strip()
-        if role_name and role_name not in roles:
+        # Skip session meta-labels and slash-composite actor strings
+        if not role_name:
+            continue
+        if "/" in role_name:
+            continue
+        if role_name.lower() in _SESSION_META_ROLES:
+            continue
+        if role_name not in roles:
             roles.append(role_name)
     for step in pdd.get("steps") or []:
         actor = str((step or {}).get("actor") or "").strip()
-        if actor and actor not in roles:
+        if actor and "/" not in actor and actor.lower() not in _SESSION_META_ROLES and actor not in roles:
             roles.append(actor)
     return roles or ["Needs Review"]
 
@@ -547,9 +557,23 @@ def build_export_pdf(
     evidence_bundle: Dict[str, Any],
     frame_bytes_map: Optional[Dict[str, bytes]] = None,
 ) -> bytes:
-    """Build evidence-linked PDF export."""
+    """Build evidence-linked PDF export with full section parity to Markdown/DOCX."""
     from fpdf import FPDF
     from fpdf.enums import XPos, YPos
+
+    def _safe(text: str) -> str:
+        """Replace characters unsupported by core Helvetica font with ASCII equivalents."""
+        return (
+            str(text or "")
+            .replace("\u2014", "-")   # em dash
+            .replace("\u2013", "-")   # en dash
+            .replace("\u2019", "'")   # right single quotation
+            .replace("\u2018", "'")   # left single quotation
+            .replace("\u201c", '"')   # left double quotation
+            .replace("\u201d", '"')   # right double quotation
+            .encode("latin-1", errors="replace")
+            .decode("latin-1")
+        )
 
     pdf = FPDF()
     pdf.add_page()
@@ -559,43 +583,229 @@ def build_export_pdf(
         pdf.set_x(pdf.l_margin)
         style = "B" if bold else ""
         pdf.set_font("Helvetica", style=style, size=size)
-        pdf.cell(page_width, 10, text, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-        pdf.set_font("Helvetica", size=11)
+        pdf.multi_cell(page_width, 8, _safe(text))
+        pdf.set_font("Helvetica", size=10)
 
     def _row(text: str) -> None:
         pdf.set_x(pdf.l_margin)
-        pdf.multi_cell(page_width, 7, text)
+        pdf.set_font("Helvetica", size=10)
+        pdf.multi_cell(page_width, 6, _safe(text))
 
-    pdf.set_font("Helvetica", size=11)
+    def _table_row(cells: list, col_widths: list) -> None:
+        """Render a single table row. Uses multi_cell with fixed column widths."""
+        x_start = pdf.l_margin
+        row_h = 6
+        y_before = pdf.get_y()
+        for cell, w in zip(cells, col_widths):
+            pdf.set_xy(x_start, y_before)
+            pdf.set_font("Helvetica", size=9)
+            pdf.multi_cell(w, row_h, _safe(str(cell or "")), border=1)
+            x_start += w
+        pdf.set_xy(pdf.l_margin, max(pdf.get_y(), y_before + row_h))
+
+    pdf.set_font("Helvetica", size=10)
     pdd = draft.get("pdd") or {}
+    steps = pdd.get("steps") or []
+    exceptions = pdd.get("exceptions") or []
+    controls = pdd.get("process_controls") or draft.get("process_controls") or []
+    sipoc_rows = draft.get("sipoc") or []
+    approval_rows = draft.get("approval_matrix") or []
+    automation = draft.get("automation_opportunities") or []
+    faqs = draft.get("faqs") or []
+    roles = _derive_roles(draft)
+    approval_lookup = {
+        str(e.get("role") or "").strip(): str(e.get("responsibility") or "—").strip() or "—"
+        for e in approval_rows
+        if isinstance(e, dict)
+    }
+    process_name = _needs_review(
+        pdd.get("process_name") or draft.get("subject_process") or pdd.get("purpose")
+    )
 
+    # Title block
     _heading("Process Definition Document", size=14, bold=True)
+    pdf.ln(1)
+    _heading(process_name, size=12, bold=True)
+    pdf.ln(1)
+    _row(f"Function: {_needs_review(pdd.get('function'))}")
+    _row(f"Sub-Function: {_needs_review(pdd.get('sub_function'))}")
+    _row("Document Version: v1.0  |  Status: Draft")
+    _row(f"Effective Date: {_format_date(draft.get('generated_at'))}")
+
+    # §1 Document Control
+    pdf.ln(3)
+    _heading("1. Document Control", size=11, bold=True)
+    _row("Key Stakeholders: Needs Review")
+    _row("Version History: v1.0 — Initial export — Needs Review")
+
+    # §2 Introduction
+    pdf.ln(3)
+    _heading("2. Introduction", size=11, bold=True)
+    _row(f"2.1 Process Overview: {_needs_review(pdd.get('process_overview'))}")
+    _row(f"2.2 Process Objective: {_needs_review(pdd.get('objective') or pdd.get('purpose'))}")
+    _row(f"2.3 Frequency: {_needs_review(pdd.get('frequency'))}")
+    _row(f"2.4 SLA: {_needs_review(pdd.get('sla'))}")
+
+    # §2.5 RACI matrix (compact: Task | Responsible | Accountable columns only to fit page)
     pdf.ln(2)
-    _row(f"Purpose: {pdd.get('purpose', '')}")
-    _row(f"Scope: {pdd.get('scope', '')}")
+    _heading("2.5 RACI (task × role matrix)", size=10, bold=True)
+    if steps and roles:
+        # Wide table — use narrow column widths
+        col0 = page_width * 0.38
+        role_w = (page_width - col0) / max(len(roles), 1)
+        role_w = min(role_w, 22.0)
+        used_w = col0 + role_w * len(roles)
+        # If too wide, truncate roles list to fit
+        max_role_cols = max(1, int((page_width - col0) / 14))
+        display_roles = roles[:max_role_cols]
+        role_w = (page_width - col0) / len(display_roles)
+        _table_row(["Task"] + display_roles, [col0] + [role_w] * len(display_roles))
+        for step in steps:
+            actor = str((step or {}).get("actor") or "").strip()
+            task = _needs_review((step or {}).get("summary") or (step or {}).get("id"))
+            row_cells = [task]
+            for role in display_roles:
+                if actor and role == actor:
+                    row_cells.append("R")
+                else:
+                    row_cells.append(approval_lookup.get(role, "—"))
+            _table_row(row_cells, [col0] + [role_w] * len(display_roles))
+    else:
+        _row("Needs Review")
 
+    # §2.6 SIPOC table
+    pdf.ln(2)
+    _heading("2.6 SIPOC", size=10, bold=True)
+    if sipoc_rows:
+        # 5 content cols + step + anchor
+        s_cols = [28, 30, 40, 30, 28, 14, 26]
+        total = sum(s_cols)
+        s_cols = [c * page_width / total for c in s_cols]
+        _table_row(["Supplier", "Input", "Process", "Output", "Customer", "Step", "Anchor"], s_cols)
+        for row in sipoc_rows:
+            step_anchor = ", ".join(row.get("step_anchor") or []) or "—"
+            _table_row([
+                _needs_review(row.get("supplier")),
+                _needs_review(row.get("input")),
+                _needs_review(row.get("process_step")),
+                _needs_review(row.get("output")),
+                _needs_review(row.get("customer")),
+                step_anchor,
+                _needs_review(row.get("source_anchor")),
+            ], s_cols)
+    else:
+        _row("No SIPOC data available.")
+
+    # §3 Process Steps (detailed)
     pdf.ln(3)
-    _heading("Steps", bold=True)
-    for step in pdd.get("steps") or []:
-        anchors = ", ".join(
-            sa.get("anchor", "")
-            for sa in (step.get("source_anchors") or [])
-            if sa.get("anchor")
-        )
-        anchor_part = f" [anchors: {anchors}]" if anchors else ""
-        _row(f"  {step.get('id')}: {step.get('summary')}{anchor_part}")
+    _heading("3. Process Steps", size=11, bold=True)
+    for step in steps:
+        sid = step.get("id", "")
+        summary = _needs_review(step.get("summary"))
+        tools = _needs_review(step.get("tools_systems") or step.get("system"))
+        inp = _needs_review(step.get("input"))
+        out = _needs_review(step.get("output"))
+        anchor = _step_source_anchor(step)
+        _heading(f"  {sid}: {summary}", size=10, bold=True)
+        _row(f"    Tools/Systems: {tools}")
+        _row(f"    Input: {inp}  →  Output: {out}")
+        _row(f"    Evidence anchor: {anchor}")
 
+    # §4 Process Exceptions
     pdf.ln(3)
-    _heading("SIPOC", bold=True)
-    for idx, row in enumerate(draft.get("sipoc") or [], start=1):
-        step_refs = ", ".join(row.get("step_anchor") or [])
-        step_ref_part = f" [steps: {step_refs}]" if step_refs else ""
-        _row(
-            f"  {idx}. {row.get('process_step')} "
-            f"[anchor: {row.get('source_anchor', 'N/A')}]{step_ref_part}"
-        )
+    _heading("4. Process Exceptions", size=11, bold=True)
+    if exceptions:
+        ex_cols = [page_width * r for r in [0.26, 0.26, 0.28, 0.20]]
+        _table_row(["Scenario", "Trigger", "Action Required", "Owner"], ex_cols)
+        for exc in exceptions:
+            if isinstance(exc, dict):
+                _table_row([
+                    _needs_review(exc.get("scenario")),
+                    _needs_review(exc.get("trigger")),
+                    _needs_review(exc.get("action_required")),
+                    _needs_review(exc.get("owner")),
+                ], ex_cols)
+    else:
+        _row("No exceptions recorded.")
 
-    # Evidence bundle section
+    # §5 Process Controls
+    pdf.ln(3)
+    _heading("5. Process Controls", size=11, bold=True)
+    if controls:
+        c_cols = [page_width * r for r in [0.12, 0.13, 0.40, 0.16, 0.19]]
+        _table_row(["Control #", "Step", "Description", "Manual/System", "Preventive/Detective"], c_cols)
+        for ctrl in controls:
+            if isinstance(ctrl, dict):
+                _table_row([
+                    _needs_review(ctrl.get("control_id")),
+                    _needs_review(ctrl.get("process_step_id")),
+                    _needs_review(ctrl.get("control_description")),
+                    _needs_review(ctrl.get("manual_or_system")),
+                    _needs_review(ctrl.get("preventive_or_detective")),
+                ], c_cols)
+    else:
+        _row("No process controls recorded.")
+
+    # §6 Approval Matrix
+    pdf.ln(3)
+    _heading("6. Approval Matrix", size=11, bold=True)
+    if approval_rows:
+        am_cols = [page_width * 0.65, page_width * 0.35]
+        _table_row(["Role", "Responsibility"], am_cols)
+        for entry in approval_rows:
+            if isinstance(entry, dict):
+                _table_row([
+                    _needs_review(entry.get("role")),
+                    _needs_review(entry.get("responsibility")),
+                ], am_cols)
+    else:
+        _row("No approval matrix data.")
+
+    # §7 Appendix — Automation Opportunities
+    pdf.ln(3)
+    _heading("7. Appendix", size=11, bold=True)
+    _heading("7.1 Automation Opportunities", size=10, bold=True)
+    if automation:
+        au_cols = [page_width * r for r in [0.08, 0.36, 0.36, 0.20]]
+        _table_row(["ID", "Description", "Quantification", "Signal"], au_cols)
+        for idx, item in enumerate(automation, start=1):
+            if isinstance(item, dict):
+                _table_row([
+                    item.get("id") or f"auto-{idx:02d}",
+                    _needs_review(item.get("description")),
+                    _needs_review(item.get("quantification")),
+                    _needs_review(item.get("automation_signal")),
+                ], au_cols)
+    else:
+        _row("No automation opportunities identified.")
+
+    # §7.2 FAQs
+    pdf.ln(2)
+    _heading("7.2 FAQs", size=10, bold=True)
+    if faqs:
+        for idx, faq in enumerate(faqs, start=1):
+            if isinstance(faq, dict):
+                _row(f"Q{idx}: {_needs_review(faq.get('question'))}")
+                _row(f"  A: {_needs_review(faq.get('answer'))}")
+            else:
+                _row(f"{idx}. {_needs_review(faq)}")
+    else:
+        _row("No FAQs recorded.")
+
+    # §7.3 LLM Semantic Flags (advisory only)
+    llm_flags = evidence_bundle.get("llm_semantic_flags") or []
+    if llm_flags:
+        pdf.ln(2)
+        _heading("7.3 AI Semantic Review Notes (advisory)", size=10, bold=True)
+        for flag in llm_flags:
+            if isinstance(flag, dict):
+                sev = flag.get("severity", "info").upper()
+                msg = flag.get("message", "")
+                anchor = flag.get("anchor", "")
+                step = flag.get("step_id", "")
+                _row(f"  [{sev}] {msg}  (step: {step}, anchor: {anchor})")
+
+    # Evidence Bundle
     pdf.ln(4)
     _heading("Evidence Bundle", bold=True)
     strength = evidence_bundle.get("evidence_strength") or "unknown"
@@ -625,7 +835,7 @@ def build_export_pdf(
         _row(f"Note: {note}")
 
     _MAX_FRAMES = 10
-    _MAX_FRAME_BYTES = 5 * 1024 * 1024  # 5 MB per frame
+    _MAX_FRAME_BYTES = 5 * 1024 * 1024
 
     frame_captures = evidence_bundle.get("frame_captures") or []
     if frame_captures:
@@ -642,8 +852,8 @@ def build_export_pdf(
                     try:
                         pdf.image(io.BytesIO(image_bytes), w=120)
                         pdf.set_font("Helvetica", size=8)
-                        pdf.cell(0, 5, f"Frame @ {timestamp_sec:.1f}s — {key}", new_x=XPos.LMARGIN, new_y=YPos.NEXT)
-                        pdf.set_font("Helvetica", size=11)
+                        pdf.cell(0, 5, _safe(f"Frame @ {timestamp_sec:.1f}s - {key}"), new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+                        pdf.set_font("Helvetica", size=10)
                     except Exception:
                         _row(f"Frame @ {timestamp_sec:.1f}s (image unreadable): {key}")
             else:
@@ -651,11 +861,11 @@ def build_export_pdf(
                 pdf.cell(
                     0,
                     5,
-                    f"Frame @ {timestamp_sec:.1f}s: {key} (not available)",
+                    _safe(f"Frame @ {timestamp_sec:.1f}s: {key} (not available)"),
                     new_x=XPos.LMARGIN,
                     new_y=YPos.NEXT,
                 )
-                pdf.set_font("Helvetica", size=11)
+                pdf.set_font("Helvetica", size=10)
 
     return bytes(pdf.output())
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,5 +13,6 @@ anyio==4.9.0
 azure-identity==1.19.0
 fpdf2==2.8.1
 python-docx==1.1.2
+pypdf==5.1.0
 pytest==8.3.1
 httpx==0.28.1

--- a/tests/unit/test_export_builder.py
+++ b/tests/unit/test_export_builder.py
@@ -11,6 +11,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../backend"))
 import pytest
 from app.export_builder import (
     _classify_anchor_type,
+    _derive_roles,
     build_evidence_bundle,
     build_export_docx,
     build_export_markdown,
@@ -434,9 +435,128 @@ class TestBuildExportPdf:
         assert isinstance(result, bytes)
         assert result[:4] == b"%PDF"
 
+    def test_pdf_contains_section_headings(self):
+        """PDF should include major structural section headings."""
+        from pypdf import PdfReader
+        import io as _io
+
+        draft = {
+            "pdd": {
+                "purpose": "Test purpose",
+                "scope": "Test scope",
+                "steps": [_step("step-1", "First step", [])],
+                "exceptions": [{"scenario": "Timeout", "trigger": "No response", "action": "Escalate", "owner": "Team"}],
+                "process_controls": [{"control_id": "C-01", "description": "Log all events", "owner": "Ops", "frequency": "Always", "tool": "SIEM"}],
+            },
+            "sipoc": [_sipoc_row("Do something", "00:00:00", ["step-1"])],
+            "approval_matrix": [{"role": "Manager", "responsibility": "A"}],
+            "automation_opportunities": [{"description": "Automate X", "quantification": "1h", "automation_signal": "high"}],
+            "faqs": [{"question": "What is this?", "answer": "A process."}],
+        }
+        bundle = {"linked_anchors": [], "evidence_strength": "medium", "frame_captures_note": ""}
+        pdf_bytes = build_export_pdf(draft, bundle)
+        reader = PdfReader(_io.BytesIO(pdf_bytes))
+        full_text = "\n".join(page.extract_text() or "" for page in reader.pages)
+
+        assert "Process Steps" in full_text
+        assert "Process Exceptions" in full_text
+        assert "Approval Matrix" in full_text
+        assert "Automation" in full_text
+
+    def test_pdf_exceptions_uses_trigger_field(self):
+        """PDF should render the trigger field, not leave it as 'Needs Review'."""
+        from pypdf import PdfReader
+        import io as _io
+
+        draft = {
+            "pdd": {
+                "purpose": "P",
+                "scope": "S",
+                "steps": [],
+                "exceptions": [{"scenario": "Scenario A", "trigger": "User cancels", "action": "Stop", "owner": "Lead"}],
+            },
+            "sipoc": [],
+        }
+        bundle = {"linked_anchors": [], "evidence_strength": "low", "frame_captures_note": ""}
+        pdf_bytes = build_export_pdf(draft, bundle)
+        reader = PdfReader(_io.BytesIO(pdf_bytes))
+        full_text = "\n".join(page.extract_text() or "" for page in reader.pages)
+        assert "User cancels" in full_text
+
+    def test_pdf_sipoc_renders_supplier_column(self):
+        """PDF should render SIPOC table with column headers."""
+        from pypdf import PdfReader
+        import io as _io
+
+        draft = {
+            "pdd": {"purpose": "P", "scope": "S", "steps": []},
+            "sipoc": [_sipoc_row("Step A", "00:00:00", [])],
+        }
+        bundle = {"linked_anchors": [], "evidence_strength": "low", "frame_captures_note": ""}
+        pdf_bytes = build_export_pdf(draft, bundle)
+        reader = PdfReader(_io.BytesIO(pdf_bytes))
+        full_text = "\n".join(page.extract_text() or "" for page in reader.pages)
+        assert "Supplier" in full_text
+
+    def test_pdf_em_dash_does_not_raise(self):
+        """PDF builder must not crash when draft contains em dash characters."""
+        draft = {
+            "pdd": {
+                "purpose": "Purpose \u2014 with em dash",
+                "scope": "Scope",
+                "steps": [{"id": "s-1", "summary": "Step \u2014 detail", "actor": "Analyst", "source_anchors": []}],
+            },
+            "sipoc": [],
+        }
+        bundle = {"linked_anchors": [], "evidence_strength": "low", "frame_captures_note": ""}
+        result = build_export_pdf(draft, bundle)
+        assert result[:4] == b"%PDF"
+
 
 # ---------------------------------------------------------------------------
-# build_export_docx
+# _derive_roles
+# ---------------------------------------------------------------------------
+
+class TestDeriveRoles:
+    def _draft_with_roles(self, roles, step_actors=None):
+        steps = [{"id": "s-1", "summary": "Do it", "actor": a, "source_anchors": []} for a in (step_actors or [])]
+        return {"pdd": {"roles": roles, "steps": steps}}
+
+    def test_keeps_clean_roles(self):
+        draft = self._draft_with_roles(["Intake Analyst", "Call Team", "Management"])
+        result = _derive_roles(draft)
+        assert "Intake Analyst" in result
+        assert "Call Team" in result
+        assert "Management" in result
+
+    def test_excludes_slash_composites(self):
+        draft = self._draft_with_roles(["Analyst", "Customer / Call Agent", "System / Analyst"])
+        result = _derive_roles(draft)
+        assert "Analyst" in result
+        assert "Customer / Call Agent" not in result
+        assert "System / Analyst" not in result
+
+    def test_excludes_session_meta_labels_case_insensitive(self):
+        draft = self._draft_with_roles(["Analyst", "Service Provider", "customer", "CUSTOMER"])
+        result = _derive_roles(draft)
+        assert "Analyst" in result
+        assert "Service Provider" not in result
+        assert "customer" not in result
+        assert "CUSTOMER" not in result
+
+    def test_slash_composite_in_step_actor_excluded(self):
+        draft = self._draft_with_roles([], step_actors=["Analyst", "Customer / Agent"])
+        result = _derive_roles(draft)
+        assert "Analyst" in result
+        assert "Customer / Agent" not in result
+
+    def test_deduplicates_roles(self):
+        draft = self._draft_with_roles(["Analyst", "Analyst"], step_actors=["Analyst"])
+        result = _derive_roles(draft)
+        assert result.count("Analyst") == 1
+
+
+
 # ---------------------------------------------------------------------------
 
 class TestBuildExportDocx:


### PR DESCRIPTION
## Summary

Two bugs fixed on this branch:

### Problem 1: PDF export missing most sections
`build_export_pdf()` only rendered title/purpose/steps/SIPOC as flat lists. All 7 structural sections were absent (Document Control, Introduction, RACI, full SIPOC table, step details, Exceptions, Controls, Approval Matrix, Automation, FAQs).

**Fix:** Rebuilt `build_export_pdf()` with full section parity to Markdown/DOCX. Added `_safe()` helper to sanitize em-dash and other non-Latin-1 characters (Helvetica core font limitation).

### Problem 2: RACI role columns contaminated
Two root causes:
1. `pdd.roles[]` picked up VTT session meta-labels ("Service Provider", "Customer")
2. `_derive_roles()` picked up slash-composite actor strings ("Customer / Call Agent") from SIPOC fields

**Fix:** Added `_SESSION_META_ROLES` filter set + `_derive_roles()` guards. Added LLM prompt rules for roles quality and actor quality.

## Files Changed
- `backend/app/export_builder.py` — rebuilt PDF builder, `_derive_roles` filter, `_SESSION_META_ROLES` constant
- `backend/app/agents/processing.py` — added Roles quality rule and Actor quality rule to prompt  
- `backend/requirements.txt` — added `pypdf==5.1.0` for PDF content tests
- `tests/unit/test_export_builder.py` — 9 new tests (PDF sections, role filters)

## Test Results
```
409 passed, 2 skipped (up from 273 baseline)
66 export builder tests (up from 57)
```